### PR TITLE
Add target folder message in complete message

### DIFF
--- a/packages/telescope/src/builder.ts
+++ b/packages/telescope/src/builder.ts
@@ -158,6 +158,6 @@ export class TelescopeBuilder {
     // finally, write one index file with all files, exported
     createIndex(this);
 
-    console.log(`✨ files transpiled under '${this.outPath}'`);
+    console.log(`✨ files transpiled in '${this.outPath}'`);
   }
 }

--- a/packages/telescope/src/builder.ts
+++ b/packages/telescope/src/builder.ts
@@ -157,5 +157,7 @@ export class TelescopeBuilder {
 
     // finally, write one index file with all files, exported
     createIndex(this);
+
+    console.log(`✨ files transpiled under '${this.outPath}'`);
   }
 }


### PR DESCRIPTION
add a transpiling complete message to show outPath like:

✨ files transpiled in '/src/codegen'
✨ transpilation successful!

A suggestion said that if telescope create target folder itself, there'll be chance users don't know where their files're transpiled in. I think that's a good point.

