### PR TITLE
fix comment format for instant hooks

### DIFF
--- a/__fixtures__/v-next/outputv2/hooks.ts
+++ b/__fixtures__/v-next/outputv2/hooks.ts
@@ -39,42 +39,103 @@ export const createRpcQueryHooks = ({
         v2: _OsmosisGammV2Queryrpc.createRpcQueryHooks(rpc)
       }
     },
-    /** Certificates queries certificates */useCertificates: _AkashCertV1beta2Queryrpc.createRpcQueryHooks(rpc).useCertificates,
-    /** Balance queries the balance of a single coin for a single account. */useBalance: _CosmosBankV1beta1Queryrpc.createRpcQueryHooks(rpc).useBalance,
-    /** Balance queries the number of NFTs of a given class owned by the owner, same as balanceOf in ERC721 */useCosmosNftV1beta1Balance: _CosmosNftV1beta1Queryrpc.createRpcQueryHooks(rpc).useBalance,
+    /**
+     * akash.cert.v1beta2.useCertificates
+     * Certificates queries certificates
+     */
+    useCertificates: _AkashCertV1beta2Queryrpc.createRpcQueryHooks(rpc).useCertificates,
+    /**
+     * cosmos.bank.v1beta1.useBalance
+     * Balance queries the balance of a single coin for a single account.
+     */
+    useBalance: _CosmosBankV1beta1Queryrpc.createRpcQueryHooks(rpc).useBalance,
+    /**
+     * cosmos.nft.v1beta1.useBalance
+     * Balance queries the number of NFTs of a given class owned by the owner, same as balanceOf in ERC721
+     */
+    useCosmosNftV1beta1Balance: _CosmosNftV1beta1Queryrpc.createRpcQueryHooks(rpc).useBalance,
+    /**
+     * osmosis.gamm.v1beta1.usePools
+     * Pools
+     */
     usePools: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).usePools,
+    /**
+     * osmosis.gamm.v1beta1.useNumPools
+     * NumPools
+     */
     useNumPools: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).useNumPools,
+    /**
+     * osmosis.gamm.v1beta1.useTotalLiquidity
+     * TotalLiquidity
+     */
     useTotalLiquidity: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).useTotalLiquidity,
     /**
+     * osmosis.gamm.v1beta1.usePoolsWithFilter
      * PoolsWithFilter allows you to query specific pools with requested
      * parameters
      */
     usePoolsWithFilter: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).usePoolsWithFilter,
-    /** Per Pool gRPC Endpoints */usePool: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).usePool,
     /**
+     * osmosis.gamm.v1beta1.usePool
+     * Per Pool gRPC Endpoints
+     */
+    usePool: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).usePool,
+    /**
+     * osmosis.gamm.v1beta1.usePoolType
      * PoolType returns the type of the pool.
      * Returns "Balancer" as a string literal when the pool is a balancer pool.
      * Errors if the pool is failed to be type caseted.
      */
     usePoolType: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).usePoolType,
     /**
+     * osmosis.gamm.v1beta1.useCalcJoinPoolNoSwapShares
      * Simulates joining pool without a swap. Returns the amount of shares you'd
      * get and tokens needed to provide
      */
     useCalcJoinPoolNoSwapShares: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).useCalcJoinPoolNoSwapShares,
+    /**
+     * osmosis.gamm.v1beta1.useCalcJoinPoolShares
+     * CalcJoinPoolShares
+     */
     useCalcJoinPoolShares: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).useCalcJoinPoolShares,
+    /**
+     * osmosis.gamm.v1beta1.useCalcExitPoolCoinsFromShares
+     * CalcExitPoolCoinsFromShares
+     */
     useCalcExitPoolCoinsFromShares: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).useCalcExitPoolCoinsFromShares,
+    /**
+     * osmosis.gamm.v1beta1.usePoolParams
+     * PoolParams
+     */
     usePoolParams: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).usePoolParams,
+    /**
+     * osmosis.gamm.v1beta1.useTotalPoolLiquidity
+     * TotalPoolLiquidity
+     */
     useTotalPoolLiquidity: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).useTotalPoolLiquidity,
+    /**
+     * osmosis.gamm.v1beta1.useTotalShares
+     * TotalShares
+     */
     useTotalShares: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).useTotalShares,
     /**
+     * osmosis.gamm.v1beta1.useSpotPrice
      * SpotPrice defines a gRPC query handler that returns the spot price given
      * a base denomination and a quote denomination.
      */
     useSpotPrice: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).useSpotPrice,
-    /** Estimate the swap. */useEstimateSwapExactAmountIn: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).useEstimateSwapExactAmountIn,
+    /**
+     * osmosis.gamm.v1beta1.useEstimateSwapExactAmountIn
+     * Estimate the swap.
+     */
+    useEstimateSwapExactAmountIn: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).useEstimateSwapExactAmountIn,
+    /**
+     * osmosis.gamm.v1beta1.useEstimateSwapExactAmountOut
+     * EstimateSwapExactAmountOut
+     */
     useEstimateSwapExactAmountOut: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).useEstimateSwapExactAmountOut,
     /**
+     * osmosis.gamm.v2.useSpotPrice
      * SpotPrice defines a gRPC query handler that returns the spot price given
      * a base denomination and a quote denomination.
      */

--- a/__fixtures__/v-next/outputv4/hooks.ts
+++ b/__fixtures__/v-next/outputv4/hooks.ts
@@ -33,54 +33,140 @@ export const createRpcQueryHooks = ({
         v2: _OsmosisGammV2Queryrpc.createRpcQueryHooks(rpc)
       }
     },
-    /** Certificates queries certificates */useCertificates: _AkashCertV1beta2Queryrpc.createRpcQueryHooks(rpc).useCertificates,
     /**
+     * akash.cert.v1beta2.useCertificates
+     * Certificates queries certificates
+     */
+    useCertificates: _AkashCertV1beta2Queryrpc.createRpcQueryHooks(rpc).useCertificates,
+    /**
+     * cosmos.auth.v1beta1.useAccounts
      * Accounts returns all the existing accounts
      * 
      * Since: cosmos-sdk 0.43
      */
     useAccounts: _CosmosAuthV1beta1Queryrpc.createRpcQueryHooks(rpc).useAccounts,
-    /** Account returns account details based on address. */useAccount: _CosmosAuthV1beta1Queryrpc.createRpcQueryHooks(rpc).useAccount,
-    /** Params queries all parameters. */useParams: _CosmosAuthV1beta1Queryrpc.createRpcQueryHooks(rpc).useParams,
-    /** ModuleAccounts returns all the existing module accounts. */useAuthModuleAccounts: _CosmosAuthV1beta1Queryrpc.createRpcQueryHooks(rpc).useModuleAccounts,
-    /** Bech32 queries bech32Prefix */useBech32Prefix: _CosmosAuthV1beta1Queryrpc.createRpcQueryHooks(rpc).useBech32Prefix,
-    /** AddressBytesToString converts Account Address bytes to string */useAddressBytesToString: _CosmosAuthV1beta1Queryrpc.createRpcQueryHooks(rpc).useAddressBytesToString,
-    /** AddressStringToBytes converts Address string to bytes */useAddressStringToBytes: _CosmosAuthV1beta1Queryrpc.createRpcQueryHooks(rpc).useAddressStringToBytes,
-    /** Balance queries the balance of a single coin for a single account. */useBankBalance: _CosmosBankV1beta1Queryrpc.createRpcQueryHooks(rpc).useBalance,
-    /** Balance queries the number of NFTs of a given class owned by the owner, same as balanceOf in ERC721 */useNftBalance: _CosmosNftV1beta1Queryrpc.createRpcQueryHooks(rpc).useBalance,
+    /**
+     * cosmos.auth.v1beta1.useAccount
+     * Account returns account details based on address.
+     */
+    useAccount: _CosmosAuthV1beta1Queryrpc.createRpcQueryHooks(rpc).useAccount,
+    /**
+     * cosmos.auth.v1beta1.useParams
+     * Params queries all parameters.
+     */
+    useParams: _CosmosAuthV1beta1Queryrpc.createRpcQueryHooks(rpc).useParams,
+    /**
+     * cosmos.auth.v1beta1.useModuleAccounts
+     * ModuleAccounts returns all the existing module accounts.
+     */
+    useAuthModuleAccounts: _CosmosAuthV1beta1Queryrpc.createRpcQueryHooks(rpc).useModuleAccounts,
+    /**
+     * cosmos.auth.v1beta1.useBech32Prefix
+     * Bech32 queries bech32Prefix
+     */
+    useBech32Prefix: _CosmosAuthV1beta1Queryrpc.createRpcQueryHooks(rpc).useBech32Prefix,
+    /**
+     * cosmos.auth.v1beta1.useAddressBytesToString
+     * AddressBytesToString converts Account Address bytes to string
+     */
+    useAddressBytesToString: _CosmosAuthV1beta1Queryrpc.createRpcQueryHooks(rpc).useAddressBytesToString,
+    /**
+     * cosmos.auth.v1beta1.useAddressStringToBytes
+     * AddressStringToBytes converts Address string to bytes
+     */
+    useAddressStringToBytes: _CosmosAuthV1beta1Queryrpc.createRpcQueryHooks(rpc).useAddressStringToBytes,
+    /**
+     * cosmos.bank.v1beta1.useBalance
+     * Balance queries the balance of a single coin for a single account.
+     */
+    useBankBalance: _CosmosBankV1beta1Queryrpc.createRpcQueryHooks(rpc).useBalance,
+    /**
+     * cosmos.nft.v1beta1.useBalance
+     * Balance queries the number of NFTs of a given class owned by the owner, same as balanceOf in ERC721
+     */
+    useNftBalance: _CosmosNftV1beta1Queryrpc.createRpcQueryHooks(rpc).useBalance,
+    /**
+     * osmosis.gamm.v1beta1.usePools
+     * Pools
+     */
     usePools: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).usePools,
+    /**
+     * osmosis.gamm.v1beta1.useNumPools
+     * NumPools
+     */
     useNumPools: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).useNumPools,
+    /**
+     * osmosis.gamm.v1beta1.useTotalLiquidity
+     * TotalLiquidity
+     */
     useTotalLiquidity: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).useTotalLiquidity,
     /**
+     * osmosis.gamm.v1beta1.usePoolsWithFilter
      * PoolsWithFilter allows you to query specific pools with requested
      * parameters
      */
     usePoolsWithFilter: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).usePoolsWithFilter,
-    /** Per Pool gRPC Endpoints */usePool: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).usePool,
     /**
+     * osmosis.gamm.v1beta1.usePool
+     * Per Pool gRPC Endpoints
+     */
+    usePool: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).usePool,
+    /**
+     * osmosis.gamm.v1beta1.usePoolType
      * PoolType returns the type of the pool.
      * Returns "Balancer" as a string literal when the pool is a balancer pool.
      * Errors if the pool is failed to be type caseted.
      */
     usePoolType: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).usePoolType,
     /**
+     * osmosis.gamm.v1beta1.useCalcJoinPoolNoSwapShares
      * Simulates joining pool without a swap. Returns the amount of shares you'd
      * get and tokens needed to provide
      */
     useCalcJoinPoolNoSwapShares: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).useCalcJoinPoolNoSwapShares,
+    /**
+     * osmosis.gamm.v1beta1.useCalcJoinPoolShares
+     * CalcJoinPoolShares
+     */
     useCalcJoinPoolShares: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).useCalcJoinPoolShares,
+    /**
+     * osmosis.gamm.v1beta1.useCalcExitPoolCoinsFromShares
+     * CalcExitPoolCoinsFromShares
+     */
     useCalcExitPoolCoinsFromShares: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).useCalcExitPoolCoinsFromShares,
+    /**
+     * osmosis.gamm.v1beta1.usePoolParams
+     * PoolParams
+     */
     usePoolParams: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).usePoolParams,
+    /**
+     * osmosis.gamm.v1beta1.useTotalPoolLiquidity
+     * TotalPoolLiquidity
+     */
     useTotalPoolLiquidity: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).useTotalPoolLiquidity,
+    /**
+     * osmosis.gamm.v1beta1.useTotalShares
+     * TotalShares
+     */
     useTotalShares: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).useTotalShares,
     /**
+     * osmosis.gamm.v1beta1.useSpotPrice
      * SpotPrice defines a gRPC query handler that returns the spot price given
      * a base denomination and a quote denomination.
      */
     useSpotPrice: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).useSpotPrice,
-    /** Estimate the swap. */useEstimateSwapExactAmountIn: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).useEstimateSwapExactAmountIn,
+    /**
+     * osmosis.gamm.v1beta1.useEstimateSwapExactAmountIn
+     * Estimate the swap.
+     */
+    useEstimateSwapExactAmountIn: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).useEstimateSwapExactAmountIn,
+    /**
+     * osmosis.gamm.v1beta1.useEstimateSwapExactAmountOut
+     * EstimateSwapExactAmountOut
+     */
     useEstimateSwapExactAmountOut: _OsmosisGammV1beta1Queryrpc.createRpcQueryHooks(rpc).useEstimateSwapExactAmountOut,
     /**
+     * osmosis.gamm.v2.useSpotPrice
      * SpotPrice defines a gRPC query handler that returns the spot price given
      * a base denomination and a quote denomination.
      */

--- a/packages/telescope/src/generators/create-react-query-bundle.ts
+++ b/packages/telescope/src/generators/create-react-query-bundle.ts
@@ -63,7 +63,7 @@ export const plugin = (
           dotty.put(instantHooksMapping, instantHookName, {
             useHookName,
             importedVarName: variableSlug(path),
-            comment: method.comment
+            comment: `${bundlerFile.package}.${useHookName}\n${method.comment ?? methodName}`
           });
 
           methodSet.add(instantHookName);


### PR DESCRIPTION
add package + useHook in front of comments of exposed hooks:
```
    /**
     * cosmos.nft.v1beta1.useBalance
     * Balance queries the number of NFTs of a given class owned by the owner, same as balanceOf in ERC721
     */
    useCosmosNftV1beta1Balance: _CosmosNftV1beta1Queryrpc.createRpcQueryHooks(rpc).useBalance,
```

if there's no comment originally, use original method name as a comment:
```
    /**
     * osmosis.gamm.v1beta1.usePools
     * Pools
     */
```