### PR TITLE
Recognize LegacyDec as Decimal and convert appropriately

### DIFF
--- a/packages/ast/src/encoding/proto/decode/utils.ts
+++ b/packages/ast/src/encoding/proto/decode/utils.ts
@@ -173,8 +173,10 @@ export const baseTypes = {
           'prototypes.typingsFormat.customTypes.useCosmosSDKDec'
         );
         const isCosmosSDKDec =
-          args.field.options?.['(gogoproto.customtype)'] ==
-          'github.com/cosmos/cosmos-sdk/types.Dec';
+            (args.field.options?.['(gogoproto.customtype)'] ==
+                'github.com/cosmos/cosmos-sdk/types.Dec') ||
+            (args.field.options?.['(gogoproto.customtype)'] ==
+                'cosmossdk.io/math.LegacyDec');
 
         let valueExpression = t.callExpression(
             t.memberExpression(

--- a/packages/ast/src/encoding/proto/encode/utils.ts
+++ b/packages/ast/src/encoding/proto/encode/utils.ts
@@ -122,6 +122,7 @@ const scalarType = (num: number, prop: string, type: string, args?: EncodeMethod
 const customType = (num: number, prop: string, type: string, customType: string, args: EncodeMethod) => {
     switch (customType) {
         case "github.com/cosmos/cosmos-sdk/types.Dec":
+        case "cosmossdk.io/math.LegacyDec":
         default:
             args.context.addUtil("Decimal");
 
@@ -359,8 +360,10 @@ export const types = {
             'prototypes.typingsFormat.customTypes.useCosmosSDKDec'
         );
         const isCosmosSDKDec =
-            args.field.options?.['(gogoproto.customtype)'] ==
-            'github.com/cosmos/cosmos-sdk/types.Dec';
+            (args.field.options?.['(gogoproto.customtype)'] ==
+                'github.com/cosmos/cosmos-sdk/types.Dec') ||
+            (args.field.options?.['(gogoproto.customtype)'] ==
+                'cosmossdk.io/math.LegacyDec');
 
         return t.ifStatement(
             wrapOptional(prop, notEmptyString(prop), isOptional),
@@ -1115,8 +1118,10 @@ export const arrayTypes = {
             'prototypes.typingsFormat.customTypes.useCosmosSDKDec'
         );
         const isCosmosSDKDec =
-            args.field.options?.['(gogoproto.customtype)'] ==
-            'github.com/cosmos/cosmos-sdk/types.Dec';
+            (args.field.options?.['(gogoproto.customtype)'] ==
+                'github.com/cosmos/cosmos-sdk/types.Dec') ||
+            (args.field.options?.['(gogoproto.customtype)'] ==
+                'cosmossdk.io/math.LegacyDec');
 
         const num = getTagNumber(args.field);
 


### PR DESCRIPTION
## Problem

Osmosis recently (https://github.com/osmosis-labs/osmosis/commit/c7904f68ad21be3c258dfc1023bc4b7e08d0d76a) switched their Decimal types from `github.com/cosmos/cosmos-sdk/types.Dec` to `cosmossdk.io/math.LegacyDec`. Though they are stored the same in the underlying type (a string with 18 decimals), telescope does not currently detect the `LegacyDec` type as a Decimal and apply the 18-decimal auto transformation to the input.

## Solution

The auto Decimal transformation feature was added in #332. This PR applies the same functionality to the LegacyDec type.