### PR TITLE
Hard exclude proto files

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ telescope({
 | ----------------------------------------- | --------------------------------------------------------------  | ---------- |
 | `prototypes.enabled`                      | enables the generation of proto encoding methods                | `true`     |
 | `prototypes.includePackageVar`            | export a `protoPackage` variable to indicate package name       | `false`    |
+| `prototypes.include.packages`            | include a set of packages when transpilation. (if a package both meet include and exclude, it'll be excluded)                    | `undefined`|
+| `prototypes.include.protos`              | include a set of proto files when transpilation. (if a proto both meet include and exclude, it'll be excluded)                 | `undefined`|
 | `prototypes.excluded.packages`            | exclude a set of packages from transpilation                    | `undefined`|
 | `prototypes.excluded.protos`              | try to exclude a set of proto files from transpilation. if files inside the list are dependencies to other files, they'll be still transpiled.                 | `undefined`|
 | `prototypes.excluded.hardProtos`              | exclude a set of proto files from transpilation. Files in this list will be excluded no mater it's dependency to other files or not.                 | `undefined`|

--- a/README.md
+++ b/README.md
@@ -275,7 +275,8 @@ telescope({
 | `prototypes.enabled`                      | enables the generation of proto encoding methods                | `true`     |
 | `prototypes.includePackageVar`            | export a `protoPackage` variable to indicate package name       | `false`    |
 | `prototypes.excluded.packages`            | exclude a set of packages from transpilation                    | `undefined`|
-| `prototypes.excluded.protos`              | exclude a set of proto files from transpilation                 | `undefined`|
+| `prototypes.excluded.protos`              | try to exclude a set of proto files from transpilation. if files inside the list are dependencies to other files, they'll be still transpiled.                 | `undefined`|
+| `prototypes.excluded.hardProtos`              | exclude a set of proto files from transpilation. Files in this list will be excluded no mater it's dependency to other files or not.                 | `undefined`|
 | `prototypes.fieldDefaultIsOptional`       | boolean value representing default optionality of field         | `false`    |
 | `prototypes.useOptionalNullable`          | use `(gogoproto.nullable)` values in determining optionality    | `true`     |
 | `prototypes.allowUndefinedTypes`          | boolean value allowing `Type`s to be `undefined`                | `false`    |

--- a/__fixtures__/misc/proto/google/api/expr/v1alpha1/eval1.proto
+++ b/__fixtures__/misc/proto/google/api/expr/v1alpha1/eval1.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+package google.api.expr.v1;

--- a/packages/parser/src/store.ts
+++ b/packages/parser/src/store.ts
@@ -215,6 +215,14 @@ export class ProtoStore implements IProtoStore {
         let resolver = new ProtoResolver(this.getDeps());
 
         this.protos = this.getProtos().map((ref: ProtoRef) => {
+            const isHardExcluded = isRefExcluded(ref, {
+              protos: this.options.prototypes.excluded.hardProtos
+            })
+
+            if(isHardExcluded){
+              return null;
+            }
+
             if (!actualFiles.has(ref.filename)) {
                 // get included imported files
                 const isIncluded = isRefIncluded(ref, this.options.prototypes.includes)
@@ -235,7 +243,7 @@ export class ProtoStore implements IProtoStore {
                 proto: ref.proto,
                 traversed: traverse(this, ref)
             };
-        });
+        }).filter(Boolean);
         this._symbols = parseFullyTraversedProtoImports(this);
 
         // process import names

--- a/packages/parser/src/store.ts
+++ b/packages/parser/src/store.ts
@@ -215,8 +215,8 @@ export class ProtoStore implements IProtoStore {
         let resolver = new ProtoResolver(this.getDeps());
 
         this.protos = this.getProtos().map((ref: ProtoRef) => {
-            const isHardExcluded = isRefExcluded(ref, {
-              protos: this.options.prototypes.excluded.hardProtos
+            const isHardExcluded = this.options?.prototypes?.excluded?.hardProtos && isRefExcluded(ref, {
+              protos: this.options?.prototypes?.excluded?.hardProtos
             })
 
             if(isHardExcluded){

--- a/packages/telescope/README.md
+++ b/packages/telescope/README.md
@@ -274,6 +274,8 @@ telescope({
 | ----------------------------------------- | --------------------------------------------------------------  | ---------- |
 | `prototypes.enabled`                      | enables the generation of proto encoding methods                | `true`     |
 | `prototypes.includePackageVar`            | export a `protoPackage` variable to indicate package name       | `false`    |
+| `prototypes.include.packages`            | include a set of packages when transpilation. (if a package both meet include and exclude, it'll be excluded)                    | `undefined`|
+| `prototypes.include.protos`              | include a set of proto files when transpilation. (if a proto both meet include and exclude, it'll be excluded)                 | `undefined`|
 | `prototypes.excluded.packages`            | exclude a set of packages from transpilation                    | `undefined`|
 | `prototypes.excluded.protos`              | try to exclude a set of proto files from transpilation. if files inside the list are dependencies to other files, they'll be still transpiled.                 | `undefined`|
 | `prototypes.excluded.hardProtos`              | exclude a set of proto files from transpilation. Files in this list will be excluded no mater it's dependency to other files or not.                 | `undefined`|

--- a/packages/telescope/README.md
+++ b/packages/telescope/README.md
@@ -275,7 +275,8 @@ telescope({
 | `prototypes.enabled`                      | enables the generation of proto encoding methods                | `true`     |
 | `prototypes.includePackageVar`            | export a `protoPackage` variable to indicate package name       | `false`    |
 | `prototypes.excluded.packages`            | exclude a set of packages from transpilation                    | `undefined`|
-| `prototypes.excluded.protos`              | exclude a set of proto files from transpilation                 | `undefined`|
+| `prototypes.excluded.protos`              | try to exclude a set of proto files from transpilation. if files inside the list are dependencies to other files, they'll be still transpiled.                 | `undefined`|
+| `prototypes.excluded.hardProtos`              | exclude a set of proto files from transpilation. Files in this list will be excluded no mater it's dependency to other files or not.                 | `undefined`|
 | `prototypes.fieldDefaultIsOptional`       | boolean value representing default optionality of field         | `false`    |
 | `prototypes.useOptionalNullable`          | use `(gogoproto.nullable)` values in determining optionality    | `true`     |
 | `prototypes.allowUndefinedTypes`          | boolean value allowing `Type`s to be `undefined`                | `false`    |

--- a/packages/telescope/__tests__/misc.test.ts
+++ b/packages/telescope/__tests__/misc.test.ts
@@ -16,6 +16,14 @@ const options: TelescopeOptions = {
 
   prototypes: {
     enabled: true,
+
+    excluded:{
+      // hard exclude faulty proto files
+      hardProtos:[
+        "google/api/expr/v1alpha1/eval1.proto"
+      ]
+    },
+
     parser: {
       keepCase: false,
     },

--- a/packages/types/src/telescope.ts
+++ b/packages/types/src/telescope.ts
@@ -62,6 +62,7 @@ interface TelescopeOpts {
         excluded?: {
             packages?: string[];
             protos?: string[];
+            hardProtos?: string[];
         };
         includes?: {
             packages?: string[];

--- a/packages/types/types/telescope.d.ts
+++ b/packages/types/types/telescope.d.ts
@@ -53,6 +53,7 @@ interface TelescopeOpts {
         excluded?: {
             packages?: string[];
             protos?: string[];
+            hardProtos?: string[];
         };
         includes?: {
             packages?: string[];


### PR DESCRIPTION
There's a new package's added to cosmos named accounts, and there's a proto file named 'accounts.proto' caused traversing issue, since there's no type definition inside the file. So I have to add a feature called hard exclude. By using the option, users can hard exclude proto files without traversing it at all.

```
//The faulty proto's like this:

syntax = "proto3";

package cosmos.accounts.v1;

option go_package = "cosmossdk.io/x/accounts/v1";

// no type here
```