### PR TITLE
allow encoding default scalar types values

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ telescope({
 | `prototypes.fieldDefaultIsOptional`       | boolean value representing default optionality of field         | `false`    |
 | `prototypes.useOptionalNullable`          | use `(gogoproto.nullable)` values in determining optionality    | `true`     |
 | `prototypes.allowUndefinedTypes`          | boolean value allowing `Type`s to be `undefined`                | `false`    |
+| `prototypes.allowEncodeDefaultScalars`          | boolean value allowing encoders encoding default values of scalar types. e.g. empty string, 0 or false                | `false`    |
 | `prototypes.optionalQueryParams`          | boolean value setting queryParams to be optional                | `false`    |
 | `prototypes.optionalPageRequests`         | boolean value setting `PageRequest` fields to optional          | `false`    |
 | `prototypes.addTypeUrlToDecoders`         | add $typeUrl field to generated interfaces          | `true`    |

--- a/__fixtures__/v-next/outputv4/akash/audit/v1beta1/audit.ts
+++ b/__fixtures__/v-next/outputv4/akash/audit/v1beta1/audit.ts
@@ -118,10 +118,10 @@ function createBaseProvider(): Provider {
 export const Provider = {
   typeUrl: "/akash.audit.v1beta1.Provider",
   encode(message: Provider, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.auditor !== "") {
+    if (message.auditor !== undefined) {
       writer.uint32(18).string(message.auditor);
     }
     for (const v of message.attributes) {
@@ -252,10 +252,10 @@ function createBaseAuditedAttributes(): AuditedAttributes {
 export const AuditedAttributes = {
   typeUrl: "/akash.audit.v1beta1.AuditedAttributes",
   encode(message: AuditedAttributes, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.auditor !== "") {
+    if (message.auditor !== undefined) {
       writer.uint32(18).string(message.auditor);
     }
     for (const v of message.attributes) {
@@ -621,10 +621,10 @@ function createBaseMsgSignProviderAttributes(): MsgSignProviderAttributes {
 export const MsgSignProviderAttributes = {
   typeUrl: "/akash.audit.v1beta1.MsgSignProviderAttributes",
   encode(message: MsgSignProviderAttributes, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.auditor !== "") {
+    if (message.auditor !== undefined) {
       writer.uint32(18).string(message.auditor);
     }
     for (const v of message.attributes) {
@@ -828,10 +828,10 @@ function createBaseMsgDeleteProviderAttributes(): MsgDeleteProviderAttributes {
 export const MsgDeleteProviderAttributes = {
   typeUrl: "/akash.audit.v1beta1.MsgDeleteProviderAttributes",
   encode(message: MsgDeleteProviderAttributes, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.auditor !== "") {
+    if (message.auditor !== undefined) {
       writer.uint32(18).string(message.auditor);
     }
     for (const v of message.keys) {

--- a/__fixtures__/v-next/outputv4/akash/audit/v1beta2/audit.ts
+++ b/__fixtures__/v-next/outputv4/akash/audit/v1beta2/audit.ts
@@ -118,10 +118,10 @@ function createBaseProvider(): Provider {
 export const Provider = {
   typeUrl: "/akash.audit.v1beta2.Provider",
   encode(message: Provider, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.auditor !== "") {
+    if (message.auditor !== undefined) {
       writer.uint32(18).string(message.auditor);
     }
     for (const v of message.attributes) {
@@ -252,10 +252,10 @@ function createBaseAuditedAttributes(): AuditedAttributes {
 export const AuditedAttributes = {
   typeUrl: "/akash.audit.v1beta2.AuditedAttributes",
   encode(message: AuditedAttributes, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.auditor !== "") {
+    if (message.auditor !== undefined) {
       writer.uint32(18).string(message.auditor);
     }
     for (const v of message.attributes) {
@@ -621,10 +621,10 @@ function createBaseMsgSignProviderAttributes(): MsgSignProviderAttributes {
 export const MsgSignProviderAttributes = {
   typeUrl: "/akash.audit.v1beta2.MsgSignProviderAttributes",
   encode(message: MsgSignProviderAttributes, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.auditor !== "") {
+    if (message.auditor !== undefined) {
       writer.uint32(18).string(message.auditor);
     }
     for (const v of message.attributes) {
@@ -828,10 +828,10 @@ function createBaseMsgDeleteProviderAttributes(): MsgDeleteProviderAttributes {
 export const MsgDeleteProviderAttributes = {
   typeUrl: "/akash.audit.v1beta2.MsgDeleteProviderAttributes",
   encode(message: MsgDeleteProviderAttributes, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.auditor !== "") {
+    if (message.auditor !== undefined) {
       writer.uint32(18).string(message.auditor);
     }
     for (const v of message.keys) {

--- a/__fixtures__/v-next/outputv4/akash/audit/v1beta2/query.ts
+++ b/__fixtures__/v-next/outputv4/akash/audit/v1beta2/query.ts
@@ -215,10 +215,10 @@ function createBaseQueryProviderRequest(): QueryProviderRequest {
 export const QueryProviderRequest = {
   typeUrl: "/akash.audit.v1beta2.QueryProviderRequest",
   encode(message: QueryProviderRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.auditor !== "") {
+    if (message.auditor !== undefined) {
       writer.uint32(10).string(message.auditor);
     }
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(18).string(message.owner);
     }
     return writer;
@@ -416,7 +416,7 @@ function createBaseQueryProviderAttributesRequest(): QueryProviderAttributesRequ
 export const QueryProviderAttributesRequest = {
   typeUrl: "/akash.audit.v1beta2.QueryProviderAttributesRequest",
   encode(message: QueryProviderAttributesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
     if (message.pagination !== undefined) {
@@ -525,10 +525,10 @@ function createBaseQueryProviderAuditorRequest(): QueryProviderAuditorRequest {
 export const QueryProviderAuditorRequest = {
   typeUrl: "/akash.audit.v1beta2.QueryProviderAuditorRequest",
   encode(message: QueryProviderAuditorRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.auditor !== "") {
+    if (message.auditor !== undefined) {
       writer.uint32(10).string(message.auditor);
     }
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(18).string(message.owner);
     }
     return writer;
@@ -632,7 +632,7 @@ function createBaseQueryAuditorAttributesRequest(): QueryAuditorAttributesReques
 export const QueryAuditorAttributesRequest = {
   typeUrl: "/akash.audit.v1beta2.QueryAuditorAttributesRequest",
   encode(message: QueryAuditorAttributesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.auditor !== "") {
+    if (message.auditor !== undefined) {
       writer.uint32(10).string(message.auditor);
     }
     if (message.pagination !== undefined) {

--- a/__fixtures__/v-next/outputv4/akash/base/v1beta1/attribute.ts
+++ b/__fixtures__/v-next/outputv4/akash/base/v1beta1/attribute.ts
@@ -66,10 +66,10 @@ function createBaseAttribute(): Attribute {
 export const Attribute = {
   typeUrl: "/akash.base.v1beta1.Attribute",
   encode(message: Attribute, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(18).string(message.value);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/akash/base/v1beta2/attribute.ts
+++ b/__fixtures__/v-next/outputv4/akash/base/v1beta2/attribute.ts
@@ -66,10 +66,10 @@ function createBaseAttribute(): Attribute {
 export const Attribute = {
   typeUrl: "/akash.base.v1beta2.Attribute",
   encode(message: Attribute, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(18).string(message.value);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/akash/base/v1beta2/endpoint.ts
+++ b/__fixtures__/v-next/outputv4/akash/base/v1beta2/endpoint.ts
@@ -68,7 +68,7 @@ export const Endpoint = {
     if (message.kind !== 0) {
       writer.uint32(8).int32(message.kind);
     }
-    if (message.sequenceNumber !== 0) {
+    if (message.sequenceNumber !== undefined) {
       writer.uint32(16).uint32(message.sequenceNumber);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/akash/base/v1beta2/resource.ts
+++ b/__fixtures__/v-next/outputv4/akash/base/v1beta2/resource.ts
@@ -299,7 +299,7 @@ function createBaseStorage(): Storage {
 export const Storage = {
   typeUrl: "/akash.base.v1beta2.Storage",
   encode(message: Storage, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     if (message.quantity !== undefined) {

--- a/__fixtures__/v-next/outputv4/akash/cert/v1beta2/cert.ts
+++ b/__fixtures__/v-next/outputv4/akash/cert/v1beta2/cert.ts
@@ -141,10 +141,10 @@ function createBaseCertificateID(): CertificateID {
 export const CertificateID = {
   typeUrl: "/akash.cert.v1beta2.CertificateID",
   encode(message: CertificateID, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.serial !== "") {
+    if (message.serial !== undefined) {
       writer.uint32(18).string(message.serial);
     }
     return writer;
@@ -371,13 +371,13 @@ function createBaseCertificateFilter(): CertificateFilter {
 export const CertificateFilter = {
   typeUrl: "/akash.cert.v1beta2.CertificateFilter",
   encode(message: CertificateFilter, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.serial !== "") {
+    if (message.serial !== undefined) {
       writer.uint32(18).string(message.serial);
     }
-    if (message.state !== "") {
+    if (message.state !== undefined) {
       writer.uint32(26).string(message.state);
     }
     return writer;
@@ -493,7 +493,7 @@ function createBaseMsgCreateCertificate(): MsgCreateCertificate {
 export const MsgCreateCertificate = {
   typeUrl: "/akash.cert.v1beta2.MsgCreateCertificate",
   encode(message: MsgCreateCertificate, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
     if (message.cert.length !== 0) {

--- a/__fixtures__/v-next/outputv4/akash/cert/v1beta2/genesis.ts
+++ b/__fixtures__/v-next/outputv4/akash/cert/v1beta2/genesis.ts
@@ -37,7 +37,7 @@ function createBaseGenesisCertificate(): GenesisCertificate {
 export const GenesisCertificate = {
   typeUrl: "/akash.cert.v1beta2.GenesisCertificate",
   encode(message: GenesisCertificate, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
     if (message.certificate !== undefined) {

--- a/__fixtures__/v-next/outputv4/akash/cert/v1beta2/query.ts
+++ b/__fixtures__/v-next/outputv4/akash/cert/v1beta2/query.ts
@@ -57,7 +57,7 @@ export const CertificateResponse = {
     if (message.certificate !== undefined) {
       Certificate.encode(message.certificate, writer.uint32(10).fork()).ldelim();
     }
-    if (message.serial !== "") {
+    if (message.serial !== undefined) {
       writer.uint32(18).string(message.serial);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/akash/deployment/v1beta1/deployment.ts
+++ b/__fixtures__/v-next/outputv4/akash/deployment/v1beta1/deployment.ts
@@ -981,10 +981,10 @@ function createBaseDeploymentID(): DeploymentID {
 export const DeploymentID = {
   typeUrl: "/akash.deployment.v1beta1.DeploymentID",
   encode(message: DeploymentID, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.dseq !== BigInt(0)) {
+    if (message.dseq !== undefined) {
       writer.uint32(16).uint64(message.dseq);
     }
     return writer;
@@ -1101,7 +1101,7 @@ export const Deployment = {
     if (message.version.length !== 0) {
       writer.uint32(26).bytes(message.version);
     }
-    if (message.createdAt !== BigInt(0)) {
+    if (message.createdAt !== undefined) {
       writer.uint32(32).int64(message.createdAt);
     }
     return writer;
@@ -1232,13 +1232,13 @@ function createBaseDeploymentFilters(): DeploymentFilters {
 export const DeploymentFilters = {
   typeUrl: "/akash.deployment.v1beta1.DeploymentFilters",
   encode(message: DeploymentFilters, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.dseq !== BigInt(0)) {
+    if (message.dseq !== undefined) {
       writer.uint32(16).uint64(message.dseq);
     }
-    if (message.state !== "") {
+    if (message.state !== undefined) {
       writer.uint32(26).string(message.state);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/akash/deployment/v1beta1/group.ts
+++ b/__fixtures__/v-next/outputv4/akash/deployment/v1beta1/group.ts
@@ -696,13 +696,13 @@ function createBaseGroupID(): GroupID {
 export const GroupID = {
   typeUrl: "/akash.deployment.v1beta1.GroupID",
   encode(message: GroupID, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.dseq !== BigInt(0)) {
+    if (message.dseq !== undefined) {
       writer.uint32(16).uint64(message.dseq);
     }
-    if (message.gseq !== 0) {
+    if (message.gseq !== undefined) {
       writer.uint32(24).uint32(message.gseq);
     }
     return writer;
@@ -820,7 +820,7 @@ function createBaseGroupSpec(): GroupSpec {
 export const GroupSpec = {
   typeUrl: "/akash.deployment.v1beta1.GroupSpec",
   encode(message: GroupSpec, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     if (message.requirements !== undefined) {
@@ -966,7 +966,7 @@ export const Group = {
     if (message.groupSpec !== undefined) {
       GroupSpec.encode(message.groupSpec, writer.uint32(26).fork()).ldelim();
     }
-    if (message.createdAt !== BigInt(0)) {
+    if (message.createdAt !== undefined) {
       writer.uint32(32).int64(message.createdAt);
     }
     return writer;
@@ -1102,7 +1102,7 @@ export const Resource = {
     if (message.resources !== undefined) {
       ResourceUnits.encode(message.resources, writer.uint32(10).fork()).ldelim();
     }
-    if (message.count !== 0) {
+    if (message.count !== undefined) {
       writer.uint32(16).uint32(message.count);
     }
     if (message.price !== undefined) {

--- a/__fixtures__/v-next/outputv4/akash/deployment/v1beta2/deployment.ts
+++ b/__fixtures__/v-next/outputv4/akash/deployment/v1beta2/deployment.ts
@@ -99,10 +99,10 @@ function createBaseDeploymentID(): DeploymentID {
 export const DeploymentID = {
   typeUrl: "/akash.deployment.v1beta2.DeploymentID",
   encode(message: DeploymentID, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.dseq !== BigInt(0)) {
+    if (message.dseq !== undefined) {
       writer.uint32(16).uint64(message.dseq);
     }
     return writer;
@@ -219,7 +219,7 @@ export const Deployment = {
     if (message.version.length !== 0) {
       writer.uint32(26).bytes(message.version);
     }
-    if (message.createdAt !== BigInt(0)) {
+    if (message.createdAt !== undefined) {
       writer.uint32(32).int64(message.createdAt);
     }
     return writer;
@@ -350,13 +350,13 @@ function createBaseDeploymentFilters(): DeploymentFilters {
 export const DeploymentFilters = {
   typeUrl: "/akash.deployment.v1beta2.DeploymentFilters",
   encode(message: DeploymentFilters, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.dseq !== BigInt(0)) {
+    if (message.dseq !== undefined) {
       writer.uint32(16).uint64(message.dseq);
     }
-    if (message.state !== "") {
+    if (message.state !== undefined) {
       writer.uint32(26).string(message.state);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/akash/deployment/v1beta2/deploymentmsg.ts
+++ b/__fixtures__/v-next/outputv4/akash/deployment/v1beta2/deploymentmsg.ts
@@ -124,7 +124,7 @@ export const MsgCreateDeployment = {
     if (message.deposit !== undefined) {
       Coin.encode(message.deposit, writer.uint32(34).fork()).ldelim();
     }
-    if (message.depositor !== "") {
+    if (message.depositor !== undefined) {
       writer.uint32(42).string(message.depositor);
     }
     return writer;
@@ -357,7 +357,7 @@ export const MsgDepositDeployment = {
     if (message.amount !== undefined) {
       Coin.encode(message.amount, writer.uint32(18).fork()).ldelim();
     }
-    if (message.depositor !== "") {
+    if (message.depositor !== undefined) {
       writer.uint32(26).string(message.depositor);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/akash/deployment/v1beta2/group.ts
+++ b/__fixtures__/v-next/outputv4/akash/deployment/v1beta2/group.ts
@@ -96,7 +96,7 @@ export const Group = {
     if (message.groupSpec !== undefined) {
       GroupSpec.encode(message.groupSpec, writer.uint32(26).fork()).ldelim();
     }
-    if (message.createdAt !== BigInt(0)) {
+    if (message.createdAt !== undefined) {
       writer.uint32(32).int64(message.createdAt);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/akash/deployment/v1beta2/groupid.ts
+++ b/__fixtures__/v-next/outputv4/akash/deployment/v1beta2/groupid.ts
@@ -27,13 +27,13 @@ function createBaseGroupID(): GroupID {
 export const GroupID = {
   typeUrl: "/akash.deployment.v1beta2.GroupID",
   encode(message: GroupID, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.dseq !== BigInt(0)) {
+    if (message.dseq !== undefined) {
       writer.uint32(16).uint64(message.dseq);
     }
-    if (message.gseq !== 0) {
+    if (message.gseq !== undefined) {
       writer.uint32(24).uint32(message.gseq);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/akash/deployment/v1beta2/groupspec.ts
+++ b/__fixtures__/v-next/outputv4/akash/deployment/v1beta2/groupspec.ts
@@ -29,7 +29,7 @@ function createBaseGroupSpec(): GroupSpec {
 export const GroupSpec = {
   typeUrl: "/akash.deployment.v1beta2.GroupSpec",
   encode(message: GroupSpec, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     if (message.requirements !== undefined) {

--- a/__fixtures__/v-next/outputv4/akash/deployment/v1beta2/resource.ts
+++ b/__fixtures__/v-next/outputv4/akash/deployment/v1beta2/resource.ts
@@ -32,7 +32,7 @@ export const Resource = {
     if (message.resources !== undefined) {
       ResourceUnits.encode(message.resources, writer.uint32(10).fork()).ldelim();
     }
-    if (message.count !== 0) {
+    if (message.count !== undefined) {
       writer.uint32(16).uint32(message.count);
     }
     if (message.price !== undefined) {

--- a/__fixtures__/v-next/outputv4/akash/escrow/v1beta1/query.ts
+++ b/__fixtures__/v-next/outputv4/akash/escrow/v1beta1/query.ts
@@ -85,16 +85,16 @@ function createBaseQueryAccountsRequest(): QueryAccountsRequest {
 export const QueryAccountsRequest = {
   typeUrl: "/akash.escrow.v1beta1.QueryAccountsRequest",
   encode(message: QueryAccountsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.scope !== "") {
+    if (message.scope !== undefined) {
       writer.uint32(10).string(message.scope);
     }
-    if (message.xid !== "") {
+    if (message.xid !== undefined) {
       writer.uint32(18).string(message.xid);
     }
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(26).string(message.owner);
     }
-    if (message.state !== "") {
+    if (message.state !== undefined) {
       writer.uint32(34).string(message.state);
     }
     if (message.pagination !== undefined) {
@@ -361,19 +361,19 @@ function createBaseQueryPaymentsRequest(): QueryPaymentsRequest {
 export const QueryPaymentsRequest = {
   typeUrl: "/akash.escrow.v1beta1.QueryPaymentsRequest",
   encode(message: QueryPaymentsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.scope !== "") {
+    if (message.scope !== undefined) {
       writer.uint32(10).string(message.scope);
     }
-    if (message.xid !== "") {
+    if (message.xid !== undefined) {
       writer.uint32(18).string(message.xid);
     }
-    if (message.id !== "") {
+    if (message.id !== undefined) {
       writer.uint32(26).string(message.id);
     }
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(34).string(message.owner);
     }
-    if (message.state !== "") {
+    if (message.state !== undefined) {
       writer.uint32(42).string(message.state);
     }
     if (message.pagination !== undefined) {

--- a/__fixtures__/v-next/outputv4/akash/escrow/v1beta1/types.ts
+++ b/__fixtures__/v-next/outputv4/akash/escrow/v1beta1/types.ts
@@ -173,10 +173,10 @@ function createBaseAccountID(): AccountID {
 export const AccountID = {
   typeUrl: "/akash.escrow.v1beta1.AccountID",
   encode(message: AccountID, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.scope !== "") {
+    if (message.scope !== undefined) {
       writer.uint32(10).string(message.scope);
     }
-    if (message.xid !== "") {
+    if (message.xid !== undefined) {
       writer.uint32(18).string(message.xid);
     }
     return writer;
@@ -287,7 +287,7 @@ export const Account = {
     if (message.id !== undefined) {
       AccountID.encode(message.id, writer.uint32(10).fork()).ldelim();
     }
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(18).string(message.owner);
     }
     if (message.state !== 0) {
@@ -299,7 +299,7 @@ export const Account = {
     if (message.transferred !== undefined) {
       Coin.encode(message.transferred, writer.uint32(42).fork()).ldelim();
     }
-    if (message.settledAt !== BigInt(0)) {
+    if (message.settledAt !== undefined) {
       writer.uint32(48).int64(message.settledAt);
     }
     return writer;
@@ -463,10 +463,10 @@ export const Payment = {
     if (message.accountId !== undefined) {
       AccountID.encode(message.accountId, writer.uint32(10).fork()).ldelim();
     }
-    if (message.paymentId !== "") {
+    if (message.paymentId !== undefined) {
       writer.uint32(18).string(message.paymentId);
     }
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(26).string(message.owner);
     }
     if (message.state !== 0) {

--- a/__fixtures__/v-next/outputv4/akash/escrow/v1beta2/query.ts
+++ b/__fixtures__/v-next/outputv4/akash/escrow/v1beta2/query.ts
@@ -85,16 +85,16 @@ function createBaseQueryAccountsRequest(): QueryAccountsRequest {
 export const QueryAccountsRequest = {
   typeUrl: "/akash.escrow.v1beta2.QueryAccountsRequest",
   encode(message: QueryAccountsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.scope !== "") {
+    if (message.scope !== undefined) {
       writer.uint32(10).string(message.scope);
     }
-    if (message.xid !== "") {
+    if (message.xid !== undefined) {
       writer.uint32(18).string(message.xid);
     }
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(26).string(message.owner);
     }
-    if (message.state !== "") {
+    if (message.state !== undefined) {
       writer.uint32(34).string(message.state);
     }
     if (message.pagination !== undefined) {
@@ -361,19 +361,19 @@ function createBaseQueryPaymentsRequest(): QueryPaymentsRequest {
 export const QueryPaymentsRequest = {
   typeUrl: "/akash.escrow.v1beta2.QueryPaymentsRequest",
   encode(message: QueryPaymentsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.scope !== "") {
+    if (message.scope !== undefined) {
       writer.uint32(10).string(message.scope);
     }
-    if (message.xid !== "") {
+    if (message.xid !== undefined) {
       writer.uint32(18).string(message.xid);
     }
-    if (message.id !== "") {
+    if (message.id !== undefined) {
       writer.uint32(26).string(message.id);
     }
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(34).string(message.owner);
     }
-    if (message.state !== "") {
+    if (message.state !== undefined) {
       writer.uint32(42).string(message.state);
     }
     if (message.pagination !== undefined) {

--- a/__fixtures__/v-next/outputv4/akash/escrow/v1beta2/types.ts
+++ b/__fixtures__/v-next/outputv4/akash/escrow/v1beta2/types.ts
@@ -186,10 +186,10 @@ function createBaseAccountID(): AccountID {
 export const AccountID = {
   typeUrl: "/akash.escrow.v1beta2.AccountID",
   encode(message: AccountID, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.scope !== "") {
+    if (message.scope !== undefined) {
       writer.uint32(10).string(message.scope);
     }
-    if (message.xid !== "") {
+    if (message.xid !== undefined) {
       writer.uint32(18).string(message.xid);
     }
     return writer;
@@ -302,7 +302,7 @@ export const Account = {
     if (message.id !== undefined) {
       AccountID.encode(message.id, writer.uint32(10).fork()).ldelim();
     }
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(18).string(message.owner);
     }
     if (message.state !== 0) {
@@ -314,10 +314,10 @@ export const Account = {
     if (message.transferred !== undefined) {
       DecCoin.encode(message.transferred, writer.uint32(42).fork()).ldelim();
     }
-    if (message.settledAt !== BigInt(0)) {
+    if (message.settledAt !== undefined) {
       writer.uint32(48).int64(message.settledAt);
     }
-    if (message.depositor !== "") {
+    if (message.depositor !== undefined) {
       writer.uint32(58).string(message.depositor);
     }
     if (message.funds !== undefined) {
@@ -508,10 +508,10 @@ export const FractionalPayment = {
     if (message.accountId !== undefined) {
       AccountID.encode(message.accountId, writer.uint32(10).fork()).ldelim();
     }
-    if (message.paymentId !== "") {
+    if (message.paymentId !== undefined) {
       writer.uint32(18).string(message.paymentId);
     }
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(26).string(message.owner);
     }
     if (message.state !== 0) {

--- a/__fixtures__/v-next/outputv4/akash/inflation/v1beta2/params.ts
+++ b/__fixtures__/v-next/outputv4/akash/inflation/v1beta2/params.ts
@@ -37,13 +37,13 @@ function createBaseParams(): Params {
 export const Params = {
   typeUrl: "/akash.inflation.v1beta2.Params",
   encode(message: Params, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.inflationDecayFactor !== "") {
+    if (message.inflationDecayFactor !== undefined) {
       writer.uint32(10).string(Decimal.fromUserInput(message.inflationDecayFactor, 18).atomics);
     }
-    if (message.initialInflation !== "") {
+    if (message.initialInflation !== undefined) {
       writer.uint32(18).string(Decimal.fromUserInput(message.initialInflation, 18).atomics);
     }
-    if (message.variance !== "") {
+    if (message.variance !== undefined) {
       writer.uint32(26).string(Decimal.fromUserInput(message.variance, 18).atomics);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/akash/market/v1beta2/bid.ts
+++ b/__fixtures__/v-next/outputv4/akash/market/v1beta2/bid.ts
@@ -184,7 +184,7 @@ export const MsgCreateBid = {
     if (message.order !== undefined) {
       OrderID.encode(message.order, writer.uint32(10).fork()).ldelim();
     }
-    if (message.provider !== "") {
+    if (message.provider !== undefined) {
       writer.uint32(18).string(message.provider);
     }
     if (message.price !== undefined) {
@@ -565,19 +565,19 @@ function createBaseBidID(): BidID {
 export const BidID = {
   typeUrl: "/akash.market.v1beta2.BidID",
   encode(message: BidID, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.dseq !== BigInt(0)) {
+    if (message.dseq !== undefined) {
       writer.uint32(16).uint64(message.dseq);
     }
-    if (message.gseq !== 0) {
+    if (message.gseq !== undefined) {
       writer.uint32(24).uint32(message.gseq);
     }
-    if (message.oseq !== 0) {
+    if (message.oseq !== undefined) {
       writer.uint32(32).uint32(message.oseq);
     }
-    if (message.provider !== "") {
+    if (message.provider !== undefined) {
       writer.uint32(42).string(message.provider);
     }
     return writer;
@@ -727,7 +727,7 @@ export const Bid = {
     if (message.price !== undefined) {
       DecCoin.encode(message.price, writer.uint32(26).fork()).ldelim();
     }
-    if (message.createdAt !== BigInt(0)) {
+    if (message.createdAt !== undefined) {
       writer.uint32(32).int64(message.createdAt);
     }
     return writer;
@@ -863,22 +863,22 @@ function createBaseBidFilters(): BidFilters {
 export const BidFilters = {
   typeUrl: "/akash.market.v1beta2.BidFilters",
   encode(message: BidFilters, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.dseq !== BigInt(0)) {
+    if (message.dseq !== undefined) {
       writer.uint32(16).uint64(message.dseq);
     }
-    if (message.gseq !== 0) {
+    if (message.gseq !== undefined) {
       writer.uint32(24).uint32(message.gseq);
     }
-    if (message.oseq !== 0) {
+    if (message.oseq !== undefined) {
       writer.uint32(32).uint32(message.oseq);
     }
-    if (message.provider !== "") {
+    if (message.provider !== undefined) {
       writer.uint32(42).string(message.provider);
     }
-    if (message.state !== "") {
+    if (message.state !== undefined) {
       writer.uint32(50).string(message.state);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/akash/market/v1beta2/lease.ts
+++ b/__fixtures__/v-next/outputv4/akash/market/v1beta2/lease.ts
@@ -185,19 +185,19 @@ function createBaseLeaseID(): LeaseID {
 export const LeaseID = {
   typeUrl: "/akash.market.v1beta2.LeaseID",
   encode(message: LeaseID, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.dseq !== BigInt(0)) {
+    if (message.dseq !== undefined) {
       writer.uint32(16).uint64(message.dseq);
     }
-    if (message.gseq !== 0) {
+    if (message.gseq !== undefined) {
       writer.uint32(24).uint32(message.gseq);
     }
-    if (message.oseq !== 0) {
+    if (message.oseq !== undefined) {
       writer.uint32(32).uint32(message.oseq);
     }
-    if (message.provider !== "") {
+    if (message.provider !== undefined) {
       writer.uint32(42).string(message.provider);
     }
     return writer;
@@ -348,10 +348,10 @@ export const Lease = {
     if (message.price !== undefined) {
       DecCoin.encode(message.price, writer.uint32(26).fork()).ldelim();
     }
-    if (message.createdAt !== BigInt(0)) {
+    if (message.createdAt !== undefined) {
       writer.uint32(32).int64(message.createdAt);
     }
-    if (message.closedOn !== BigInt(0)) {
+    if (message.closedOn !== undefined) {
       writer.uint32(40).int64(message.closedOn);
     }
     return writer;
@@ -500,22 +500,22 @@ function createBaseLeaseFilters(): LeaseFilters {
 export const LeaseFilters = {
   typeUrl: "/akash.market.v1beta2.LeaseFilters",
   encode(message: LeaseFilters, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.dseq !== BigInt(0)) {
+    if (message.dseq !== undefined) {
       writer.uint32(16).uint64(message.dseq);
     }
-    if (message.gseq !== 0) {
+    if (message.gseq !== undefined) {
       writer.uint32(24).uint32(message.gseq);
     }
-    if (message.oseq !== 0) {
+    if (message.oseq !== undefined) {
       writer.uint32(32).uint32(message.oseq);
     }
-    if (message.provider !== "") {
+    if (message.provider !== undefined) {
       writer.uint32(42).string(message.provider);
     }
-    if (message.state !== "") {
+    if (message.state !== undefined) {
       writer.uint32(50).string(message.state);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/akash/market/v1beta2/order.ts
+++ b/__fixtures__/v-next/outputv4/akash/market/v1beta2/order.ts
@@ -117,16 +117,16 @@ function createBaseOrderID(): OrderID {
 export const OrderID = {
   typeUrl: "/akash.market.v1beta2.OrderID",
   encode(message: OrderID, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.dseq !== BigInt(0)) {
+    if (message.dseq !== undefined) {
       writer.uint32(16).uint64(message.dseq);
     }
-    if (message.gseq !== 0) {
+    if (message.gseq !== undefined) {
       writer.uint32(24).uint32(message.gseq);
     }
-    if (message.oseq !== 0) {
+    if (message.oseq !== undefined) {
       writer.uint32(32).uint32(message.oseq);
     }
     return writer;
@@ -265,7 +265,7 @@ export const Order = {
     if (message.spec !== undefined) {
       GroupSpec.encode(message.spec, writer.uint32(26).fork()).ldelim();
     }
-    if (message.createdAt !== BigInt(0)) {
+    if (message.createdAt !== undefined) {
       writer.uint32(32).int64(message.createdAt);
     }
     return writer;
@@ -400,19 +400,19 @@ function createBaseOrderFilters(): OrderFilters {
 export const OrderFilters = {
   typeUrl: "/akash.market.v1beta2.OrderFilters",
   encode(message: OrderFilters, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.dseq !== BigInt(0)) {
+    if (message.dseq !== undefined) {
       writer.uint32(16).uint64(message.dseq);
     }
-    if (message.gseq !== 0) {
+    if (message.gseq !== undefined) {
       writer.uint32(24).uint32(message.gseq);
     }
-    if (message.oseq !== 0) {
+    if (message.oseq !== undefined) {
       writer.uint32(32).uint32(message.oseq);
     }
-    if (message.state !== "") {
+    if (message.state !== undefined) {
       writer.uint32(42).string(message.state);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/akash/market/v1beta2/params.ts
+++ b/__fixtures__/v-next/outputv4/akash/market/v1beta2/params.ts
@@ -28,7 +28,7 @@ export const Params = {
     if (message.bidMinDeposit !== undefined) {
       Coin.encode(message.bidMinDeposit, writer.uint32(10).fork()).ldelim();
     }
-    if (message.orderMaxBids !== 0) {
+    if (message.orderMaxBids !== undefined) {
       writer.uint32(16).uint32(message.orderMaxBids);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/akash/provider/v1beta1/provider.ts
+++ b/__fixtures__/v-next/outputv4/akash/provider/v1beta1/provider.ts
@@ -115,10 +115,10 @@ function createBaseProviderInfo(): ProviderInfo {
 export const ProviderInfo = {
   typeUrl: "/akash.provider.v1beta1.ProviderInfo",
   encode(message: ProviderInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.email !== "") {
+    if (message.email !== undefined) {
       writer.uint32(10).string(message.email);
     }
-    if (message.website !== "") {
+    if (message.website !== undefined) {
       writer.uint32(18).string(message.website);
     }
     return writer;
@@ -224,10 +224,10 @@ function createBaseMsgCreateProvider(): MsgCreateProvider {
 export const MsgCreateProvider = {
   typeUrl: "/akash.provider.v1beta1.MsgCreateProvider",
   encode(message: MsgCreateProvider, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.hostUri !== "") {
+    if (message.hostUri !== undefined) {
       writer.uint32(18).string(message.hostUri);
     }
     for (const v of message.attributes) {
@@ -448,10 +448,10 @@ function createBaseMsgUpdateProvider(): MsgUpdateProvider {
 export const MsgUpdateProvider = {
   typeUrl: "/akash.provider.v1beta1.MsgUpdateProvider",
   encode(message: MsgUpdateProvider, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.hostUri !== "") {
+    if (message.hostUri !== undefined) {
       writer.uint32(18).string(message.hostUri);
     }
     for (const v of message.attributes) {
@@ -669,7 +669,7 @@ function createBaseMsgDeleteProvider(): MsgDeleteProvider {
 export const MsgDeleteProvider = {
   typeUrl: "/akash.provider.v1beta1.MsgDeleteProvider",
   encode(message: MsgDeleteProvider, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
     return writer;
@@ -837,10 +837,10 @@ function createBaseProvider(): Provider {
 export const Provider = {
   typeUrl: "/akash.provider.v1beta1.Provider",
   encode(message: Provider, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.hostUri !== "") {
+    if (message.hostUri !== undefined) {
       writer.uint32(18).string(message.hostUri);
     }
     for (const v of message.attributes) {

--- a/__fixtures__/v-next/outputv4/akash/provider/v1beta2/provider.ts
+++ b/__fixtures__/v-next/outputv4/akash/provider/v1beta2/provider.ts
@@ -115,10 +115,10 @@ function createBaseProviderInfo(): ProviderInfo {
 export const ProviderInfo = {
   typeUrl: "/akash.provider.v1beta2.ProviderInfo",
   encode(message: ProviderInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.email !== "") {
+    if (message.email !== undefined) {
       writer.uint32(10).string(message.email);
     }
-    if (message.website !== "") {
+    if (message.website !== undefined) {
       writer.uint32(18).string(message.website);
     }
     return writer;
@@ -224,10 +224,10 @@ function createBaseMsgCreateProvider(): MsgCreateProvider {
 export const MsgCreateProvider = {
   typeUrl: "/akash.provider.v1beta2.MsgCreateProvider",
   encode(message: MsgCreateProvider, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.hostUri !== "") {
+    if (message.hostUri !== undefined) {
       writer.uint32(18).string(message.hostUri);
     }
     for (const v of message.attributes) {
@@ -448,10 +448,10 @@ function createBaseMsgUpdateProvider(): MsgUpdateProvider {
 export const MsgUpdateProvider = {
   typeUrl: "/akash.provider.v1beta2.MsgUpdateProvider",
   encode(message: MsgUpdateProvider, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.hostUri !== "") {
+    if (message.hostUri !== undefined) {
       writer.uint32(18).string(message.hostUri);
     }
     for (const v of message.attributes) {
@@ -669,7 +669,7 @@ function createBaseMsgDeleteProvider(): MsgDeleteProvider {
 export const MsgDeleteProvider = {
   typeUrl: "/akash.provider.v1beta2.MsgDeleteProvider",
   encode(message: MsgDeleteProvider, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
     return writer;
@@ -837,10 +837,10 @@ function createBaseProvider(): Provider {
 export const Provider = {
   typeUrl: "/akash.provider.v1beta2.Provider",
   encode(message: Provider, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.hostUri !== "") {
+    if (message.hostUri !== undefined) {
       writer.uint32(18).string(message.hostUri);
     }
     for (const v of message.attributes) {

--- a/__fixtures__/v-next/outputv4/akash/provider/v1beta2/query.ts
+++ b/__fixtures__/v-next/outputv4/akash/provider/v1beta2/query.ts
@@ -276,7 +276,7 @@ function createBaseQueryProviderRequest(): QueryProviderRequest {
 export const QueryProviderRequest = {
   typeUrl: "/akash.provider.v1beta2.QueryProviderRequest",
   encode(message: QueryProviderRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/confio/proofs.ts
+++ b/__fixtures__/v-next/outputv4/confio/proofs.ts
@@ -1209,10 +1209,10 @@ export const ProofSpec = {
     if (message.innerSpec !== undefined) {
       InnerSpec.encode(message.innerSpec, writer.uint32(18).fork()).ldelim();
     }
-    if (message.maxDepth !== 0) {
+    if (message.maxDepth !== undefined) {
       writer.uint32(24).int32(message.maxDepth);
     }
-    if (message.minDepth !== 0) {
+    if (message.minDepth !== undefined) {
       writer.uint32(32).int32(message.minDepth);
     }
     return writer;
@@ -1345,13 +1345,13 @@ export const InnerSpec = {
       writer.int32(v);
     }
     writer.ldelim();
-    if (message.childSize !== 0) {
+    if (message.childSize !== undefined) {
       writer.uint32(16).int32(message.childSize);
     }
-    if (message.minPrefixLength !== 0) {
+    if (message.minPrefixLength !== undefined) {
       writer.uint32(24).int32(message.minPrefixLength);
     }
-    if (message.maxPrefixLength !== 0) {
+    if (message.maxPrefixLength !== undefined) {
       writer.uint32(32).int32(message.maxPrefixLength);
     }
     if (message.emptyChild.length !== 0) {

--- a/__fixtures__/v-next/outputv4/cosmos/app/v1alpha1/config.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/app/v1alpha1/config.ts
@@ -174,7 +174,7 @@ function createBaseModuleConfig(): ModuleConfig {
 export const ModuleConfig = {
   typeUrl: "/cosmos.app.v1alpha1.ModuleConfig",
   encode(message: ModuleConfig, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     if (message.config !== undefined) {

--- a/__fixtures__/v-next/outputv4/cosmos/app/v1alpha1/module.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/app/v1alpha1/module.ts
@@ -123,7 +123,7 @@ function createBaseModuleDescriptor(): ModuleDescriptor {
 export const ModuleDescriptor = {
   typeUrl: "/cosmos.app.v1alpha1.ModuleDescriptor",
   encode(message: ModuleDescriptor, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.goImport !== "") {
+    if (message.goImport !== undefined) {
       writer.uint32(10).string(message.goImport);
     }
     for (const v of message.usePackage) {
@@ -268,10 +268,10 @@ function createBasePackageReference(): PackageReference {
 export const PackageReference = {
   typeUrl: "/cosmos.app.v1alpha1.PackageReference",
   encode(message: PackageReference, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.revision !== 0) {
+    if (message.revision !== undefined) {
       writer.uint32(16).uint32(message.revision);
     }
     return writer;
@@ -374,7 +374,7 @@ function createBaseMigrateFromInfo(): MigrateFromInfo {
 export const MigrateFromInfo = {
   typeUrl: "/cosmos.app.v1alpha1.MigrateFromInfo",
   encode(message: MigrateFromInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.module !== "") {
+    if (message.module !== undefined) {
       writer.uint32(10).string(message.module);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/auth/v1beta1/auth.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/auth/v1beta1/auth.ts
@@ -75,16 +75,16 @@ function createBaseBaseAccount(): BaseAccount {
 export const BaseAccount = {
   typeUrl: "/cosmos.auth.v1beta1.BaseAccount",
   encode(message: BaseAccount, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     if (message.pubKey !== undefined) {
       Any.encode(message.pubKey, writer.uint32(18).fork()).ldelim();
     }
-    if (message.accountNumber !== BigInt(0)) {
+    if (message.accountNumber !== undefined) {
       writer.uint32(24).uint64(message.accountNumber);
     }
-    if (message.sequence !== BigInt(0)) {
+    if (message.sequence !== undefined) {
       writer.uint32(32).uint64(message.sequence);
     }
     return writer;
@@ -220,7 +220,7 @@ export const ModuleAccount = {
     if (message.baseAccount !== undefined) {
       BaseAccount.encode(message.baseAccount, writer.uint32(10).fork()).ldelim();
     }
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(18).string(message.name);
     }
     for (const v of message.permissions) {
@@ -355,19 +355,19 @@ function createBaseParams(): Params {
 export const Params = {
   typeUrl: "/cosmos.auth.v1beta1.Params",
   encode(message: Params, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.maxMemoCharacters !== BigInt(0)) {
+    if (message.maxMemoCharacters !== undefined) {
       writer.uint32(8).uint64(message.maxMemoCharacters);
     }
-    if (message.txSigLimit !== BigInt(0)) {
+    if (message.txSigLimit !== undefined) {
       writer.uint32(16).uint64(message.txSigLimit);
     }
-    if (message.txSizeCostPerByte !== BigInt(0)) {
+    if (message.txSizeCostPerByte !== undefined) {
       writer.uint32(24).uint64(message.txSizeCostPerByte);
     }
-    if (message.sigVerifyCostEd25519 !== BigInt(0)) {
+    if (message.sigVerifyCostEd25519 !== undefined) {
       writer.uint32(32).uint64(message.sigVerifyCostEd25519);
     }
-    if (message.sigVerifyCostSecp256k1 !== BigInt(0)) {
+    if (message.sigVerifyCostSecp256k1 !== undefined) {
       writer.uint32(40).uint64(message.sigVerifyCostSecp256k1);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/auth/v1beta1/query.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/auth/v1beta1/query.ts
@@ -407,7 +407,7 @@ function createBaseQueryAccountRequest(): QueryAccountRequest {
 export const QueryAccountRequest = {
   typeUrl: "/cosmos.auth.v1beta1.QueryAccountRequest",
   encode(message: QueryAccountRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     return writer;
@@ -1010,7 +1010,7 @@ function createBaseBech32PrefixResponse(): Bech32PrefixResponse {
 export const Bech32PrefixResponse = {
   typeUrl: "/cosmos.auth.v1beta1.Bech32PrefixResponse",
   encode(message: Bech32PrefixResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.bech32Prefix !== "") {
+    if (message.bech32Prefix !== undefined) {
       writer.uint32(10).string(message.bech32Prefix);
     }
     return writer;
@@ -1194,7 +1194,7 @@ function createBaseAddressBytesToStringResponse(): AddressBytesToStringResponse 
 export const AddressBytesToStringResponse = {
   typeUrl: "/cosmos.auth.v1beta1.AddressBytesToStringResponse",
   encode(message: AddressBytesToStringResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.addressString !== "") {
+    if (message.addressString !== undefined) {
       writer.uint32(10).string(message.addressString);
     }
     return writer;
@@ -1286,7 +1286,7 @@ function createBaseAddressStringToBytesRequest(): AddressStringToBytesRequest {
 export const AddressStringToBytesRequest = {
   typeUrl: "/cosmos.auth.v1beta1.AddressStringToBytesRequest",
   encode(message: AddressStringToBytesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.addressString !== "") {
+    if (message.addressString !== undefined) {
       writer.uint32(10).string(message.addressString);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/authz/v1beta1/authz.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/authz/v1beta1/authz.ts
@@ -92,7 +92,7 @@ function createBaseGenericAuthorization(): GenericAuthorization {
 export const GenericAuthorization = {
   typeUrl: "/cosmos.authz.v1beta1.GenericAuthorization",
   encode(message: GenericAuthorization, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.msg !== "") {
+    if (message.msg !== undefined) {
       writer.uint32(10).string(message.msg);
     }
     return writer;
@@ -296,10 +296,10 @@ function createBaseGrantAuthorization(): GrantAuthorization {
 export const GrantAuthorization = {
   typeUrl: "/cosmos.authz.v1beta1.GrantAuthorization",
   encode(message: GrantAuthorization, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.granter !== "") {
+    if (message.granter !== undefined) {
       writer.uint32(10).string(message.granter);
     }
-    if (message.grantee !== "") {
+    if (message.grantee !== undefined) {
       writer.uint32(18).string(message.grantee);
     }
     if (message.authorization !== undefined) {

--- a/__fixtures__/v-next/outputv4/cosmos/authz/v1beta1/query.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/authz/v1beta1/query.ts
@@ -112,13 +112,13 @@ function createBaseQueryGrantsRequest(): QueryGrantsRequest {
 export const QueryGrantsRequest = {
   typeUrl: "/cosmos.authz.v1beta1.QueryGrantsRequest",
   encode(message: QueryGrantsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.granter !== "") {
+    if (message.granter !== undefined) {
       writer.uint32(10).string(message.granter);
     }
-    if (message.grantee !== "") {
+    if (message.grantee !== undefined) {
       writer.uint32(18).string(message.grantee);
     }
-    if (message.msgTypeUrl !== "") {
+    if (message.msgTypeUrl !== undefined) {
       writer.uint32(26).string(message.msgTypeUrl);
     }
     if (message.pagination !== undefined) {
@@ -370,7 +370,7 @@ function createBaseQueryGranterGrantsRequest(): QueryGranterGrantsRequest {
 export const QueryGranterGrantsRequest = {
   typeUrl: "/cosmos.authz.v1beta1.QueryGranterGrantsRequest",
   encode(message: QueryGranterGrantsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.granter !== "") {
+    if (message.granter !== undefined) {
       writer.uint32(10).string(message.granter);
     }
     if (message.pagination !== undefined) {
@@ -600,7 +600,7 @@ function createBaseQueryGranteeGrantsRequest(): QueryGranteeGrantsRequest {
 export const QueryGranteeGrantsRequest = {
   typeUrl: "/cosmos.authz.v1beta1.QueryGranteeGrantsRequest",
   encode(message: QueryGranteeGrantsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.grantee !== "") {
+    if (message.grantee !== undefined) {
       writer.uint32(10).string(message.grantee);
     }
     if (message.pagination !== undefined) {

--- a/__fixtures__/v-next/outputv4/cosmos/authz/v1beta1/tx.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/authz/v1beta1/tx.ts
@@ -112,10 +112,10 @@ function createBaseMsgGrant(): MsgGrant {
 export const MsgGrant = {
   typeUrl: "/cosmos.authz.v1beta1.MsgGrant",
   encode(message: MsgGrant, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.granter !== "") {
+    if (message.granter !== undefined) {
       writer.uint32(10).string(message.granter);
     }
-    if (message.grantee !== "") {
+    if (message.grantee !== undefined) {
       writer.uint32(18).string(message.grantee);
     }
     if (message.grant !== undefined) {
@@ -339,7 +339,7 @@ function createBaseMsgExec(): MsgExec {
 export const MsgExec = {
   typeUrl: "/cosmos.authz.v1beta1.MsgExec",
   encode(message: MsgExec, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.grantee !== "") {
+    if (message.grantee !== undefined) {
       writer.uint32(10).string(message.grantee);
     }
     for (const v of message.msgs) {
@@ -532,13 +532,13 @@ function createBaseMsgRevoke(): MsgRevoke {
 export const MsgRevoke = {
   typeUrl: "/cosmos.authz.v1beta1.MsgRevoke",
   encode(message: MsgRevoke, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.granter !== "") {
+    if (message.granter !== undefined) {
       writer.uint32(10).string(message.granter);
     }
-    if (message.grantee !== "") {
+    if (message.grantee !== undefined) {
       writer.uint32(18).string(message.grantee);
     }
-    if (message.msgTypeUrl !== "") {
+    if (message.msgTypeUrl !== undefined) {
       writer.uint32(26).string(message.msgTypeUrl);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/bank/v1beta1/bank.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/bank/v1beta1/bank.ts
@@ -189,7 +189,7 @@ export const Params = {
     for (const v of message.sendEnabled) {
       SendEnabled.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.defaultSendEnabled === true) {
+    if (message.defaultSendEnabled !== undefined) {
       writer.uint32(16).bool(message.defaultSendEnabled);
     }
     return writer;
@@ -305,10 +305,10 @@ function createBaseSendEnabled(): SendEnabled {
 export const SendEnabled = {
   typeUrl: "/cosmos.bank.v1beta1.SendEnabled",
   encode(message: SendEnabled, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(10).string(message.denom);
     }
-    if (message.enabled === true) {
+    if (message.enabled !== undefined) {
       writer.uint32(16).bool(message.enabled);
     }
     return writer;
@@ -412,7 +412,7 @@ function createBaseInput(): Input {
 export const Input = {
   typeUrl: "/cosmos.bank.v1beta1.Input",
   encode(message: Input, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     for (const v of message.coins) {
@@ -531,7 +531,7 @@ function createBaseOutput(): Output {
 export const Output = {
   typeUrl: "/cosmos.bank.v1beta1.Output",
   encode(message: Output, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     for (const v of message.coins) {
@@ -755,10 +755,10 @@ function createBaseDenomUnit(): DenomUnit {
 export const DenomUnit = {
   typeUrl: "/cosmos.bank.v1beta1.DenomUnit",
   encode(message: DenomUnit, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(10).string(message.denom);
     }
-    if (message.exponent !== 0) {
+    if (message.exponent !== undefined) {
       writer.uint32(16).uint32(message.exponent);
     }
     for (const v of message.aliases) {
@@ -894,28 +894,28 @@ function createBaseMetadata(): Metadata {
 export const Metadata = {
   typeUrl: "/cosmos.bank.v1beta1.Metadata",
   encode(message: Metadata, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(10).string(message.description);
     }
     for (const v of message.denomUnits) {
       DenomUnit.encode(v!, writer.uint32(18).fork()).ldelim();
     }
-    if (message.base !== "") {
+    if (message.base !== undefined) {
       writer.uint32(26).string(message.base);
     }
-    if (message.display !== "") {
+    if (message.display !== undefined) {
       writer.uint32(34).string(message.display);
     }
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(42).string(message.name);
     }
-    if (message.symbol !== "") {
+    if (message.symbol !== undefined) {
       writer.uint32(50).string(message.symbol);
     }
-    if (message.uri !== "") {
+    if (message.uri !== undefined) {
       writer.uint32(58).string(message.uri);
     }
-    if (message.uriHash !== "") {
+    if (message.uriHash !== undefined) {
       writer.uint32(66).string(message.uriHash);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/bank/v1beta1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/bank/v1beta1/genesis.ts
@@ -234,7 +234,7 @@ function createBaseBalance(): Balance {
 export const Balance = {
   typeUrl: "/cosmos.bank.v1beta1.Balance",
   encode(message: Balance, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     for (const v of message.coins) {

--- a/__fixtures__/v-next/outputv4/cosmos/bank/v1beta1/query.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/bank/v1beta1/query.ts
@@ -349,10 +349,10 @@ function createBaseQueryBalanceRequest(): QueryBalanceRequest {
 export const QueryBalanceRequest = {
   typeUrl: "/cosmos.bank.v1beta1.QueryBalanceRequest",
   encode(message: QueryBalanceRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(18).string(message.denom);
     }
     return writer;
@@ -550,7 +550,7 @@ function createBaseQueryAllBalancesRequest(): QueryAllBalancesRequest {
 export const QueryAllBalancesRequest = {
   typeUrl: "/cosmos.bank.v1beta1.QueryAllBalancesRequest",
   encode(message: QueryAllBalancesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     if (message.pagination !== undefined) {
@@ -780,7 +780,7 @@ function createBaseQuerySpendableBalancesRequest(): QuerySpendableBalancesReques
 export const QuerySpendableBalancesRequest = {
   typeUrl: "/cosmos.bank.v1beta1.QuerySpendableBalancesRequest",
   encode(message: QuerySpendableBalancesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     if (message.pagination !== undefined) {
@@ -1224,7 +1224,7 @@ function createBaseQuerySupplyOfRequest(): QuerySupplyOfRequest {
 export const QuerySupplyOfRequest = {
   typeUrl: "/cosmos.bank.v1beta1.QuerySupplyOfRequest",
   encode(message: QuerySupplyOfRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(10).string(message.denom);
     }
     return writer;
@@ -1792,7 +1792,7 @@ function createBaseQueryDenomMetadataRequest(): QueryDenomMetadataRequest {
 export const QueryDenomMetadataRequest = {
   typeUrl: "/cosmos.bank.v1beta1.QueryDenomMetadataRequest",
   encode(message: QueryDenomMetadataRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(10).string(message.denom);
     }
     return writer;
@@ -1979,7 +1979,7 @@ function createBaseQueryDenomOwnersRequest(): QueryDenomOwnersRequest {
 export const QueryDenomOwnersRequest = {
   typeUrl: "/cosmos.bank.v1beta1.QueryDenomOwnersRequest",
   encode(message: QueryDenomOwnersRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(10).string(message.denom);
     }
     if (message.pagination !== undefined) {
@@ -2088,7 +2088,7 @@ function createBaseDenomOwner(): DenomOwner {
 export const DenomOwner = {
   typeUrl: "/cosmos.bank.v1beta1.DenomOwner",
   encode(message: DenomOwner, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     if (message.balance !== undefined) {

--- a/__fixtures__/v-next/outputv4/cosmos/bank/v1beta1/tx.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/bank/v1beta1/tx.ts
@@ -59,10 +59,10 @@ function createBaseMsgSend(): MsgSend {
 export const MsgSend = {
   typeUrl: "/cosmos.bank.v1beta1.MsgSend",
   encode(message: MsgSend, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.fromAddress !== "") {
+    if (message.fromAddress !== undefined) {
       writer.uint32(10).string(message.fromAddress);
     }
-    if (message.toAddress !== "") {
+    if (message.toAddress !== undefined) {
       writer.uint32(18).string(message.toAddress);
     }
     for (const v of message.amount) {

--- a/__fixtures__/v-next/outputv4/cosmos/base/abci/v1beta1/abci.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/base/abci/v1beta1/abci.ts
@@ -302,40 +302,40 @@ function createBaseTxResponse(): TxResponse {
 export const TxResponse = {
   typeUrl: "/cosmos.base.abci.v1beta1.TxResponse",
   encode(message: TxResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.height !== BigInt(0)) {
+    if (message.height !== undefined) {
       writer.uint32(8).int64(message.height);
     }
-    if (message.txhash !== "") {
+    if (message.txhash !== undefined) {
       writer.uint32(18).string(message.txhash);
     }
-    if (message.codespace !== "") {
+    if (message.codespace !== undefined) {
       writer.uint32(26).string(message.codespace);
     }
-    if (message.code !== 0) {
+    if (message.code !== undefined) {
       writer.uint32(32).uint32(message.code);
     }
-    if (message.data !== "") {
+    if (message.data !== undefined) {
       writer.uint32(42).string(message.data);
     }
-    if (message.rawLog !== "") {
+    if (message.rawLog !== undefined) {
       writer.uint32(50).string(message.rawLog);
     }
     for (const v of message.logs) {
       ABCIMessageLog.encode(v!, writer.uint32(58).fork()).ldelim();
     }
-    if (message.info !== "") {
+    if (message.info !== undefined) {
       writer.uint32(66).string(message.info);
     }
-    if (message.gasWanted !== BigInt(0)) {
+    if (message.gasWanted !== undefined) {
       writer.uint32(72).int64(message.gasWanted);
     }
-    if (message.gasUsed !== BigInt(0)) {
+    if (message.gasUsed !== undefined) {
       writer.uint32(80).int64(message.gasUsed);
     }
     if (message.tx !== undefined) {
       Any.encode(message.tx, writer.uint32(90).fork()).ldelim();
     }
-    if (message.timestamp !== "") {
+    if (message.timestamp !== undefined) {
       writer.uint32(98).string(message.timestamp);
     }
     for (const v of message.events) {
@@ -596,10 +596,10 @@ function createBaseABCIMessageLog(): ABCIMessageLog {
 export const ABCIMessageLog = {
   typeUrl: "/cosmos.base.abci.v1beta1.ABCIMessageLog",
   encode(message: ABCIMessageLog, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.msgIndex !== 0) {
+    if (message.msgIndex !== undefined) {
       writer.uint32(8).uint32(message.msgIndex);
     }
-    if (message.log !== "") {
+    if (message.log !== undefined) {
       writer.uint32(18).string(message.log);
     }
     for (const v of message.events) {
@@ -729,7 +729,7 @@ function createBaseStringEvent(): StringEvent {
 export const StringEvent = {
   typeUrl: "/cosmos.base.abci.v1beta1.StringEvent",
   encode(message: StringEvent, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.type !== "") {
+    if (message.type !== undefined) {
       writer.uint32(10).string(message.type);
     }
     for (const v of message.attributes) {
@@ -848,10 +848,10 @@ function createBaseAttribute(): Attribute {
 export const Attribute = {
   typeUrl: "/cosmos.base.abci.v1beta1.Attribute",
   encode(message: Attribute, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(18).string(message.value);
     }
     return writer;
@@ -955,10 +955,10 @@ function createBaseGasInfo(): GasInfo {
 export const GasInfo = {
   typeUrl: "/cosmos.base.abci.v1beta1.GasInfo",
   encode(message: GasInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.gasWanted !== BigInt(0)) {
+    if (message.gasWanted !== undefined) {
       writer.uint32(8).uint64(message.gasWanted);
     }
-    if (message.gasUsed !== BigInt(0)) {
+    if (message.gasUsed !== undefined) {
       writer.uint32(16).uint64(message.gasUsed);
     }
     return writer;
@@ -1071,7 +1071,7 @@ export const Result = {
     if (message.data.length !== 0) {
       writer.uint32(10).bytes(message.data);
     }
-    if (message.log !== "") {
+    if (message.log !== undefined) {
       writer.uint32(18).string(message.log);
     }
     for (const v of message.events) {
@@ -1338,7 +1338,7 @@ function createBaseMsgData(): MsgData {
 export const MsgData = {
   typeUrl: "/cosmos.base.abci.v1beta1.MsgData",
   encode(message: MsgData, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.msgType !== "") {
+    if (message.msgType !== undefined) {
       writer.uint32(10).string(message.msgType);
     }
     if (message.data.length !== 0) {
@@ -1580,19 +1580,19 @@ function createBaseSearchTxsResult(): SearchTxsResult {
 export const SearchTxsResult = {
   typeUrl: "/cosmos.base.abci.v1beta1.SearchTxsResult",
   encode(message: SearchTxsResult, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.totalCount !== BigInt(0)) {
+    if (message.totalCount !== undefined) {
       writer.uint32(8).uint64(message.totalCount);
     }
-    if (message.count !== BigInt(0)) {
+    if (message.count !== undefined) {
       writer.uint32(16).uint64(message.count);
     }
-    if (message.pageNumber !== BigInt(0)) {
+    if (message.pageNumber !== undefined) {
       writer.uint32(24).uint64(message.pageNumber);
     }
-    if (message.pageTotal !== BigInt(0)) {
+    if (message.pageTotal !== undefined) {
       writer.uint32(32).uint64(message.pageTotal);
     }
-    if (message.limit !== BigInt(0)) {
+    if (message.limit !== undefined) {
       writer.uint32(40).uint64(message.limit);
     }
     for (const v of message.txs) {

--- a/__fixtures__/v-next/outputv4/cosmos/base/query/v1beta1/pagination.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/base/query/v1beta1/pagination.ts
@@ -116,16 +116,16 @@ export const PageRequest = {
     if (message.key.length !== 0) {
       writer.uint32(10).bytes(message.key);
     }
-    if (message.offset !== BigInt(0)) {
+    if (message.offset !== undefined) {
       writer.uint32(16).uint64(message.offset);
     }
-    if (message.limit !== BigInt(0)) {
+    if (message.limit !== undefined) {
       writer.uint32(24).uint64(message.limit);
     }
-    if (message.countTotal === true) {
+    if (message.countTotal !== undefined) {
       writer.uint32(32).bool(message.countTotal);
     }
-    if (message.reverse === true) {
+    if (message.reverse !== undefined) {
       writer.uint32(40).bool(message.reverse);
     }
     return writer;
@@ -269,7 +269,7 @@ export const PageResponse = {
     if (message.nextKey.length !== 0) {
       writer.uint32(10).bytes(message.nextKey);
     }
-    if (message.total !== BigInt(0)) {
+    if (message.total !== undefined) {
       writer.uint32(16).uint64(message.total);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/base/reflection/v1beta1/reflection.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/base/reflection/v1beta1/reflection.ts
@@ -244,7 +244,7 @@ function createBaseListImplementationsRequest(): ListImplementationsRequest {
 export const ListImplementationsRequest = {
   typeUrl: "/cosmos.base.reflection.v1beta1.ListImplementationsRequest",
   encode(message: ListImplementationsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.interfaceName !== "") {
+    if (message.interfaceName !== undefined) {
       writer.uint32(10).string(message.interfaceName);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/base/reflection/v2alpha1/reflection.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/base/reflection/v2alpha1/reflection.ts
@@ -600,7 +600,7 @@ function createBaseTxDescriptor(): TxDescriptor {
 export const TxDescriptor = {
   typeUrl: "/cosmos.base.reflection.v2alpha1.TxDescriptor",
   encode(message: TxDescriptor, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.fullname !== "") {
+    if (message.fullname !== undefined) {
       writer.uint32(10).string(message.fullname);
     }
     for (const v of message.msgs) {
@@ -824,13 +824,13 @@ function createBaseSigningModeDescriptor(): SigningModeDescriptor {
 export const SigningModeDescriptor = {
   typeUrl: "/cosmos.base.reflection.v2alpha1.SigningModeDescriptor",
   encode(message: SigningModeDescriptor, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.number !== 0) {
+    if (message.number !== undefined) {
       writer.uint32(16).int32(message.number);
     }
-    if (message.authnInfoProviderMethodFullname !== "") {
+    if (message.authnInfoProviderMethodFullname !== undefined) {
       writer.uint32(26).string(message.authnInfoProviderMethodFullname);
     }
     return writer;
@@ -944,7 +944,7 @@ function createBaseChainDescriptor(): ChainDescriptor {
 export const ChainDescriptor = {
   typeUrl: "/cosmos.base.reflection.v2alpha1.ChainDescriptor",
   encode(message: ChainDescriptor, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.id !== "") {
+    if (message.id !== undefined) {
       writer.uint32(10).string(message.id);
     }
     return writer;
@@ -1142,7 +1142,7 @@ function createBaseInterfaceDescriptor(): InterfaceDescriptor {
 export const InterfaceDescriptor = {
   typeUrl: "/cosmos.base.reflection.v2alpha1.InterfaceDescriptor",
   encode(message: InterfaceDescriptor, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.fullname !== "") {
+    if (message.fullname !== undefined) {
       writer.uint32(10).string(message.fullname);
     }
     for (const v of message.interfaceAcceptingMessages) {
@@ -1287,10 +1287,10 @@ function createBaseInterfaceImplementerDescriptor(): InterfaceImplementerDescrip
 export const InterfaceImplementerDescriptor = {
   typeUrl: "/cosmos.base.reflection.v2alpha1.InterfaceImplementerDescriptor",
   encode(message: InterfaceImplementerDescriptor, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.fullname !== "") {
+    if (message.fullname !== undefined) {
       writer.uint32(10).string(message.fullname);
     }
-    if (message.typeUrl !== "") {
+    if (message.typeUrl !== undefined) {
       writer.uint32(18).string(message.typeUrl);
     }
     return writer;
@@ -1394,7 +1394,7 @@ function createBaseInterfaceAcceptingMessageDescriptor(): InterfaceAcceptingMess
 export const InterfaceAcceptingMessageDescriptor = {
   typeUrl: "/cosmos.base.reflection.v2alpha1.InterfaceAcceptingMessageDescriptor",
   encode(message: InterfaceAcceptingMessageDescriptor, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.fullname !== "") {
+    if (message.fullname !== undefined) {
       writer.uint32(10).string(message.fullname);
     }
     for (const v of message.fieldDescriptorNames) {
@@ -1512,7 +1512,7 @@ function createBaseConfigurationDescriptor(): ConfigurationDescriptor {
 export const ConfigurationDescriptor = {
   typeUrl: "/cosmos.base.reflection.v2alpha1.ConfigurationDescriptor",
   encode(message: ConfigurationDescriptor, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.bech32AccountAddressPrefix !== "") {
+    if (message.bech32AccountAddressPrefix !== undefined) {
       writer.uint32(10).string(message.bech32AccountAddressPrefix);
     }
     return writer;
@@ -1604,7 +1604,7 @@ function createBaseMsgDescriptor(): MsgDescriptor {
 export const MsgDescriptor = {
   typeUrl: "/cosmos.base.reflection.v2alpha1.MsgDescriptor",
   encode(message: MsgDescriptor, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.msgTypeUrl !== "") {
+    if (message.msgTypeUrl !== undefined) {
       writer.uint32(10).string(message.msgTypeUrl);
     }
     return writer;
@@ -2804,10 +2804,10 @@ function createBaseQueryServiceDescriptor(): QueryServiceDescriptor {
 export const QueryServiceDescriptor = {
   typeUrl: "/cosmos.base.reflection.v2alpha1.QueryServiceDescriptor",
   encode(message: QueryServiceDescriptor, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.fullname !== "") {
+    if (message.fullname !== undefined) {
       writer.uint32(10).string(message.fullname);
     }
-    if (message.isModule === true) {
+    if (message.isModule !== undefined) {
       writer.uint32(16).bool(message.isModule);
     }
     for (const v of message.methods) {
@@ -2937,10 +2937,10 @@ function createBaseQueryMethodDescriptor(): QueryMethodDescriptor {
 export const QueryMethodDescriptor = {
   typeUrl: "/cosmos.base.reflection.v2alpha1.QueryMethodDescriptor",
   encode(message: QueryMethodDescriptor, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.fullQueryPath !== "") {
+    if (message.fullQueryPath !== undefined) {
       writer.uint32(18).string(message.fullQueryPath);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/base/snapshots/v1beta1/snapshot.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/base/snapshots/v1beta1/snapshot.ts
@@ -152,13 +152,13 @@ function createBaseSnapshot(): Snapshot {
 export const Snapshot = {
   typeUrl: "/cosmos.base.snapshots.v1beta1.Snapshot",
   encode(message: Snapshot, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.height !== BigInt(0)) {
+    if (message.height !== undefined) {
       writer.uint32(8).uint64(message.height);
     }
-    if (message.format !== 0) {
+    if (message.format !== undefined) {
       writer.uint32(16).uint32(message.format);
     }
-    if (message.chunks !== 0) {
+    if (message.chunks !== undefined) {
       writer.uint32(24).uint32(message.chunks);
     }
     if (message.hash.length !== 0) {
@@ -587,7 +587,7 @@ function createBaseSnapshotStoreItem(): SnapshotStoreItem {
 export const SnapshotStoreItem = {
   typeUrl: "/cosmos.base.snapshots.v1beta1.SnapshotStoreItem",
   encode(message: SnapshotStoreItem, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     return writer;
@@ -688,10 +688,10 @@ export const SnapshotIAVLItem = {
     if (message.value.length !== 0) {
       writer.uint32(18).bytes(message.value);
     }
-    if (message.version !== BigInt(0)) {
+    if (message.version !== undefined) {
       writer.uint32(24).int64(message.version);
     }
-    if (message.height !== 0) {
+    if (message.height !== undefined) {
       writer.uint32(32).int32(message.height);
     }
     return writer;
@@ -819,10 +819,10 @@ function createBaseSnapshotExtensionMeta(): SnapshotExtensionMeta {
 export const SnapshotExtensionMeta = {
   typeUrl: "/cosmos.base.snapshots.v1beta1.SnapshotExtensionMeta",
   encode(message: SnapshotExtensionMeta, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.format !== 0) {
+    if (message.format !== undefined) {
       writer.uint32(16).uint32(message.format);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/base/store/v1beta1/commit_info.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/base/store/v1beta1/commit_info.ts
@@ -70,7 +70,7 @@ function createBaseCommitInfo(): CommitInfo {
 export const CommitInfo = {
   typeUrl: "/cosmos.base.store.v1beta1.CommitInfo",
   encode(message: CommitInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.version !== BigInt(0)) {
+    if (message.version !== undefined) {
       writer.uint32(8).int64(message.version);
     }
     for (const v of message.storeInfos) {
@@ -191,7 +191,7 @@ function createBaseStoreInfo(): StoreInfo {
 export const StoreInfo = {
   typeUrl: "/cosmos.base.store.v1beta1.StoreInfo",
   encode(message: StoreInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     if (message.commitId !== undefined) {
@@ -300,7 +300,7 @@ function createBaseCommitID(): CommitID {
 export const CommitID = {
   typeUrl: "/cosmos.base.store.v1beta1.CommitID",
   encode(message: CommitID, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.version !== BigInt(0)) {
+    if (message.version !== undefined) {
       writer.uint32(8).int64(message.version);
     }
     if (message.hash.length !== 0) {

--- a/__fixtures__/v-next/outputv4/cosmos/base/store/v1beta1/listening.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/base/store/v1beta1/listening.ts
@@ -44,10 +44,10 @@ function createBaseStoreKVPair(): StoreKVPair {
 export const StoreKVPair = {
   typeUrl: "/cosmos.base.store.v1beta1.StoreKVPair",
   encode(message: StoreKVPair, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.storeKey !== "") {
+    if (message.storeKey !== undefined) {
       writer.uint32(10).string(message.storeKey);
     }
-    if (message.delete === true) {
+    if (message.delete !== undefined) {
       writer.uint32(16).bool(message.delete);
     }
     if (message.key.length !== 0) {

--- a/__fixtures__/v-next/outputv4/cosmos/base/tendermint/v1beta1/query.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/base/tendermint/v1beta1/query.ts
@@ -231,7 +231,7 @@ function createBaseGetValidatorSetByHeightRequest(): GetValidatorSetByHeightRequ
 export const GetValidatorSetByHeightRequest = {
   typeUrl: "/cosmos.base.tendermint.v1beta1.GetValidatorSetByHeightRequest",
   encode(message: GetValidatorSetByHeightRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.height !== BigInt(0)) {
+    if (message.height !== undefined) {
       writer.uint32(8).int64(message.height);
     }
     if (message.pagination !== undefined) {
@@ -343,7 +343,7 @@ function createBaseGetValidatorSetByHeightResponse(): GetValidatorSetByHeightRes
 export const GetValidatorSetByHeightResponse = {
   typeUrl: "/cosmos.base.tendermint.v1beta1.GetValidatorSetByHeightResponse",
   encode(message: GetValidatorSetByHeightResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.blockHeight !== BigInt(0)) {
+    if (message.blockHeight !== undefined) {
       writer.uint32(8).int64(message.blockHeight);
     }
     for (const v of message.validators) {
@@ -575,7 +575,7 @@ function createBaseGetLatestValidatorSetResponse(): GetLatestValidatorSetRespons
 export const GetLatestValidatorSetResponse = {
   typeUrl: "/cosmos.base.tendermint.v1beta1.GetLatestValidatorSetResponse",
   encode(message: GetLatestValidatorSetResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.blockHeight !== BigInt(0)) {
+    if (message.blockHeight !== undefined) {
       writer.uint32(8).int64(message.blockHeight);
     }
     for (const v of message.validators) {
@@ -714,16 +714,16 @@ function createBaseValidator(): Validator {
 export const Validator = {
   typeUrl: "/cosmos.base.tendermint.v1beta1.Validator",
   encode(message: Validator, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     if (message.pubKey !== undefined) {
       Any.encode(message.pubKey, writer.uint32(18).fork()).ldelim();
     }
-    if (message.votingPower !== BigInt(0)) {
+    if (message.votingPower !== undefined) {
       writer.uint32(24).int64(message.votingPower);
     }
-    if (message.proposerPriority !== BigInt(0)) {
+    if (message.proposerPriority !== undefined) {
       writer.uint32(32).int64(message.proposerPriority);
     }
     return writer;
@@ -854,7 +854,7 @@ function createBaseGetBlockByHeightRequest(): GetBlockByHeightRequest {
 export const GetBlockByHeightRequest = {
   typeUrl: "/cosmos.base.tendermint.v1beta1.GetBlockByHeightRequest",
   encode(message: GetBlockByHeightRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.height !== BigInt(0)) {
+    if (message.height !== undefined) {
       writer.uint32(8).int64(message.height);
     }
     return writer;
@@ -1316,7 +1316,7 @@ function createBaseGetSyncingResponse(): GetSyncingResponse {
 export const GetSyncingResponse = {
   typeUrl: "/cosmos.base.tendermint.v1beta1.GetSyncingResponse",
   encode(message: GetSyncingResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.syncing === true) {
+    if (message.syncing !== undefined) {
       writer.uint32(8).bool(message.syncing);
     }
     return writer;
@@ -1599,28 +1599,28 @@ function createBaseVersionInfo(): VersionInfo {
 export const VersionInfo = {
   typeUrl: "/cosmos.base.tendermint.v1beta1.VersionInfo",
   encode(message: VersionInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.appName !== "") {
+    if (message.appName !== undefined) {
       writer.uint32(18).string(message.appName);
     }
-    if (message.version !== "") {
+    if (message.version !== undefined) {
       writer.uint32(26).string(message.version);
     }
-    if (message.gitCommit !== "") {
+    if (message.gitCommit !== undefined) {
       writer.uint32(34).string(message.gitCommit);
     }
-    if (message.buildTags !== "") {
+    if (message.buildTags !== undefined) {
       writer.uint32(42).string(message.buildTags);
     }
-    if (message.goVersion !== "") {
+    if (message.goVersion !== undefined) {
       writer.uint32(50).string(message.goVersion);
     }
     for (const v of message.buildDeps) {
       Module.encode(v!, writer.uint32(58).fork()).ldelim();
     }
-    if (message.cosmosSdkVersion !== "") {
+    if (message.cosmosSdkVersion !== undefined) {
       writer.uint32(66).string(message.cosmosSdkVersion);
     }
     return writer;
@@ -1803,13 +1803,13 @@ function createBaseModule(): Module {
 export const Module = {
   typeUrl: "/cosmos.base.tendermint.v1beta1.Module",
   encode(message: Module, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.path !== "") {
+    if (message.path !== undefined) {
       writer.uint32(10).string(message.path);
     }
-    if (message.version !== "") {
+    if (message.version !== undefined) {
       writer.uint32(18).string(message.version);
     }
-    if (message.sum !== "") {
+    if (message.sum !== undefined) {
       writer.uint32(26).string(message.sum);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/base/v1beta1/coin.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/base/v1beta1/coin.ts
@@ -82,10 +82,10 @@ function createBaseCoin(): Coin {
 export const Coin = {
   typeUrl: "/cosmos.base.v1beta1.Coin",
   encode(message: Coin, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(10).string(message.denom);
     }
-    if (message.amount !== "") {
+    if (message.amount !== undefined) {
       writer.uint32(18).string(message.amount);
     }
     return writer;
@@ -189,10 +189,10 @@ function createBaseDecCoin(): DecCoin {
 export const DecCoin = {
   typeUrl: "/cosmos.base.v1beta1.DecCoin",
   encode(message: DecCoin, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(10).string(message.denom);
     }
-    if (message.amount !== "") {
+    if (message.amount !== undefined) {
       writer.uint32(18).string(message.amount);
     }
     return writer;
@@ -295,7 +295,7 @@ function createBaseIntProto(): IntProto {
 export const IntProto = {
   typeUrl: "/cosmos.base.v1beta1.IntProto",
   encode(message: IntProto, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.int !== "") {
+    if (message.int !== undefined) {
       writer.uint32(10).string(message.int);
     }
     return writer;
@@ -387,7 +387,7 @@ function createBaseDecProto(): DecProto {
 export const DecProto = {
   typeUrl: "/cosmos.base.v1beta1.DecProto",
   encode(message: DecProto, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.dec !== "") {
+    if (message.dec !== undefined) {
       writer.uint32(10).string(message.dec);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/capability/v1beta1/capability.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/capability/v1beta1/capability.ts
@@ -65,7 +65,7 @@ function createBaseCapability(): Capability {
 export const Capability = {
   typeUrl: "/cosmos.capability.v1beta1.Capability",
   encode(message: Capability, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.index !== BigInt(0)) {
+    if (message.index !== undefined) {
       writer.uint32(8).uint64(message.index);
     }
     return writer;
@@ -160,10 +160,10 @@ function createBaseOwner(): Owner {
 export const Owner = {
   typeUrl: "/cosmos.capability.v1beta1.Owner",
   encode(message: Owner, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.module !== "") {
+    if (message.module !== undefined) {
       writer.uint32(10).string(message.module);
     }
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(18).string(message.name);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/capability/v1beta1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/capability/v1beta1/genesis.ts
@@ -46,7 +46,7 @@ function createBaseGenesisOwners(): GenesisOwners {
 export const GenesisOwners = {
   typeUrl: "/cosmos.capability.v1beta1.GenesisOwners",
   encode(message: GenesisOwners, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.index !== BigInt(0)) {
+    if (message.index !== undefined) {
       writer.uint32(8).uint64(message.index);
     }
     if (message.indexOwners !== undefined) {
@@ -157,7 +157,7 @@ function createBaseGenesisState(): GenesisState {
 export const GenesisState = {
   typeUrl: "/cosmos.capability.v1beta1.GenesisState",
   encode(message: GenesisState, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.index !== BigInt(0)) {
+    if (message.index !== undefined) {
       writer.uint32(8).uint64(message.index);
     }
     for (const v of message.owners) {

--- a/__fixtures__/v-next/outputv4/cosmos/crisis/v1beta1/tx.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/crisis/v1beta1/tx.ts
@@ -35,13 +35,13 @@ function createBaseMsgVerifyInvariant(): MsgVerifyInvariant {
 export const MsgVerifyInvariant = {
   typeUrl: "/cosmos.crisis.v1beta1.MsgVerifyInvariant",
   encode(message: MsgVerifyInvariant, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
-    if (message.invariantModuleName !== "") {
+    if (message.invariantModuleName !== undefined) {
       writer.uint32(18).string(message.invariantModuleName);
     }
-    if (message.invariantRoute !== "") {
+    if (message.invariantRoute !== undefined) {
       writer.uint32(26).string(message.invariantRoute);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/crypto/hd/v1/hd.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/crypto/hd/v1/hd.ts
@@ -41,19 +41,19 @@ function createBaseBIP44Params(): BIP44Params {
 export const BIP44Params = {
   typeUrl: "/cosmos.crypto.hd.v1.BIP44Params",
   encode(message: BIP44Params, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.purpose !== 0) {
+    if (message.purpose !== undefined) {
       writer.uint32(8).uint32(message.purpose);
     }
-    if (message.coinType !== 0) {
+    if (message.coinType !== undefined) {
       writer.uint32(16).uint32(message.coinType);
     }
-    if (message.account !== 0) {
+    if (message.account !== undefined) {
       writer.uint32(24).uint32(message.account);
     }
-    if (message.change === true) {
+    if (message.change !== undefined) {
       writer.uint32(32).bool(message.change);
     }
-    if (message.addressIndex !== 0) {
+    if (message.addressIndex !== undefined) {
       writer.uint32(40).uint32(message.addressIndex);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/crypto/keyring/v1/record.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/crypto/keyring/v1/record.ts
@@ -92,7 +92,7 @@ function createBaseRecord(): Record {
 export const Record = {
   typeUrl: "/cosmos.crypto.keyring.v1.Record",
   encode(message: Record, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     if (message.pubKey !== undefined) {
@@ -268,7 +268,7 @@ export const Record_Local = {
     if (message.privKey !== undefined) {
       Any.encode(message.privKey, writer.uint32(10).fork()).ldelim();
     }
-    if (message.privKeyType !== "") {
+    if (message.privKeyType !== undefined) {
       writer.uint32(18).string(message.privKeyType);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/crypto/multisig/keys.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/crypto/multisig/keys.ts
@@ -33,7 +33,7 @@ function createBaseLegacyAminoPubKey(): LegacyAminoPubKey {
 export const LegacyAminoPubKey = {
   typeUrl: "/cosmos.crypto.multisig.LegacyAminoPubKey",
   encode(message: LegacyAminoPubKey, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.threshold !== 0) {
+    if (message.threshold !== undefined) {
       writer.uint32(8).uint32(message.threshold);
     }
     for (const v of message.publicKeys) {

--- a/__fixtures__/v-next/outputv4/cosmos/crypto/multisig/v1beta1/multisig.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/crypto/multisig/v1beta1/multisig.ts
@@ -158,7 +158,7 @@ function createBaseCompactBitArray(): CompactBitArray {
 export const CompactBitArray = {
   typeUrl: "/cosmos.crypto.multisig.v1beta1.CompactBitArray",
   encode(message: CompactBitArray, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.extraBitsStored !== 0) {
+    if (message.extraBitsStored !== undefined) {
       writer.uint32(8).uint32(message.extraBitsStored);
     }
     if (message.elems.length !== 0) {

--- a/__fixtures__/v-next/outputv4/cosmos/distribution/v1beta1/distribution.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/distribution/v1beta1/distribution.ts
@@ -280,16 +280,16 @@ function createBaseParams(): Params {
 export const Params = {
   typeUrl: "/cosmos.distribution.v1beta1.Params",
   encode(message: Params, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.communityTax !== "") {
+    if (message.communityTax !== undefined) {
       writer.uint32(10).string(Decimal.fromUserInput(message.communityTax, 18).atomics);
     }
-    if (message.baseProposerReward !== "") {
+    if (message.baseProposerReward !== undefined) {
       writer.uint32(18).string(Decimal.fromUserInput(message.baseProposerReward, 18).atomics);
     }
-    if (message.bonusProposerReward !== "") {
+    if (message.bonusProposerReward !== undefined) {
       writer.uint32(26).string(Decimal.fromUserInput(message.bonusProposerReward, 18).atomics);
     }
-    if (message.withdrawAddrEnabled === true) {
+    if (message.withdrawAddrEnabled !== undefined) {
       writer.uint32(32).bool(message.withdrawAddrEnabled);
     }
     return writer;
@@ -418,7 +418,7 @@ export const ValidatorHistoricalRewards = {
     for (const v of message.cumulativeRewardRatio) {
       DecCoin.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.referenceCount !== 0) {
+    if (message.referenceCount !== undefined) {
       writer.uint32(16).uint32(message.referenceCount);
     }
     return writer;
@@ -537,7 +537,7 @@ export const ValidatorCurrentRewards = {
     for (const v of message.rewards) {
       DecCoin.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.period !== BigInt(0)) {
+    if (message.period !== undefined) {
       writer.uint32(16).uint64(message.period);
     }
     return writer;
@@ -863,10 +863,10 @@ function createBaseValidatorSlashEvent(): ValidatorSlashEvent {
 export const ValidatorSlashEvent = {
   typeUrl: "/cosmos.distribution.v1beta1.ValidatorSlashEvent",
   encode(message: ValidatorSlashEvent, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.validatorPeriod !== BigInt(0)) {
+    if (message.validatorPeriod !== undefined) {
       writer.uint32(8).uint64(message.validatorPeriod);
     }
-    if (message.fraction !== "") {
+    if (message.fraction !== undefined) {
       writer.uint32(18).string(Decimal.fromUserInput(message.fraction, 18).atomics);
     }
     return writer;
@@ -1182,13 +1182,13 @@ function createBaseCommunityPoolSpendProposal(): CommunityPoolSpendProposal {
 export const CommunityPoolSpendProposal = {
   typeUrl: "/cosmos.distribution.v1beta1.CommunityPoolSpendProposal",
   encode(message: CommunityPoolSpendProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
-    if (message.recipient !== "") {
+    if (message.recipient !== undefined) {
       writer.uint32(26).string(message.recipient);
     }
     for (const v of message.amount) {
@@ -1330,13 +1330,13 @@ function createBaseDelegatorStartingInfo(): DelegatorStartingInfo {
 export const DelegatorStartingInfo = {
   typeUrl: "/cosmos.distribution.v1beta1.DelegatorStartingInfo",
   encode(message: DelegatorStartingInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.previousPeriod !== BigInt(0)) {
+    if (message.previousPeriod !== undefined) {
       writer.uint32(8).uint64(message.previousPeriod);
     }
-    if (message.stake !== "") {
+    if (message.stake !== undefined) {
       writer.uint32(18).string(Decimal.fromUserInput(message.stake, 18).atomics);
     }
-    if (message.height !== BigInt(0)) {
+    if (message.height !== undefined) {
       writer.uint32(24).uint64(message.height);
     }
     return writer;
@@ -1455,7 +1455,7 @@ function createBaseDelegationDelegatorReward(): DelegationDelegatorReward {
 export const DelegationDelegatorReward = {
   typeUrl: "/cosmos.distribution.v1beta1.DelegationDelegatorReward",
   encode(message: DelegationDelegatorReward, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.validatorAddress !== "") {
+    if (message.validatorAddress !== undefined) {
       writer.uint32(10).string(message.validatorAddress);
     }
     for (const v of message.reward) {
@@ -1577,19 +1577,19 @@ function createBaseCommunityPoolSpendProposalWithDeposit(): CommunityPoolSpendPr
 export const CommunityPoolSpendProposalWithDeposit = {
   typeUrl: "/cosmos.distribution.v1beta1.CommunityPoolSpendProposalWithDeposit",
   encode(message: CommunityPoolSpendProposalWithDeposit, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
-    if (message.recipient !== "") {
+    if (message.recipient !== undefined) {
       writer.uint32(26).string(message.recipient);
     }
-    if (message.amount !== "") {
+    if (message.amount !== undefined) {
       writer.uint32(34).string(message.amount);
     }
-    if (message.deposit !== "") {
+    if (message.deposit !== undefined) {
       writer.uint32(42).string(message.deposit);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/distribution/v1beta1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/distribution/v1beta1/genesis.ts
@@ -196,10 +196,10 @@ function createBaseDelegatorWithdrawInfo(): DelegatorWithdrawInfo {
 export const DelegatorWithdrawInfo = {
   typeUrl: "/cosmos.distribution.v1beta1.DelegatorWithdrawInfo",
   encode(message: DelegatorWithdrawInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddress !== "") {
+    if (message.delegatorAddress !== undefined) {
       writer.uint32(10).string(message.delegatorAddress);
     }
-    if (message.withdrawAddress !== "") {
+    if (message.withdrawAddress !== undefined) {
       writer.uint32(18).string(message.withdrawAddress);
     }
     return writer;
@@ -303,7 +303,7 @@ function createBaseValidatorOutstandingRewardsRecord(): ValidatorOutstandingRewa
 export const ValidatorOutstandingRewardsRecord = {
   typeUrl: "/cosmos.distribution.v1beta1.ValidatorOutstandingRewardsRecord",
   encode(message: ValidatorOutstandingRewardsRecord, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.validatorAddress !== "") {
+    if (message.validatorAddress !== undefined) {
       writer.uint32(10).string(message.validatorAddress);
     }
     for (const v of message.outstandingRewards) {
@@ -422,7 +422,7 @@ function createBaseValidatorAccumulatedCommissionRecord(): ValidatorAccumulatedC
 export const ValidatorAccumulatedCommissionRecord = {
   typeUrl: "/cosmos.distribution.v1beta1.ValidatorAccumulatedCommissionRecord",
   encode(message: ValidatorAccumulatedCommissionRecord, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.validatorAddress !== "") {
+    if (message.validatorAddress !== undefined) {
       writer.uint32(10).string(message.validatorAddress);
     }
     if (message.accumulated !== undefined) {
@@ -532,10 +532,10 @@ function createBaseValidatorHistoricalRewardsRecord(): ValidatorHistoricalReward
 export const ValidatorHistoricalRewardsRecord = {
   typeUrl: "/cosmos.distribution.v1beta1.ValidatorHistoricalRewardsRecord",
   encode(message: ValidatorHistoricalRewardsRecord, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.validatorAddress !== "") {
+    if (message.validatorAddress !== undefined) {
       writer.uint32(10).string(message.validatorAddress);
     }
-    if (message.period !== BigInt(0)) {
+    if (message.period !== undefined) {
       writer.uint32(16).uint64(message.period);
     }
     if (message.rewards !== undefined) {
@@ -657,7 +657,7 @@ function createBaseValidatorCurrentRewardsRecord(): ValidatorCurrentRewardsRecor
 export const ValidatorCurrentRewardsRecord = {
   typeUrl: "/cosmos.distribution.v1beta1.ValidatorCurrentRewardsRecord",
   encode(message: ValidatorCurrentRewardsRecord, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.validatorAddress !== "") {
+    if (message.validatorAddress !== undefined) {
       writer.uint32(10).string(message.validatorAddress);
     }
     if (message.rewards !== undefined) {
@@ -767,10 +767,10 @@ function createBaseDelegatorStartingInfoRecord(): DelegatorStartingInfoRecord {
 export const DelegatorStartingInfoRecord = {
   typeUrl: "/cosmos.distribution.v1beta1.DelegatorStartingInfoRecord",
   encode(message: DelegatorStartingInfoRecord, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddress !== "") {
+    if (message.delegatorAddress !== undefined) {
       writer.uint32(10).string(message.delegatorAddress);
     }
-    if (message.validatorAddress !== "") {
+    if (message.validatorAddress !== undefined) {
       writer.uint32(18).string(message.validatorAddress);
     }
     if (message.startingInfo !== undefined) {
@@ -892,13 +892,13 @@ function createBaseValidatorSlashEventRecord(): ValidatorSlashEventRecord {
 export const ValidatorSlashEventRecord = {
   typeUrl: "/cosmos.distribution.v1beta1.ValidatorSlashEventRecord",
   encode(message: ValidatorSlashEventRecord, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.validatorAddress !== "") {
+    if (message.validatorAddress !== undefined) {
       writer.uint32(10).string(message.validatorAddress);
     }
-    if (message.height !== BigInt(0)) {
+    if (message.height !== undefined) {
       writer.uint32(16).uint64(message.height);
     }
-    if (message.period !== BigInt(0)) {
+    if (message.period !== undefined) {
       writer.uint32(24).uint64(message.period);
     }
     if (message.validatorSlashEvent !== undefined) {
@@ -1050,7 +1050,7 @@ export const GenesisState = {
     for (const v of message.delegatorWithdrawInfos) {
       DelegatorWithdrawInfo.encode(v!, writer.uint32(26).fork()).ldelim();
     }
-    if (message.previousProposer !== "") {
+    if (message.previousProposer !== undefined) {
       writer.uint32(34).string(message.previousProposer);
     }
     for (const v of message.outstandingRewards) {

--- a/__fixtures__/v-next/outputv4/cosmos/distribution/v1beta1/query.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/distribution/v1beta1/query.ts
@@ -516,7 +516,7 @@ function createBaseQueryValidatorOutstandingRewardsRequest(): QueryValidatorOuts
 export const QueryValidatorOutstandingRewardsRequest = {
   typeUrl: "/cosmos.distribution.v1beta1.QueryValidatorOutstandingRewardsRequest",
   encode(message: QueryValidatorOutstandingRewardsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.validatorAddress !== "") {
+    if (message.validatorAddress !== undefined) {
       writer.uint32(10).string(message.validatorAddress);
     }
     return writer;
@@ -702,7 +702,7 @@ function createBaseQueryValidatorCommissionRequest(): QueryValidatorCommissionRe
 export const QueryValidatorCommissionRequest = {
   typeUrl: "/cosmos.distribution.v1beta1.QueryValidatorCommissionRequest",
   encode(message: QueryValidatorCommissionRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.validatorAddress !== "") {
+    if (message.validatorAddress !== undefined) {
       writer.uint32(10).string(message.validatorAddress);
     }
     return writer;
@@ -891,13 +891,13 @@ function createBaseQueryValidatorSlashesRequest(): QueryValidatorSlashesRequest 
 export const QueryValidatorSlashesRequest = {
   typeUrl: "/cosmos.distribution.v1beta1.QueryValidatorSlashesRequest",
   encode(message: QueryValidatorSlashesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.validatorAddress !== "") {
+    if (message.validatorAddress !== undefined) {
       writer.uint32(10).string(message.validatorAddress);
     }
-    if (message.startingHeight !== BigInt(0)) {
+    if (message.startingHeight !== undefined) {
       writer.uint32(16).uint64(message.startingHeight);
     }
-    if (message.endingHeight !== BigInt(0)) {
+    if (message.endingHeight !== undefined) {
       writer.uint32(24).uint64(message.endingHeight);
     }
     if (message.pagination !== undefined) {
@@ -1153,10 +1153,10 @@ function createBaseQueryDelegationRewardsRequest(): QueryDelegationRewardsReques
 export const QueryDelegationRewardsRequest = {
   typeUrl: "/cosmos.distribution.v1beta1.QueryDelegationRewardsRequest",
   encode(message: QueryDelegationRewardsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddress !== "") {
+    if (message.delegatorAddress !== undefined) {
       writer.uint32(10).string(message.delegatorAddress);
     }
-    if (message.validatorAddress !== "") {
+    if (message.validatorAddress !== undefined) {
       writer.uint32(18).string(message.validatorAddress);
     }
     return writer;
@@ -1363,7 +1363,7 @@ function createBaseQueryDelegationTotalRewardsRequest(): QueryDelegationTotalRew
 export const QueryDelegationTotalRewardsRequest = {
   typeUrl: "/cosmos.distribution.v1beta1.QueryDelegationTotalRewardsRequest",
   encode(message: QueryDelegationTotalRewardsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddress !== "") {
+    if (message.delegatorAddress !== undefined) {
       writer.uint32(10).string(message.delegatorAddress);
     }
     return writer;
@@ -1586,7 +1586,7 @@ function createBaseQueryDelegatorValidatorsRequest(): QueryDelegatorValidatorsRe
 export const QueryDelegatorValidatorsRequest = {
   typeUrl: "/cosmos.distribution.v1beta1.QueryDelegatorValidatorsRequest",
   encode(message: QueryDelegatorValidatorsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddress !== "") {
+    if (message.delegatorAddress !== undefined) {
       writer.uint32(10).string(message.delegatorAddress);
     }
     return writer;
@@ -1782,7 +1782,7 @@ function createBaseQueryDelegatorWithdrawAddressRequest(): QueryDelegatorWithdra
 export const QueryDelegatorWithdrawAddressRequest = {
   typeUrl: "/cosmos.distribution.v1beta1.QueryDelegatorWithdrawAddressRequest",
   encode(message: QueryDelegatorWithdrawAddressRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddress !== "") {
+    if (message.delegatorAddress !== undefined) {
       writer.uint32(10).string(message.delegatorAddress);
     }
     return writer;
@@ -1874,7 +1874,7 @@ function createBaseQueryDelegatorWithdrawAddressResponse(): QueryDelegatorWithdr
 export const QueryDelegatorWithdrawAddressResponse = {
   typeUrl: "/cosmos.distribution.v1beta1.QueryDelegatorWithdrawAddressResponse",
   encode(message: QueryDelegatorWithdrawAddressResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.withdrawAddress !== "") {
+    if (message.withdrawAddress !== undefined) {
       writer.uint32(10).string(message.withdrawAddress);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/distribution/v1beta1/tx.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/distribution/v1beta1/tx.ts
@@ -129,10 +129,10 @@ function createBaseMsgSetWithdrawAddress(): MsgSetWithdrawAddress {
 export const MsgSetWithdrawAddress = {
   typeUrl: "/cosmos.distribution.v1beta1.MsgSetWithdrawAddress",
   encode(message: MsgSetWithdrawAddress, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddress !== "") {
+    if (message.delegatorAddress !== undefined) {
       writer.uint32(10).string(message.delegatorAddress);
     }
-    if (message.withdrawAddress !== "") {
+    if (message.withdrawAddress !== undefined) {
       writer.uint32(18).string(message.withdrawAddress);
     }
     return writer;
@@ -309,10 +309,10 @@ function createBaseMsgWithdrawDelegatorReward(): MsgWithdrawDelegatorReward {
 export const MsgWithdrawDelegatorReward = {
   typeUrl: "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward",
   encode(message: MsgWithdrawDelegatorReward, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddress !== "") {
+    if (message.delegatorAddress !== undefined) {
       writer.uint32(10).string(message.delegatorAddress);
     }
-    if (message.validatorAddress !== "") {
+    if (message.validatorAddress !== undefined) {
       writer.uint32(18).string(message.validatorAddress);
     }
     return writer;
@@ -519,7 +519,7 @@ function createBaseMsgWithdrawValidatorCommission(): MsgWithdrawValidatorCommiss
 export const MsgWithdrawValidatorCommission = {
   typeUrl: "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission",
   encode(message: MsgWithdrawValidatorCommission, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.validatorAddress !== "") {
+    if (message.validatorAddress !== undefined) {
       writer.uint32(10).string(message.validatorAddress);
     }
     return writer;
@@ -719,7 +719,7 @@ export const MsgFundCommunityPool = {
     for (const v of message.amount) {
       Coin.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.depositor !== "") {
+    if (message.depositor !== undefined) {
       writer.uint32(18).string(message.depositor);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/evidence/v1beta1/evidence.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/evidence/v1beta1/evidence.ts
@@ -37,16 +37,16 @@ function createBaseEquivocation(): Equivocation {
 export const Equivocation = {
   typeUrl: "/cosmos.evidence.v1beta1.Equivocation",
   encode(message: Equivocation, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.height !== BigInt(0)) {
+    if (message.height !== undefined) {
       writer.uint32(8).int64(message.height);
     }
     if (message.time !== undefined) {
       Timestamp.encode(toTimestamp(message.time), writer.uint32(18).fork()).ldelim();
     }
-    if (message.power !== BigInt(0)) {
+    if (message.power !== undefined) {
       writer.uint32(24).int64(message.power);
     }
-    if (message.consensusAddress !== "") {
+    if (message.consensusAddress !== undefined) {
       writer.uint32(34).string(message.consensusAddress);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/evidence/v1beta1/tx.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/evidence/v1beta1/tx.ts
@@ -44,7 +44,7 @@ function createBaseMsgSubmitEvidence(): MsgSubmitEvidence {
 export const MsgSubmitEvidence = {
   typeUrl: "/cosmos.evidence.v1beta1.MsgSubmitEvidence",
   encode(message: MsgSubmitEvidence, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.submitter !== "") {
+    if (message.submitter !== undefined) {
       writer.uint32(10).string(message.submitter);
     }
     if (message.evidence !== undefined) {

--- a/__fixtures__/v-next/outputv4/cosmos/feegrant/v1beta1/feegrant.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/feegrant/v1beta1/feegrant.ts
@@ -537,10 +537,10 @@ function createBaseGrant(): Grant {
 export const Grant = {
   typeUrl: "/cosmos.feegrant.v1beta1.Grant",
   encode(message: Grant, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.granter !== "") {
+    if (message.granter !== undefined) {
       writer.uint32(10).string(message.granter);
     }
-    if (message.grantee !== "") {
+    if (message.grantee !== undefined) {
       writer.uint32(18).string(message.grantee);
     }
     if (message.allowance !== undefined) {

--- a/__fixtures__/v-next/outputv4/cosmos/feegrant/v1beta1/query.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/feegrant/v1beta1/query.ts
@@ -103,10 +103,10 @@ function createBaseQueryAllowanceRequest(): QueryAllowanceRequest {
 export const QueryAllowanceRequest = {
   typeUrl: "/cosmos.feegrant.v1beta1.QueryAllowanceRequest",
   encode(message: QueryAllowanceRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.granter !== "") {
+    if (message.granter !== undefined) {
       writer.uint32(10).string(message.granter);
     }
-    if (message.grantee !== "") {
+    if (message.grantee !== undefined) {
       writer.uint32(18).string(message.grantee);
     }
     return writer;
@@ -304,7 +304,7 @@ function createBaseQueryAllowancesRequest(): QueryAllowancesRequest {
 export const QueryAllowancesRequest = {
   typeUrl: "/cosmos.feegrant.v1beta1.QueryAllowancesRequest",
   encode(message: QueryAllowancesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.grantee !== "") {
+    if (message.grantee !== undefined) {
       writer.uint32(10).string(message.grantee);
     }
     if (message.pagination !== undefined) {
@@ -534,7 +534,7 @@ function createBaseQueryAllowancesByGranterRequest(): QueryAllowancesByGranterRe
 export const QueryAllowancesByGranterRequest = {
   typeUrl: "/cosmos.feegrant.v1beta1.QueryAllowancesByGranterRequest",
   encode(message: QueryAllowancesByGranterRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.granter !== "") {
+    if (message.granter !== undefined) {
       writer.uint32(10).string(message.granter);
     }
     if (message.pagination !== undefined) {

--- a/__fixtures__/v-next/outputv4/cosmos/feegrant/v1beta1/tx.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/feegrant/v1beta1/tx.ts
@@ -69,10 +69,10 @@ function createBaseMsgGrantAllowance(): MsgGrantAllowance {
 export const MsgGrantAllowance = {
   typeUrl: "/cosmos.feegrant.v1beta1.MsgGrantAllowance",
   encode(message: MsgGrantAllowance, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.granter !== "") {
+    if (message.granter !== undefined) {
       writer.uint32(10).string(message.granter);
     }
-    if (message.grantee !== "") {
+    if (message.grantee !== undefined) {
       writer.uint32(18).string(message.grantee);
     }
     if (message.allowance !== undefined) {
@@ -265,10 +265,10 @@ function createBaseMsgRevokeAllowance(): MsgRevokeAllowance {
 export const MsgRevokeAllowance = {
   typeUrl: "/cosmos.feegrant.v1beta1.MsgRevokeAllowance",
   encode(message: MsgRevokeAllowance, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.granter !== "") {
+    if (message.granter !== undefined) {
       writer.uint32(10).string(message.granter);
     }
-    if (message.grantee !== "") {
+    if (message.grantee !== undefined) {
       writer.uint32(18).string(message.grantee);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/gov/v1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/gov/v1/genesis.ts
@@ -47,7 +47,7 @@ function createBaseGenesisState(): GenesisState {
 export const GenesisState = {
   typeUrl: "/cosmos.gov.v1.GenesisState",
   encode(message: GenesisState, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.startingProposalId !== BigInt(0)) {
+    if (message.startingProposalId !== undefined) {
       writer.uint32(8).uint64(message.startingProposalId);
     }
     for (const v of message.deposits) {

--- a/__fixtures__/v-next/outputv4/cosmos/gov/v1/gov.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/gov/v1/gov.ts
@@ -321,7 +321,7 @@ export const WeightedVoteOption = {
     if (message.option !== 0) {
       writer.uint32(8).int32(message.option);
     }
-    if (message.weight !== "") {
+    if (message.weight !== undefined) {
       writer.uint32(18).string(message.weight);
     }
     return writer;
@@ -426,10 +426,10 @@ function createBaseDeposit(): Deposit {
 export const Deposit = {
   typeUrl: "/cosmos.gov.v1.Deposit",
   encode(message: Deposit, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
-    if (message.depositor !== "") {
+    if (message.depositor !== undefined) {
       writer.uint32(18).string(message.depositor);
     }
     for (const v of message.amount) {
@@ -569,7 +569,7 @@ function createBaseProposal(): Proposal {
 export const Proposal = {
   typeUrl: "/cosmos.gov.v1.Proposal",
   encode(message: Proposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.id !== BigInt(0)) {
+    if (message.id !== undefined) {
       writer.uint32(8).uint64(message.id);
     }
     for (const v of message.messages) {
@@ -596,7 +596,7 @@ export const Proposal = {
     if (message.votingEndTime !== undefined) {
       Timestamp.encode(toTimestamp(message.votingEndTime), writer.uint32(74).fork()).ldelim();
     }
-    if (message.metadata !== "") {
+    if (message.metadata !== undefined) {
       writer.uint32(82).string(message.metadata);
     }
     return writer;
@@ -818,16 +818,16 @@ function createBaseTallyResult(): TallyResult {
 export const TallyResult = {
   typeUrl: "/cosmos.gov.v1.TallyResult",
   encode(message: TallyResult, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.yesCount !== "") {
+    if (message.yesCount !== undefined) {
       writer.uint32(10).string(message.yesCount);
     }
-    if (message.abstainCount !== "") {
+    if (message.abstainCount !== undefined) {
       writer.uint32(18).string(message.abstainCount);
     }
-    if (message.noCount !== "") {
+    if (message.noCount !== undefined) {
       writer.uint32(26).string(message.noCount);
     }
-    if (message.noWithVetoCount !== "") {
+    if (message.noWithVetoCount !== undefined) {
       writer.uint32(34).string(message.noWithVetoCount);
     }
     return writer;
@@ -955,16 +955,16 @@ function createBaseVote(): Vote {
 export const Vote = {
   typeUrl: "/cosmos.gov.v1.Vote",
   encode(message: Vote, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
-    if (message.voter !== "") {
+    if (message.voter !== undefined) {
       writer.uint32(18).string(message.voter);
     }
     for (const v of message.options) {
       WeightedVoteOption.encode(v!, writer.uint32(34).fork()).ldelim();
     }
-    if (message.metadata !== "") {
+    if (message.metadata !== undefined) {
       writer.uint32(42).string(message.metadata);
     }
     return writer;
@@ -1320,13 +1320,13 @@ function createBaseTallyParams(): TallyParams {
 export const TallyParams = {
   typeUrl: "/cosmos.gov.v1.TallyParams",
   encode(message: TallyParams, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.quorum !== "") {
+    if (message.quorum !== undefined) {
       writer.uint32(10).string(message.quorum);
     }
-    if (message.threshold !== "") {
+    if (message.threshold !== undefined) {
       writer.uint32(18).string(message.threshold);
     }
-    if (message.vetoThreshold !== "") {
+    if (message.vetoThreshold !== undefined) {
       writer.uint32(26).string(message.vetoThreshold);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/gov/v1/query.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/gov/v1/query.ts
@@ -261,7 +261,7 @@ function createBaseQueryProposalRequest(): QueryProposalRequest {
 export const QueryProposalRequest = {
   typeUrl: "/cosmos.gov.v1.QueryProposalRequest",
   encode(message: QueryProposalRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
     return writer;
@@ -455,10 +455,10 @@ export const QueryProposalsRequest = {
     if (message.proposalStatus !== 0) {
       writer.uint32(8).int32(message.proposalStatus);
     }
-    if (message.voter !== "") {
+    if (message.voter !== undefined) {
       writer.uint32(18).string(message.voter);
     }
-    if (message.depositor !== "") {
+    if (message.depositor !== undefined) {
       writer.uint32(26).string(message.depositor);
     }
     if (message.pagination !== undefined) {
@@ -710,10 +710,10 @@ function createBaseQueryVoteRequest(): QueryVoteRequest {
 export const QueryVoteRequest = {
   typeUrl: "/cosmos.gov.v1.QueryVoteRequest",
   encode(message: QueryVoteRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
-    if (message.voter !== "") {
+    if (message.voter !== undefined) {
       writer.uint32(18).string(message.voter);
     }
     return writer;
@@ -913,7 +913,7 @@ function createBaseQueryVotesRequest(): QueryVotesRequest {
 export const QueryVotesRequest = {
   typeUrl: "/cosmos.gov.v1.QueryVotesRequest",
   encode(message: QueryVotesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
     if (message.pagination !== undefined) {
@@ -1144,7 +1144,7 @@ function createBaseQueryParamsRequest(): QueryParamsRequest {
 export const QueryParamsRequest = {
   typeUrl: "/cosmos.gov.v1.QueryParamsRequest",
   encode(message: QueryParamsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.paramsType !== "") {
+    if (message.paramsType !== undefined) {
       writer.uint32(10).string(message.paramsType);
     }
     return writer;
@@ -1365,10 +1365,10 @@ function createBaseQueryDepositRequest(): QueryDepositRequest {
 export const QueryDepositRequest = {
   typeUrl: "/cosmos.gov.v1.QueryDepositRequest",
   encode(message: QueryDepositRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
-    if (message.depositor !== "") {
+    if (message.depositor !== undefined) {
       writer.uint32(18).string(message.depositor);
     }
     return writer;
@@ -1568,7 +1568,7 @@ function createBaseQueryDepositsRequest(): QueryDepositsRequest {
 export const QueryDepositsRequest = {
   typeUrl: "/cosmos.gov.v1.QueryDepositsRequest",
   encode(message: QueryDepositsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
     if (message.pagination !== undefined) {
@@ -1799,7 +1799,7 @@ function createBaseQueryTallyResultRequest(): QueryTallyResultRequest {
 export const QueryTallyResultRequest = {
   typeUrl: "/cosmos.gov.v1.QueryTallyResultRequest",
   encode(message: QueryTallyResultRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/gov/v1/tx.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/gov/v1/tx.ts
@@ -164,10 +164,10 @@ export const MsgSubmitProposal = {
     for (const v of message.initialDeposit) {
       Coin.encode(v!, writer.uint32(18).fork()).ldelim();
     }
-    if (message.proposer !== "") {
+    if (message.proposer !== undefined) {
       writer.uint32(26).string(message.proposer);
     }
-    if (message.metadata !== "") {
+    if (message.metadata !== undefined) {
       writer.uint32(34).string(message.metadata);
     }
     return writer;
@@ -316,7 +316,7 @@ function createBaseMsgSubmitProposalResponse(): MsgSubmitProposalResponse {
 export const MsgSubmitProposalResponse = {
   typeUrl: "/cosmos.gov.v1.MsgSubmitProposalResponse",
   encode(message: MsgSubmitProposalResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
     return writer;
@@ -414,7 +414,7 @@ export const MsgExecLegacyContent = {
     if (message.content !== undefined) {
       Any.encode(message.content, writer.uint32(10).fork()).ldelim();
     }
-    if (message.authority !== "") {
+    if (message.authority !== undefined) {
       writer.uint32(18).string(message.authority);
     }
     return writer;
@@ -595,16 +595,16 @@ function createBaseMsgVote(): MsgVote {
 export const MsgVote = {
   typeUrl: "/cosmos.gov.v1.MsgVote",
   encode(message: MsgVote, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
-    if (message.voter !== "") {
+    if (message.voter !== undefined) {
       writer.uint32(18).string(message.voter);
     }
     if (message.option !== 0) {
       writer.uint32(24).int32(message.option);
     }
-    if (message.metadata !== "") {
+    if (message.metadata !== undefined) {
       writer.uint32(34).string(message.metadata);
     }
     return writer;
@@ -807,16 +807,16 @@ function createBaseMsgVoteWeighted(): MsgVoteWeighted {
 export const MsgVoteWeighted = {
   typeUrl: "/cosmos.gov.v1.MsgVoteWeighted",
   encode(message: MsgVoteWeighted, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
-    if (message.voter !== "") {
+    if (message.voter !== undefined) {
       writer.uint32(18).string(message.voter);
     }
     for (const v of message.options) {
       WeightedVoteOption.encode(v!, writer.uint32(26).fork()).ldelim();
     }
-    if (message.metadata !== "") {
+    if (message.metadata !== undefined) {
       writer.uint32(34).string(message.metadata);
     }
     return writer;
@@ -1030,10 +1030,10 @@ function createBaseMsgDeposit(): MsgDeposit {
 export const MsgDeposit = {
   typeUrl: "/cosmos.gov.v1.MsgDeposit",
   encode(message: MsgDeposit, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
-    if (message.depositor !== "") {
+    if (message.depositor !== undefined) {
       writer.uint32(18).string(message.depositor);
     }
     for (const v of message.amount) {

--- a/__fixtures__/v-next/outputv4/cosmos/gov/v1beta1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/gov/v1beta1/genesis.ts
@@ -47,7 +47,7 @@ function createBaseGenesisState(): GenesisState {
 export const GenesisState = {
   typeUrl: "/cosmos.gov.v1beta1.GenesisState",
   encode(message: GenesisState, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.startingProposalId !== BigInt(0)) {
+    if (message.startingProposalId !== undefined) {
       writer.uint32(8).uint64(message.startingProposalId);
     }
     for (const v of message.deposits) {

--- a/__fixtures__/v-next/outputv4/cosmos/gov/v1beta1/gov.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/gov/v1beta1/gov.ts
@@ -354,7 +354,7 @@ export const WeightedVoteOption = {
     if (message.option !== 0) {
       writer.uint32(8).int32(message.option);
     }
-    if (message.weight !== "") {
+    if (message.weight !== undefined) {
       writer.uint32(18).string(Decimal.fromUserInput(message.weight, 18).atomics);
     }
     return writer;
@@ -458,10 +458,10 @@ function createBaseTextProposal(): TextProposal {
 export const TextProposal = {
   typeUrl: "/cosmos.gov.v1beta1.TextProposal",
   encode(message: TextProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
     return writer;
@@ -566,10 +566,10 @@ function createBaseDeposit(): Deposit {
 export const Deposit = {
   typeUrl: "/cosmos.gov.v1beta1.Deposit",
   encode(message: Deposit, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
-    if (message.depositor !== "") {
+    if (message.depositor !== undefined) {
       writer.uint32(18).string(message.depositor);
     }
     for (const v of message.amount) {
@@ -708,7 +708,7 @@ function createBaseProposal(): Proposal {
 export const Proposal = {
   typeUrl: "/cosmos.gov.v1beta1.Proposal",
   encode(message: Proposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
     if (message.content !== undefined) {
@@ -933,16 +933,16 @@ function createBaseTallyResult(): TallyResult {
 export const TallyResult = {
   typeUrl: "/cosmos.gov.v1beta1.TallyResult",
   encode(message: TallyResult, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.yes !== "") {
+    if (message.yes !== undefined) {
       writer.uint32(10).string(message.yes);
     }
-    if (message.abstain !== "") {
+    if (message.abstain !== undefined) {
       writer.uint32(18).string(message.abstain);
     }
-    if (message.no !== "") {
+    if (message.no !== undefined) {
       writer.uint32(26).string(message.no);
     }
-    if (message.noWithVeto !== "") {
+    if (message.noWithVeto !== undefined) {
       writer.uint32(34).string(message.noWithVeto);
     }
     return writer;
@@ -1070,10 +1070,10 @@ function createBaseVote(): Vote {
 export const Vote = {
   typeUrl: "/cosmos.gov.v1beta1.Vote",
   encode(message: Vote, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
-    if (message.voter !== "") {
+    if (message.voter !== undefined) {
       writer.uint32(18).string(message.voter);
     }
     if (message.option !== 0) {

--- a/__fixtures__/v-next/outputv4/cosmos/gov/v1beta1/query.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/gov/v1beta1/query.ts
@@ -261,7 +261,7 @@ function createBaseQueryProposalRequest(): QueryProposalRequest {
 export const QueryProposalRequest = {
   typeUrl: "/cosmos.gov.v1beta1.QueryProposalRequest",
   encode(message: QueryProposalRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
     return writer;
@@ -455,10 +455,10 @@ export const QueryProposalsRequest = {
     if (message.proposalStatus !== 0) {
       writer.uint32(8).int32(message.proposalStatus);
     }
-    if (message.voter !== "") {
+    if (message.voter !== undefined) {
       writer.uint32(18).string(message.voter);
     }
-    if (message.depositor !== "") {
+    if (message.depositor !== undefined) {
       writer.uint32(26).string(message.depositor);
     }
     if (message.pagination !== undefined) {
@@ -710,10 +710,10 @@ function createBaseQueryVoteRequest(): QueryVoteRequest {
 export const QueryVoteRequest = {
   typeUrl: "/cosmos.gov.v1beta1.QueryVoteRequest",
   encode(message: QueryVoteRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
-    if (message.voter !== "") {
+    if (message.voter !== undefined) {
       writer.uint32(18).string(message.voter);
     }
     return writer;
@@ -913,7 +913,7 @@ function createBaseQueryVotesRequest(): QueryVotesRequest {
 export const QueryVotesRequest = {
   typeUrl: "/cosmos.gov.v1beta1.QueryVotesRequest",
   encode(message: QueryVotesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
     if (message.pagination !== undefined) {
@@ -1144,7 +1144,7 @@ function createBaseQueryParamsRequest(): QueryParamsRequest {
 export const QueryParamsRequest = {
   typeUrl: "/cosmos.gov.v1beta1.QueryParamsRequest",
   encode(message: QueryParamsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.paramsType !== "") {
+    if (message.paramsType !== undefined) {
       writer.uint32(10).string(message.paramsType);
     }
     return writer;
@@ -1365,10 +1365,10 @@ function createBaseQueryDepositRequest(): QueryDepositRequest {
 export const QueryDepositRequest = {
   typeUrl: "/cosmos.gov.v1beta1.QueryDepositRequest",
   encode(message: QueryDepositRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
-    if (message.depositor !== "") {
+    if (message.depositor !== undefined) {
       writer.uint32(18).string(message.depositor);
     }
     return writer;
@@ -1568,7 +1568,7 @@ function createBaseQueryDepositsRequest(): QueryDepositsRequest {
 export const QueryDepositsRequest = {
   typeUrl: "/cosmos.gov.v1beta1.QueryDepositsRequest",
   encode(message: QueryDepositsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
     if (message.pagination !== undefined) {
@@ -1799,7 +1799,7 @@ function createBaseQueryTallyResultRequest(): QueryTallyResultRequest {
 export const QueryTallyResultRequest = {
   typeUrl: "/cosmos.gov.v1beta1.QueryTallyResultRequest",
   encode(message: QueryTallyResultRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/gov/v1beta1/tx.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/gov/v1beta1/tx.ts
@@ -142,7 +142,7 @@ export const MsgSubmitProposal = {
     for (const v of message.initialDeposit) {
       Coin.encode(v!, writer.uint32(18).fork()).ldelim();
     }
-    if (message.proposer !== "") {
+    if (message.proposer !== undefined) {
       writer.uint32(26).string(message.proposer);
     }
     return writer;
@@ -270,7 +270,7 @@ function createBaseMsgSubmitProposalResponse(): MsgSubmitProposalResponse {
 export const MsgSubmitProposalResponse = {
   typeUrl: "/cosmos.gov.v1beta1.MsgSubmitProposalResponse",
   encode(message: MsgSubmitProposalResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
     return writer;
@@ -366,10 +366,10 @@ function createBaseMsgVote(): MsgVote {
 export const MsgVote = {
   typeUrl: "/cosmos.gov.v1beta1.MsgVote",
   encode(message: MsgVote, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
-    if (message.voter !== "") {
+    if (message.voter !== undefined) {
       writer.uint32(18).string(message.voter);
     }
     if (message.option !== 0) {
@@ -563,10 +563,10 @@ function createBaseMsgVoteWeighted(): MsgVoteWeighted {
 export const MsgVoteWeighted = {
   typeUrl: "/cosmos.gov.v1beta1.MsgVoteWeighted",
   encode(message: MsgVoteWeighted, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
-    if (message.voter !== "") {
+    if (message.voter !== undefined) {
       writer.uint32(18).string(message.voter);
     }
     for (const v of message.options) {
@@ -772,10 +772,10 @@ function createBaseMsgDeposit(): MsgDeposit {
 export const MsgDeposit = {
   typeUrl: "/cosmos.gov.v1beta1.MsgDeposit",
   encode(message: MsgDeposit, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
-    if (message.depositor !== "") {
+    if (message.depositor !== undefined) {
       writer.uint32(18).string(message.depositor);
     }
     for (const v of message.amount) {

--- a/__fixtures__/v-next/outputv4/cosmos/group/v1/events.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/group/v1/events.ts
@@ -133,7 +133,7 @@ function createBaseEventCreateGroup(): EventCreateGroup {
 export const EventCreateGroup = {
   typeUrl: "/cosmos.group.v1.EventCreateGroup",
   encode(message: EventCreateGroup, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.groupId !== BigInt(0)) {
+    if (message.groupId !== undefined) {
       writer.uint32(8).uint64(message.groupId);
     }
     return writer;
@@ -227,7 +227,7 @@ function createBaseEventUpdateGroup(): EventUpdateGroup {
 export const EventUpdateGroup = {
   typeUrl: "/cosmos.group.v1.EventUpdateGroup",
   encode(message: EventUpdateGroup, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.groupId !== BigInt(0)) {
+    if (message.groupId !== undefined) {
       writer.uint32(8).uint64(message.groupId);
     }
     return writer;
@@ -321,7 +321,7 @@ function createBaseEventCreateGroupPolicy(): EventCreateGroupPolicy {
 export const EventCreateGroupPolicy = {
   typeUrl: "/cosmos.group.v1.EventCreateGroupPolicy",
   encode(message: EventCreateGroupPolicy, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     return writer;
@@ -413,7 +413,7 @@ function createBaseEventUpdateGroupPolicy(): EventUpdateGroupPolicy {
 export const EventUpdateGroupPolicy = {
   typeUrl: "/cosmos.group.v1.EventUpdateGroupPolicy",
   encode(message: EventUpdateGroupPolicy, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     return writer;
@@ -505,7 +505,7 @@ function createBaseEventSubmitProposal(): EventSubmitProposal {
 export const EventSubmitProposal = {
   typeUrl: "/cosmos.group.v1.EventSubmitProposal",
   encode(message: EventSubmitProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
     return writer;
@@ -599,7 +599,7 @@ function createBaseEventWithdrawProposal(): EventWithdrawProposal {
 export const EventWithdrawProposal = {
   typeUrl: "/cosmos.group.v1.EventWithdrawProposal",
   encode(message: EventWithdrawProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
     return writer;
@@ -693,7 +693,7 @@ function createBaseEventVote(): EventVote {
 export const EventVote = {
   typeUrl: "/cosmos.group.v1.EventVote",
   encode(message: EventVote, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
     return writer;
@@ -788,7 +788,7 @@ function createBaseEventExec(): EventExec {
 export const EventExec = {
   typeUrl: "/cosmos.group.v1.EventExec",
   encode(message: EventExec, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
     if (message.result !== 0) {
@@ -897,10 +897,10 @@ function createBaseEventLeaveGroup(): EventLeaveGroup {
 export const EventLeaveGroup = {
   typeUrl: "/cosmos.group.v1.EventLeaveGroup",
   encode(message: EventLeaveGroup, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.groupId !== BigInt(0)) {
+    if (message.groupId !== undefined) {
       writer.uint32(8).uint64(message.groupId);
     }
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(18).string(message.address);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/group/v1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/group/v1/genesis.ts
@@ -60,7 +60,7 @@ function createBaseGenesisState(): GenesisState {
 export const GenesisState = {
   typeUrl: "/cosmos.group.v1.GenesisState",
   encode(message: GenesisState, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.groupSeq !== BigInt(0)) {
+    if (message.groupSeq !== undefined) {
       writer.uint32(8).uint64(message.groupSeq);
     }
     for (const v of message.groups) {
@@ -69,13 +69,13 @@ export const GenesisState = {
     for (const v of message.groupMembers) {
       GroupMember.encode(v!, writer.uint32(26).fork()).ldelim();
     }
-    if (message.groupPolicySeq !== BigInt(0)) {
+    if (message.groupPolicySeq !== undefined) {
       writer.uint32(32).uint64(message.groupPolicySeq);
     }
     for (const v of message.groupPolicies) {
       GroupPolicyInfo.encode(v!, writer.uint32(42).fork()).ldelim();
     }
-    if (message.proposalSeq !== BigInt(0)) {
+    if (message.proposalSeq !== undefined) {
       writer.uint32(48).uint64(message.proposalSeq);
     }
     for (const v of message.proposals) {

--- a/__fixtures__/v-next/outputv4/cosmos/group/v1/query.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/group/v1/query.ts
@@ -400,7 +400,7 @@ function createBaseQueryGroupInfoRequest(): QueryGroupInfoRequest {
 export const QueryGroupInfoRequest = {
   typeUrl: "/cosmos.group.v1.QueryGroupInfoRequest",
   encode(message: QueryGroupInfoRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.groupId !== BigInt(0)) {
+    if (message.groupId !== undefined) {
       writer.uint32(8).uint64(message.groupId);
     }
     return writer;
@@ -588,7 +588,7 @@ function createBaseQueryGroupPolicyInfoRequest(): QueryGroupPolicyInfoRequest {
 export const QueryGroupPolicyInfoRequest = {
   typeUrl: "/cosmos.group.v1.QueryGroupPolicyInfoRequest",
   encode(message: QueryGroupPolicyInfoRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     return writer;
@@ -775,7 +775,7 @@ function createBaseQueryGroupMembersRequest(): QueryGroupMembersRequest {
 export const QueryGroupMembersRequest = {
   typeUrl: "/cosmos.group.v1.QueryGroupMembersRequest",
   encode(message: QueryGroupMembersRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.groupId !== BigInt(0)) {
+    if (message.groupId !== undefined) {
       writer.uint32(8).uint64(message.groupId);
     }
     if (message.pagination !== undefined) {
@@ -1007,7 +1007,7 @@ function createBaseQueryGroupsByAdminRequest(): QueryGroupsByAdminRequest {
 export const QueryGroupsByAdminRequest = {
   typeUrl: "/cosmos.group.v1.QueryGroupsByAdminRequest",
   encode(message: QueryGroupsByAdminRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.admin !== "") {
+    if (message.admin !== undefined) {
       writer.uint32(10).string(message.admin);
     }
     if (message.pagination !== undefined) {
@@ -1237,7 +1237,7 @@ function createBaseQueryGroupPoliciesByGroupRequest(): QueryGroupPoliciesByGroup
 export const QueryGroupPoliciesByGroupRequest = {
   typeUrl: "/cosmos.group.v1.QueryGroupPoliciesByGroupRequest",
   encode(message: QueryGroupPoliciesByGroupRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.groupId !== BigInt(0)) {
+    if (message.groupId !== undefined) {
       writer.uint32(8).uint64(message.groupId);
     }
     if (message.pagination !== undefined) {
@@ -1469,7 +1469,7 @@ function createBaseQueryGroupPoliciesByAdminRequest(): QueryGroupPoliciesByAdmin
 export const QueryGroupPoliciesByAdminRequest = {
   typeUrl: "/cosmos.group.v1.QueryGroupPoliciesByAdminRequest",
   encode(message: QueryGroupPoliciesByAdminRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.admin !== "") {
+    if (message.admin !== undefined) {
       writer.uint32(10).string(message.admin);
     }
     if (message.pagination !== undefined) {
@@ -1698,7 +1698,7 @@ function createBaseQueryProposalRequest(): QueryProposalRequest {
 export const QueryProposalRequest = {
   typeUrl: "/cosmos.group.v1.QueryProposalRequest",
   encode(message: QueryProposalRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
     return writer;
@@ -1887,7 +1887,7 @@ function createBaseQueryProposalsByGroupPolicyRequest(): QueryProposalsByGroupPo
 export const QueryProposalsByGroupPolicyRequest = {
   typeUrl: "/cosmos.group.v1.QueryProposalsByGroupPolicyRequest",
   encode(message: QueryProposalsByGroupPolicyRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     if (message.pagination !== undefined) {
@@ -2117,10 +2117,10 @@ function createBaseQueryVoteByProposalVoterRequest(): QueryVoteByProposalVoterRe
 export const QueryVoteByProposalVoterRequest = {
   typeUrl: "/cosmos.group.v1.QueryVoteByProposalVoterRequest",
   encode(message: QueryVoteByProposalVoterRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
-    if (message.voter !== "") {
+    if (message.voter !== undefined) {
       writer.uint32(18).string(message.voter);
     }
     return writer;
@@ -2320,7 +2320,7 @@ function createBaseQueryVotesByProposalRequest(): QueryVotesByProposalRequest {
 export const QueryVotesByProposalRequest = {
   typeUrl: "/cosmos.group.v1.QueryVotesByProposalRequest",
   encode(message: QueryVotesByProposalRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
     if (message.pagination !== undefined) {
@@ -2552,7 +2552,7 @@ function createBaseQueryVotesByVoterRequest(): QueryVotesByVoterRequest {
 export const QueryVotesByVoterRequest = {
   typeUrl: "/cosmos.group.v1.QueryVotesByVoterRequest",
   encode(message: QueryVotesByVoterRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.voter !== "") {
+    if (message.voter !== undefined) {
       writer.uint32(10).string(message.voter);
     }
     if (message.pagination !== undefined) {
@@ -2782,7 +2782,7 @@ function createBaseQueryGroupsByMemberRequest(): QueryGroupsByMemberRequest {
 export const QueryGroupsByMemberRequest = {
   typeUrl: "/cosmos.group.v1.QueryGroupsByMemberRequest",
   encode(message: QueryGroupsByMemberRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     if (message.pagination !== undefined) {
@@ -3011,7 +3011,7 @@ function createBaseQueryTallyResultRequest(): QueryTallyResultRequest {
 export const QueryTallyResultRequest = {
   typeUrl: "/cosmos.group.v1.QueryTallyResultRequest",
   encode(message: QueryTallyResultRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/group/v1/tx.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/group/v1/tx.ts
@@ -484,13 +484,13 @@ function createBaseMsgCreateGroup(): MsgCreateGroup {
 export const MsgCreateGroup = {
   typeUrl: "/cosmos.group.v1.MsgCreateGroup",
   encode(message: MsgCreateGroup, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.admin !== "") {
+    if (message.admin !== undefined) {
       writer.uint32(10).string(message.admin);
     }
     for (const v of message.members) {
       Member.encode(v!, writer.uint32(18).fork()).ldelim();
     }
-    if (message.metadata !== "") {
+    if (message.metadata !== undefined) {
       writer.uint32(26).string(message.metadata);
     }
     return writer;
@@ -616,7 +616,7 @@ function createBaseMsgCreateGroupResponse(): MsgCreateGroupResponse {
 export const MsgCreateGroupResponse = {
   typeUrl: "/cosmos.group.v1.MsgCreateGroupResponse",
   encode(message: MsgCreateGroupResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.groupId !== BigInt(0)) {
+    if (message.groupId !== undefined) {
       writer.uint32(8).uint64(message.groupId);
     }
     return writer;
@@ -712,10 +712,10 @@ function createBaseMsgUpdateGroupMembers(): MsgUpdateGroupMembers {
 export const MsgUpdateGroupMembers = {
   typeUrl: "/cosmos.group.v1.MsgUpdateGroupMembers",
   encode(message: MsgUpdateGroupMembers, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.admin !== "") {
+    if (message.admin !== undefined) {
       writer.uint32(10).string(message.admin);
     }
-    if (message.groupId !== BigInt(0)) {
+    if (message.groupId !== undefined) {
       writer.uint32(16).uint64(message.groupId);
     }
     for (const v of message.memberUpdates) {
@@ -921,13 +921,13 @@ function createBaseMsgUpdateGroupAdmin(): MsgUpdateGroupAdmin {
 export const MsgUpdateGroupAdmin = {
   typeUrl: "/cosmos.group.v1.MsgUpdateGroupAdmin",
   encode(message: MsgUpdateGroupAdmin, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.admin !== "") {
+    if (message.admin !== undefined) {
       writer.uint32(10).string(message.admin);
     }
-    if (message.groupId !== BigInt(0)) {
+    if (message.groupId !== undefined) {
       writer.uint32(16).uint64(message.groupId);
     }
-    if (message.newAdmin !== "") {
+    if (message.newAdmin !== undefined) {
       writer.uint32(26).string(message.newAdmin);
     }
     return writer;
@@ -1118,13 +1118,13 @@ function createBaseMsgUpdateGroupMetadata(): MsgUpdateGroupMetadata {
 export const MsgUpdateGroupMetadata = {
   typeUrl: "/cosmos.group.v1.MsgUpdateGroupMetadata",
   encode(message: MsgUpdateGroupMetadata, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.admin !== "") {
+    if (message.admin !== undefined) {
       writer.uint32(10).string(message.admin);
     }
-    if (message.groupId !== BigInt(0)) {
+    if (message.groupId !== undefined) {
       writer.uint32(16).uint64(message.groupId);
     }
-    if (message.metadata !== "") {
+    if (message.metadata !== undefined) {
       writer.uint32(26).string(message.metadata);
     }
     return writer;
@@ -1316,13 +1316,13 @@ function createBaseMsgCreateGroupPolicy(): MsgCreateGroupPolicy {
 export const MsgCreateGroupPolicy = {
   typeUrl: "/cosmos.group.v1.MsgCreateGroupPolicy",
   encode(message: MsgCreateGroupPolicy, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.admin !== "") {
+    if (message.admin !== undefined) {
       writer.uint32(10).string(message.admin);
     }
-    if (message.groupId !== BigInt(0)) {
+    if (message.groupId !== undefined) {
       writer.uint32(16).uint64(message.groupId);
     }
-    if (message.metadata !== "") {
+    if (message.metadata !== undefined) {
       writer.uint32(26).string(message.metadata);
     }
     if (message.decisionPolicy !== undefined) {
@@ -1454,7 +1454,7 @@ function createBaseMsgCreateGroupPolicyResponse(): MsgCreateGroupPolicyResponse 
 export const MsgCreateGroupPolicyResponse = {
   typeUrl: "/cosmos.group.v1.MsgCreateGroupPolicyResponse",
   encode(message: MsgCreateGroupPolicyResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     return writer;
@@ -1548,13 +1548,13 @@ function createBaseMsgUpdateGroupPolicyAdmin(): MsgUpdateGroupPolicyAdmin {
 export const MsgUpdateGroupPolicyAdmin = {
   typeUrl: "/cosmos.group.v1.MsgUpdateGroupPolicyAdmin",
   encode(message: MsgUpdateGroupPolicyAdmin, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.admin !== "") {
+    if (message.admin !== undefined) {
       writer.uint32(10).string(message.admin);
     }
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(18).string(message.address);
     }
-    if (message.newAdmin !== "") {
+    if (message.newAdmin !== undefined) {
       writer.uint32(26).string(message.newAdmin);
     }
     return writer;
@@ -1673,19 +1673,19 @@ function createBaseMsgCreateGroupWithPolicy(): MsgCreateGroupWithPolicy {
 export const MsgCreateGroupWithPolicy = {
   typeUrl: "/cosmos.group.v1.MsgCreateGroupWithPolicy",
   encode(message: MsgCreateGroupWithPolicy, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.admin !== "") {
+    if (message.admin !== undefined) {
       writer.uint32(10).string(message.admin);
     }
     for (const v of message.members) {
       Member.encode(v!, writer.uint32(18).fork()).ldelim();
     }
-    if (message.groupMetadata !== "") {
+    if (message.groupMetadata !== undefined) {
       writer.uint32(26).string(message.groupMetadata);
     }
-    if (message.groupPolicyMetadata !== "") {
+    if (message.groupPolicyMetadata !== undefined) {
       writer.uint32(34).string(message.groupPolicyMetadata);
     }
-    if (message.groupPolicyAsAdmin === true) {
+    if (message.groupPolicyAsAdmin !== undefined) {
       writer.uint32(40).bool(message.groupPolicyAsAdmin);
     }
     if (message.decisionPolicy !== undefined) {
@@ -1850,10 +1850,10 @@ function createBaseMsgCreateGroupWithPolicyResponse(): MsgCreateGroupWithPolicyR
 export const MsgCreateGroupWithPolicyResponse = {
   typeUrl: "/cosmos.group.v1.MsgCreateGroupWithPolicyResponse",
   encode(message: MsgCreateGroupWithPolicyResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.groupId !== BigInt(0)) {
+    if (message.groupId !== undefined) {
       writer.uint32(8).uint64(message.groupId);
     }
-    if (message.groupPolicyAddress !== "") {
+    if (message.groupPolicyAddress !== undefined) {
       writer.uint32(18).string(message.groupPolicyAddress);
     }
     return writer;
@@ -2033,10 +2033,10 @@ function createBaseMsgUpdateGroupPolicyDecisionPolicy(): MsgUpdateGroupPolicyDec
 export const MsgUpdateGroupPolicyDecisionPolicy = {
   typeUrl: "/cosmos.group.v1.MsgUpdateGroupPolicyDecisionPolicy",
   encode(message: MsgUpdateGroupPolicyDecisionPolicy, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.admin !== "") {
+    if (message.admin !== undefined) {
       writer.uint32(10).string(message.admin);
     }
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(18).string(message.address);
     }
     if (message.decisionPolicy !== undefined) {
@@ -2230,13 +2230,13 @@ function createBaseMsgUpdateGroupPolicyMetadata(): MsgUpdateGroupPolicyMetadata 
 export const MsgUpdateGroupPolicyMetadata = {
   typeUrl: "/cosmos.group.v1.MsgUpdateGroupPolicyMetadata",
   encode(message: MsgUpdateGroupPolicyMetadata, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.admin !== "") {
+    if (message.admin !== undefined) {
       writer.uint32(10).string(message.admin);
     }
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(18).string(message.address);
     }
-    if (message.metadata !== "") {
+    if (message.metadata !== undefined) {
       writer.uint32(26).string(message.metadata);
     }
     return writer;
@@ -2427,13 +2427,13 @@ function createBaseMsgSubmitProposal(): MsgSubmitProposal {
 export const MsgSubmitProposal = {
   typeUrl: "/cosmos.group.v1.MsgSubmitProposal",
   encode(message: MsgSubmitProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     for (const v of message.proposers) {
       writer.uint32(18).string(v!);
     }
-    if (message.metadata !== "") {
+    if (message.metadata !== undefined) {
       writer.uint32(26).string(message.metadata);
     }
     for (const v of message.messages) {
@@ -2599,7 +2599,7 @@ function createBaseMsgSubmitProposalResponse(): MsgSubmitProposalResponse {
 export const MsgSubmitProposalResponse = {
   typeUrl: "/cosmos.group.v1.MsgSubmitProposalResponse",
   encode(message: MsgSubmitProposalResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
     return writer;
@@ -2694,10 +2694,10 @@ function createBaseMsgWithdrawProposal(): MsgWithdrawProposal {
 export const MsgWithdrawProposal = {
   typeUrl: "/cosmos.group.v1.MsgWithdrawProposal",
   encode(message: MsgWithdrawProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(18).string(message.address);
     }
     return writer;
@@ -2879,16 +2879,16 @@ function createBaseMsgVote(): MsgVote {
 export const MsgVote = {
   typeUrl: "/cosmos.group.v1.MsgVote",
   encode(message: MsgVote, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
-    if (message.voter !== "") {
+    if (message.voter !== undefined) {
       writer.uint32(18).string(message.voter);
     }
     if (message.option !== 0) {
       writer.uint32(24).int32(message.option);
     }
-    if (message.metadata !== "") {
+    if (message.metadata !== undefined) {
       writer.uint32(34).string(message.metadata);
     }
     if (message.exec !== 0) {
@@ -3103,10 +3103,10 @@ function createBaseMsgExec(): MsgExec {
 export const MsgExec = {
   typeUrl: "/cosmos.group.v1.MsgExec",
   encode(message: MsgExec, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
-    if (message.signer !== "") {
+    if (message.signer !== undefined) {
       writer.uint32(18).string(message.signer);
     }
     return writer;
@@ -3285,10 +3285,10 @@ function createBaseMsgLeaveGroup(): MsgLeaveGroup {
 export const MsgLeaveGroup = {
   typeUrl: "/cosmos.group.v1.MsgLeaveGroup",
   encode(message: MsgLeaveGroup, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
-    if (message.groupId !== BigInt(0)) {
+    if (message.groupId !== undefined) {
       writer.uint32(16).uint64(message.groupId);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/group/v1/types.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/group/v1/types.ts
@@ -537,13 +537,13 @@ function createBaseMember(): Member {
 export const Member = {
   typeUrl: "/cosmos.group.v1.Member",
   encode(message: Member, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
-    if (message.weight !== "") {
+    if (message.weight !== undefined) {
       writer.uint32(18).string(message.weight);
     }
-    if (message.metadata !== "") {
+    if (message.metadata !== undefined) {
       writer.uint32(26).string(message.metadata);
     }
     if (message.addedAt !== undefined) {
@@ -776,7 +776,7 @@ function createBaseThresholdDecisionPolicy(): ThresholdDecisionPolicy {
 export const ThresholdDecisionPolicy = {
   typeUrl: "/cosmos.group.v1.ThresholdDecisionPolicy",
   encode(message: ThresholdDecisionPolicy, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.threshold !== "") {
+    if (message.threshold !== undefined) {
       writer.uint32(10).string(message.threshold);
     }
     if (message.windows !== undefined) {
@@ -885,7 +885,7 @@ function createBasePercentageDecisionPolicy(): PercentageDecisionPolicy {
 export const PercentageDecisionPolicy = {
   typeUrl: "/cosmos.group.v1.PercentageDecisionPolicy",
   encode(message: PercentageDecisionPolicy, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.percentage !== "") {
+    if (message.percentage !== undefined) {
       writer.uint32(10).string(message.percentage);
     }
     if (message.windows !== undefined) {
@@ -1109,19 +1109,19 @@ function createBaseGroupInfo(): GroupInfo {
 export const GroupInfo = {
   typeUrl: "/cosmos.group.v1.GroupInfo",
   encode(message: GroupInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.id !== BigInt(0)) {
+    if (message.id !== undefined) {
       writer.uint32(8).uint64(message.id);
     }
-    if (message.admin !== "") {
+    if (message.admin !== undefined) {
       writer.uint32(18).string(message.admin);
     }
-    if (message.metadata !== "") {
+    if (message.metadata !== undefined) {
       writer.uint32(26).string(message.metadata);
     }
-    if (message.version !== BigInt(0)) {
+    if (message.version !== undefined) {
       writer.uint32(32).uint64(message.version);
     }
-    if (message.totalWeight !== "") {
+    if (message.totalWeight !== undefined) {
       writer.uint32(42).string(message.totalWeight);
     }
     if (message.createdAt !== undefined) {
@@ -1276,7 +1276,7 @@ function createBaseGroupMember(): GroupMember {
 export const GroupMember = {
   typeUrl: "/cosmos.group.v1.GroupMember",
   encode(message: GroupMember, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.groupId !== BigInt(0)) {
+    if (message.groupId !== undefined) {
       writer.uint32(8).uint64(message.groupId);
     }
     if (message.member !== undefined) {
@@ -1392,19 +1392,19 @@ function createBaseGroupPolicyInfo(): GroupPolicyInfo {
 export const GroupPolicyInfo = {
   typeUrl: "/cosmos.group.v1.GroupPolicyInfo",
   encode(message: GroupPolicyInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
-    if (message.groupId !== BigInt(0)) {
+    if (message.groupId !== undefined) {
       writer.uint32(16).uint64(message.groupId);
     }
-    if (message.admin !== "") {
+    if (message.admin !== undefined) {
       writer.uint32(26).string(message.admin);
     }
-    if (message.metadata !== "") {
+    if (message.metadata !== undefined) {
       writer.uint32(34).string(message.metadata);
     }
-    if (message.version !== BigInt(0)) {
+    if (message.version !== undefined) {
       writer.uint32(40).uint64(message.version);
     }
     if (message.decisionPolicy !== undefined) {
@@ -1586,13 +1586,13 @@ function createBaseProposal(): Proposal {
 export const Proposal = {
   typeUrl: "/cosmos.group.v1.Proposal",
   encode(message: Proposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.id !== BigInt(0)) {
+    if (message.id !== undefined) {
       writer.uint32(8).uint64(message.id);
     }
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(18).string(message.address);
     }
-    if (message.metadata !== "") {
+    if (message.metadata !== undefined) {
       writer.uint32(26).string(message.metadata);
     }
     for (const v of message.proposers) {
@@ -1601,10 +1601,10 @@ export const Proposal = {
     if (message.submitTime !== undefined) {
       Timestamp.encode(toTimestamp(message.submitTime), writer.uint32(42).fork()).ldelim();
     }
-    if (message.groupVersion !== BigInt(0)) {
+    if (message.groupVersion !== undefined) {
       writer.uint32(48).uint64(message.groupVersion);
     }
-    if (message.groupPolicyVersion !== BigInt(0)) {
+    if (message.groupPolicyVersion !== undefined) {
       writer.uint32(56).uint64(message.groupPolicyVersion);
     }
     if (message.status !== 0) {
@@ -1881,16 +1881,16 @@ function createBaseTallyResult(): TallyResult {
 export const TallyResult = {
   typeUrl: "/cosmos.group.v1.TallyResult",
   encode(message: TallyResult, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.yesCount !== "") {
+    if (message.yesCount !== undefined) {
       writer.uint32(10).string(message.yesCount);
     }
-    if (message.abstainCount !== "") {
+    if (message.abstainCount !== undefined) {
       writer.uint32(18).string(message.abstainCount);
     }
-    if (message.noCount !== "") {
+    if (message.noCount !== undefined) {
       writer.uint32(26).string(message.noCount);
     }
-    if (message.noWithVetoCount !== "") {
+    if (message.noWithVetoCount !== undefined) {
       writer.uint32(34).string(message.noWithVetoCount);
     }
     return writer;
@@ -2019,16 +2019,16 @@ function createBaseVote(): Vote {
 export const Vote = {
   typeUrl: "/cosmos.group.v1.Vote",
   encode(message: Vote, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.proposalId !== BigInt(0)) {
+    if (message.proposalId !== undefined) {
       writer.uint32(8).uint64(message.proposalId);
     }
-    if (message.voter !== "") {
+    if (message.voter !== undefined) {
       writer.uint32(18).string(message.voter);
     }
     if (message.option !== 0) {
       writer.uint32(24).int32(message.option);
     }
-    if (message.metadata !== "") {
+    if (message.metadata !== undefined) {
       writer.uint32(34).string(message.metadata);
     }
     if (message.submitTime !== undefined) {

--- a/__fixtures__/v-next/outputv4/cosmos/mint/v1beta1/mint.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/mint/v1beta1/mint.ts
@@ -55,10 +55,10 @@ function createBaseMinter(): Minter {
 export const Minter = {
   typeUrl: "/cosmos.mint.v1beta1.Minter",
   encode(message: Minter, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.inflation !== "") {
+    if (message.inflation !== undefined) {
       writer.uint32(10).string(Decimal.fromUserInput(message.inflation, 18).atomics);
     }
-    if (message.annualProvisions !== "") {
+    if (message.annualProvisions !== undefined) {
       writer.uint32(18).string(Decimal.fromUserInput(message.annualProvisions, 18).atomics);
     }
     return writer;
@@ -166,22 +166,22 @@ function createBaseParams(): Params {
 export const Params = {
   typeUrl: "/cosmos.mint.v1beta1.Params",
   encode(message: Params, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.mintDenom !== "") {
+    if (message.mintDenom !== undefined) {
       writer.uint32(10).string(message.mintDenom);
     }
-    if (message.inflationRateChange !== "") {
+    if (message.inflationRateChange !== undefined) {
       writer.uint32(18).string(Decimal.fromUserInput(message.inflationRateChange, 18).atomics);
     }
-    if (message.inflationMax !== "") {
+    if (message.inflationMax !== undefined) {
       writer.uint32(26).string(Decimal.fromUserInput(message.inflationMax, 18).atomics);
     }
-    if (message.inflationMin !== "") {
+    if (message.inflationMin !== undefined) {
       writer.uint32(34).string(Decimal.fromUserInput(message.inflationMin, 18).atomics);
     }
-    if (message.goalBonded !== "") {
+    if (message.goalBonded !== undefined) {
       writer.uint32(42).string(Decimal.fromUserInput(message.goalBonded, 18).atomics);
     }
-    if (message.blocksPerYear !== BigInt(0)) {
+    if (message.blocksPerYear !== undefined) {
       writer.uint32(48).uint64(message.blocksPerYear);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/nft/v1beta1/event.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/nft/v1beta1/event.ts
@@ -62,16 +62,16 @@ function createBaseEventSend(): EventSend {
 export const EventSend = {
   typeUrl: "/cosmos.nft.v1beta1.EventSend",
   encode(message: EventSend, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.classId !== "") {
+    if (message.classId !== undefined) {
       writer.uint32(10).string(message.classId);
     }
-    if (message.id !== "") {
+    if (message.id !== undefined) {
       writer.uint32(18).string(message.id);
     }
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(26).string(message.sender);
     }
-    if (message.receiver !== "") {
+    if (message.receiver !== undefined) {
       writer.uint32(34).string(message.receiver);
     }
     return writer;
@@ -198,13 +198,13 @@ function createBaseEventMint(): EventMint {
 export const EventMint = {
   typeUrl: "/cosmos.nft.v1beta1.EventMint",
   encode(message: EventMint, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.classId !== "") {
+    if (message.classId !== undefined) {
       writer.uint32(10).string(message.classId);
     }
-    if (message.id !== "") {
+    if (message.id !== undefined) {
       writer.uint32(18).string(message.id);
     }
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(26).string(message.owner);
     }
     return writer;
@@ -320,13 +320,13 @@ function createBaseEventBurn(): EventBurn {
 export const EventBurn = {
   typeUrl: "/cosmos.nft.v1beta1.EventBurn",
   encode(message: EventBurn, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.classId !== "") {
+    if (message.classId !== undefined) {
       writer.uint32(10).string(message.classId);
     }
-    if (message.id !== "") {
+    if (message.id !== undefined) {
       writer.uint32(18).string(message.id);
     }
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(26).string(message.owner);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/nft/v1beta1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/nft/v1beta1/genesis.ts
@@ -173,7 +173,7 @@ function createBaseEntry(): Entry {
 export const Entry = {
   typeUrl: "/cosmos.nft.v1beta1.Entry",
   encode(message: Entry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
     for (const v of message.nfts) {

--- a/__fixtures__/v-next/outputv4/cosmos/nft/v1beta1/nft.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/nft/v1beta1/nft.ts
@@ -72,22 +72,22 @@ function createBaseClass(): Class {
 export const Class = {
   typeUrl: "/cosmos.nft.v1beta1.Class",
   encode(message: Class, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.id !== "") {
+    if (message.id !== undefined) {
       writer.uint32(10).string(message.id);
     }
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(18).string(message.name);
     }
-    if (message.symbol !== "") {
+    if (message.symbol !== undefined) {
       writer.uint32(26).string(message.symbol);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(34).string(message.description);
     }
-    if (message.uri !== "") {
+    if (message.uri !== undefined) {
       writer.uint32(42).string(message.uri);
     }
-    if (message.uriHash !== "") {
+    if (message.uriHash !== undefined) {
       writer.uint32(50).string(message.uriHash);
     }
     if (message.data !== undefined) {
@@ -254,16 +254,16 @@ function createBaseNFT(): NFT {
 export const NFT = {
   typeUrl: "/cosmos.nft.v1beta1.NFT",
   encode(message: NFT, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.classId !== "") {
+    if (message.classId !== undefined) {
       writer.uint32(10).string(message.classId);
     }
-    if (message.id !== "") {
+    if (message.id !== undefined) {
       writer.uint32(18).string(message.id);
     }
-    if (message.uri !== "") {
+    if (message.uri !== undefined) {
       writer.uint32(26).string(message.uri);
     }
-    if (message.uriHash !== "") {
+    if (message.uriHash !== undefined) {
       writer.uint32(34).string(message.uriHash);
     }
     if (message.data !== undefined) {

--- a/__fixtures__/v-next/outputv4/cosmos/nft/v1beta1/query.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/nft/v1beta1/query.ts
@@ -195,10 +195,10 @@ function createBaseQueryBalanceRequest(): QueryBalanceRequest {
 export const QueryBalanceRequest = {
   typeUrl: "/cosmos.nft.v1beta1.QueryBalanceRequest",
   encode(message: QueryBalanceRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.classId !== "") {
+    if (message.classId !== undefined) {
       writer.uint32(10).string(message.classId);
     }
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(18).string(message.owner);
     }
     return writer;
@@ -301,7 +301,7 @@ function createBaseQueryBalanceResponse(): QueryBalanceResponse {
 export const QueryBalanceResponse = {
   typeUrl: "/cosmos.nft.v1beta1.QueryBalanceResponse",
   encode(message: QueryBalanceResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.amount !== BigInt(0)) {
+    if (message.amount !== undefined) {
       writer.uint32(8).uint64(message.amount);
     }
     return writer;
@@ -396,10 +396,10 @@ function createBaseQueryOwnerRequest(): QueryOwnerRequest {
 export const QueryOwnerRequest = {
   typeUrl: "/cosmos.nft.v1beta1.QueryOwnerRequest",
   encode(message: QueryOwnerRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.classId !== "") {
+    if (message.classId !== undefined) {
       writer.uint32(10).string(message.classId);
     }
-    if (message.id !== "") {
+    if (message.id !== undefined) {
       writer.uint32(18).string(message.id);
     }
     return writer;
@@ -502,7 +502,7 @@ function createBaseQueryOwnerResponse(): QueryOwnerResponse {
 export const QueryOwnerResponse = {
   typeUrl: "/cosmos.nft.v1beta1.QueryOwnerResponse",
   encode(message: QueryOwnerResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
     return writer;
@@ -594,7 +594,7 @@ function createBaseQuerySupplyRequest(): QuerySupplyRequest {
 export const QuerySupplyRequest = {
   typeUrl: "/cosmos.nft.v1beta1.QuerySupplyRequest",
   encode(message: QuerySupplyRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.classId !== "") {
+    if (message.classId !== undefined) {
       writer.uint32(10).string(message.classId);
     }
     return writer;
@@ -686,7 +686,7 @@ function createBaseQuerySupplyResponse(): QuerySupplyResponse {
 export const QuerySupplyResponse = {
   typeUrl: "/cosmos.nft.v1beta1.QuerySupplyResponse",
   encode(message: QuerySupplyResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.amount !== BigInt(0)) {
+    if (message.amount !== undefined) {
       writer.uint32(8).uint64(message.amount);
     }
     return writer;
@@ -782,10 +782,10 @@ function createBaseQueryNFTsRequest(): QueryNFTsRequest {
 export const QueryNFTsRequest = {
   typeUrl: "/cosmos.nft.v1beta1.QueryNFTsRequest",
   encode(message: QueryNFTsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.classId !== "") {
+    if (message.classId !== undefined) {
       writer.uint32(10).string(message.classId);
     }
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(18).string(message.owner);
     }
     if (message.pagination !== undefined) {
@@ -1026,10 +1026,10 @@ function createBaseQueryNFTRequest(): QueryNFTRequest {
 export const QueryNFTRequest = {
   typeUrl: "/cosmos.nft.v1beta1.QueryNFTRequest",
   encode(message: QueryNFTRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.classId !== "") {
+    if (message.classId !== undefined) {
       writer.uint32(10).string(message.classId);
     }
-    if (message.id !== "") {
+    if (message.id !== undefined) {
       writer.uint32(18).string(message.id);
     }
     return writer;
@@ -1226,7 +1226,7 @@ function createBaseQueryClassRequest(): QueryClassRequest {
 export const QueryClassRequest = {
   typeUrl: "/cosmos.nft.v1beta1.QueryClassRequest",
   encode(message: QueryClassRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.classId !== "") {
+    if (message.classId !== undefined) {
       writer.uint32(10).string(message.classId);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/nft/v1beta1/tx.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/nft/v1beta1/tx.ts
@@ -42,16 +42,16 @@ function createBaseMsgSend(): MsgSend {
 export const MsgSend = {
   typeUrl: "/cosmos.nft.v1beta1.MsgSend",
   encode(message: MsgSend, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.classId !== "") {
+    if (message.classId !== undefined) {
       writer.uint32(10).string(message.classId);
     }
-    if (message.id !== "") {
+    if (message.id !== undefined) {
       writer.uint32(18).string(message.id);
     }
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(26).string(message.sender);
     }
-    if (message.receiver !== "") {
+    if (message.receiver !== undefined) {
       writer.uint32(34).string(message.receiver);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/orm/v1/orm.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/orm/v1/orm.ts
@@ -141,7 +141,7 @@ export const TableDescriptor = {
     for (const v of message.index) {
       SecondaryIndexDescriptor.encode(v!, writer.uint32(18).fork()).ldelim();
     }
-    if (message.id !== 0) {
+    if (message.id !== undefined) {
       writer.uint32(24).uint32(message.id);
     }
     return writer;
@@ -270,10 +270,10 @@ function createBasePrimaryKeyDescriptor(): PrimaryKeyDescriptor {
 export const PrimaryKeyDescriptor = {
   typeUrl: "/cosmos.orm.v1.PrimaryKeyDescriptor",
   encode(message: PrimaryKeyDescriptor, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.fields !== "") {
+    if (message.fields !== undefined) {
       writer.uint32(10).string(message.fields);
     }
-    if (message.autoIncrement === true) {
+    if (message.autoIncrement !== undefined) {
       writer.uint32(16).bool(message.autoIncrement);
     }
     return writer;
@@ -378,13 +378,13 @@ function createBaseSecondaryIndexDescriptor(): SecondaryIndexDescriptor {
 export const SecondaryIndexDescriptor = {
   typeUrl: "/cosmos.orm.v1.SecondaryIndexDescriptor",
   encode(message: SecondaryIndexDescriptor, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.fields !== "") {
+    if (message.fields !== undefined) {
       writer.uint32(10).string(message.fields);
     }
-    if (message.id !== 0) {
+    if (message.id !== undefined) {
       writer.uint32(16).uint32(message.id);
     }
-    if (message.unique === true) {
+    if (message.unique !== undefined) {
       writer.uint32(24).bool(message.unique);
     }
     return writer;
@@ -498,7 +498,7 @@ function createBaseSingletonDescriptor(): SingletonDescriptor {
 export const SingletonDescriptor = {
   typeUrl: "/cosmos.orm.v1.SingletonDescriptor",
   encode(message: SingletonDescriptor, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.id !== 0) {
+    if (message.id !== undefined) {
       writer.uint32(8).uint32(message.id);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/orm/v1alpha1/schema.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/orm/v1alpha1/schema.ts
@@ -262,10 +262,10 @@ function createBaseModuleSchemaDescriptor_FileEntry(): ModuleSchemaDescriptor_Fi
 export const ModuleSchemaDescriptor_FileEntry = {
   typeUrl: "/cosmos.orm.v1alpha1.FileEntry",
   encode(message: ModuleSchemaDescriptor_FileEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.id !== 0) {
+    if (message.id !== undefined) {
       writer.uint32(8).uint32(message.id);
     }
-    if (message.protoFileName !== "") {
+    if (message.protoFileName !== undefined) {
       writer.uint32(18).string(message.protoFileName);
     }
     if (message.storageType !== 0) {

--- a/__fixtures__/v-next/outputv4/cosmos/params/v1beta1/params.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/params/v1beta1/params.ts
@@ -49,10 +49,10 @@ function createBaseParameterChangeProposal(): ParameterChangeProposal {
 export const ParameterChangeProposal = {
   typeUrl: "/cosmos.params.v1beta1.ParameterChangeProposal",
   encode(message: ParameterChangeProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
     for (const v of message.changes) {
@@ -183,13 +183,13 @@ function createBaseParamChange(): ParamChange {
 export const ParamChange = {
   typeUrl: "/cosmos.params.v1beta1.ParamChange",
   encode(message: ParamChange, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.subspace !== "") {
+    if (message.subspace !== undefined) {
       writer.uint32(10).string(message.subspace);
     }
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(18).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(26).string(message.value);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/params/v1beta1/query.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/params/v1beta1/query.ts
@@ -92,10 +92,10 @@ function createBaseQueryParamsRequest(): QueryParamsRequest {
 export const QueryParamsRequest = {
   typeUrl: "/cosmos.params.v1beta1.QueryParamsRequest",
   encode(message: QueryParamsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.subspace !== "") {
+    if (message.subspace !== undefined) {
       writer.uint32(10).string(message.subspace);
     }
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(18).string(message.key);
     }
     return writer;
@@ -470,7 +470,7 @@ function createBaseSubspace(): Subspace {
 export const Subspace = {
   typeUrl: "/cosmos.params.v1beta1.Subspace",
   encode(message: Subspace, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.subspace !== "") {
+    if (message.subspace !== undefined) {
       writer.uint32(10).string(message.subspace);
     }
     for (const v of message.keys) {

--- a/__fixtures__/v-next/outputv4/cosmos/slashing/v1beta1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/slashing/v1beta1/genesis.ts
@@ -238,7 +238,7 @@ function createBaseSigningInfo(): SigningInfo {
 export const SigningInfo = {
   typeUrl: "/cosmos.slashing.v1beta1.SigningInfo",
   encode(message: SigningInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     if (message.validatorSigningInfo !== undefined) {
@@ -347,7 +347,7 @@ function createBaseValidatorMissedBlocks(): ValidatorMissedBlocks {
 export const ValidatorMissedBlocks = {
   typeUrl: "/cosmos.slashing.v1beta1.ValidatorMissedBlocks",
   encode(message: ValidatorMissedBlocks, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     for (const v of message.missedBlocks) {
@@ -466,10 +466,10 @@ function createBaseMissedBlock(): MissedBlock {
 export const MissedBlock = {
   typeUrl: "/cosmos.slashing.v1beta1.MissedBlock",
   encode(message: MissedBlock, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.index !== BigInt(0)) {
+    if (message.index !== undefined) {
       writer.uint32(8).int64(message.index);
     }
-    if (message.missed === true) {
+    if (message.missed !== undefined) {
       writer.uint32(16).bool(message.missed);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/slashing/v1beta1/query.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/slashing/v1beta1/query.ts
@@ -275,7 +275,7 @@ function createBaseQuerySigningInfoRequest(): QuerySigningInfoRequest {
 export const QuerySigningInfoRequest = {
   typeUrl: "/cosmos.slashing.v1beta1.QuerySigningInfoRequest",
   encode(message: QuerySigningInfoRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.consAddress !== "") {
+    if (message.consAddress !== undefined) {
       writer.uint32(10).string(message.consAddress);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/slashing/v1beta1/slashing.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/slashing/v1beta1/slashing.ts
@@ -79,22 +79,22 @@ function createBaseValidatorSigningInfo(): ValidatorSigningInfo {
 export const ValidatorSigningInfo = {
   typeUrl: "/cosmos.slashing.v1beta1.ValidatorSigningInfo",
   encode(message: ValidatorSigningInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
-    if (message.startHeight !== BigInt(0)) {
+    if (message.startHeight !== undefined) {
       writer.uint32(16).int64(message.startHeight);
     }
-    if (message.indexOffset !== BigInt(0)) {
+    if (message.indexOffset !== undefined) {
       writer.uint32(24).int64(message.indexOffset);
     }
     if (message.jailedUntil !== undefined) {
       Timestamp.encode(toTimestamp(message.jailedUntil), writer.uint32(34).fork()).ldelim();
     }
-    if (message.tombstoned === true) {
+    if (message.tombstoned !== undefined) {
       writer.uint32(40).bool(message.tombstoned);
     }
-    if (message.missedBlocksCounter !== BigInt(0)) {
+    if (message.missedBlocksCounter !== undefined) {
       writer.uint32(48).int64(message.missedBlocksCounter);
     }
     return writer;
@@ -251,7 +251,7 @@ function createBaseParams(): Params {
 export const Params = {
   typeUrl: "/cosmos.slashing.v1beta1.Params",
   encode(message: Params, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.signedBlocksWindow !== BigInt(0)) {
+    if (message.signedBlocksWindow !== undefined) {
       writer.uint32(8).int64(message.signedBlocksWindow);
     }
     if (message.minSignedPerWindow.length !== 0) {

--- a/__fixtures__/v-next/outputv4/cosmos/slashing/v1beta1/tx.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/slashing/v1beta1/tx.ts
@@ -29,7 +29,7 @@ function createBaseMsgUnjail(): MsgUnjail {
 export const MsgUnjail = {
   typeUrl: "/cosmos.slashing.v1beta1.MsgUnjail",
   encode(message: MsgUnjail, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.validatorAddr !== "") {
+    if (message.validatorAddr !== undefined) {
       writer.uint32(10).string(message.validatorAddr);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/staking/v1beta1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/staking/v1beta1/genesis.ts
@@ -93,7 +93,7 @@ export const GenesisState = {
     for (const v of message.redelegations) {
       Redelegation.encode(v!, writer.uint32(58).fork()).ldelim();
     }
-    if (message.exported === true) {
+    if (message.exported !== undefined) {
       writer.uint32(64).bool(message.exported);
     }
     return writer;
@@ -325,10 +325,10 @@ function createBaseLastValidatorPower(): LastValidatorPower {
 export const LastValidatorPower = {
   typeUrl: "/cosmos.staking.v1beta1.LastValidatorPower",
   encode(message: LastValidatorPower, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
-    if (message.power !== BigInt(0)) {
+    if (message.power !== undefined) {
       writer.uint32(16).int64(message.power);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/staking/v1beta1/query.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/staking/v1beta1/query.ts
@@ -527,7 +527,7 @@ function createBaseQueryValidatorsRequest(): QueryValidatorsRequest {
 export const QueryValidatorsRequest = {
   typeUrl: "/cosmos.staking.v1beta1.QueryValidatorsRequest",
   encode(message: QueryValidatorsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.status !== "") {
+    if (message.status !== undefined) {
       writer.uint32(10).string(message.status);
     }
     if (message.pagination !== undefined) {
@@ -756,7 +756,7 @@ function createBaseQueryValidatorRequest(): QueryValidatorRequest {
 export const QueryValidatorRequest = {
   typeUrl: "/cosmos.staking.v1beta1.QueryValidatorRequest",
   encode(message: QueryValidatorRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.validatorAddr !== "") {
+    if (message.validatorAddr !== undefined) {
       writer.uint32(10).string(message.validatorAddr);
     }
     return writer;
@@ -943,7 +943,7 @@ function createBaseQueryValidatorDelegationsRequest(): QueryValidatorDelegations
 export const QueryValidatorDelegationsRequest = {
   typeUrl: "/cosmos.staking.v1beta1.QueryValidatorDelegationsRequest",
   encode(message: QueryValidatorDelegationsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.validatorAddr !== "") {
+    if (message.validatorAddr !== undefined) {
       writer.uint32(10).string(message.validatorAddr);
     }
     if (message.pagination !== undefined) {
@@ -1173,7 +1173,7 @@ function createBaseQueryValidatorUnbondingDelegationsRequest(): QueryValidatorUn
 export const QueryValidatorUnbondingDelegationsRequest = {
   typeUrl: "/cosmos.staking.v1beta1.QueryValidatorUnbondingDelegationsRequest",
   encode(message: QueryValidatorUnbondingDelegationsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.validatorAddr !== "") {
+    if (message.validatorAddr !== undefined) {
       writer.uint32(10).string(message.validatorAddr);
     }
     if (message.pagination !== undefined) {
@@ -1403,10 +1403,10 @@ function createBaseQueryDelegationRequest(): QueryDelegationRequest {
 export const QueryDelegationRequest = {
   typeUrl: "/cosmos.staking.v1beta1.QueryDelegationRequest",
   encode(message: QueryDelegationRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddr !== "") {
+    if (message.delegatorAddr !== undefined) {
       writer.uint32(10).string(message.delegatorAddr);
     }
-    if (message.validatorAddr !== "") {
+    if (message.validatorAddr !== undefined) {
       writer.uint32(18).string(message.validatorAddr);
     }
     return writer;
@@ -1604,10 +1604,10 @@ function createBaseQueryUnbondingDelegationRequest(): QueryUnbondingDelegationRe
 export const QueryUnbondingDelegationRequest = {
   typeUrl: "/cosmos.staking.v1beta1.QueryUnbondingDelegationRequest",
   encode(message: QueryUnbondingDelegationRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddr !== "") {
+    if (message.delegatorAddr !== undefined) {
       writer.uint32(10).string(message.delegatorAddr);
     }
-    if (message.validatorAddr !== "") {
+    if (message.validatorAddr !== undefined) {
       writer.uint32(18).string(message.validatorAddr);
     }
     return writer;
@@ -1805,7 +1805,7 @@ function createBaseQueryDelegatorDelegationsRequest(): QueryDelegatorDelegations
 export const QueryDelegatorDelegationsRequest = {
   typeUrl: "/cosmos.staking.v1beta1.QueryDelegatorDelegationsRequest",
   encode(message: QueryDelegatorDelegationsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddr !== "") {
+    if (message.delegatorAddr !== undefined) {
       writer.uint32(10).string(message.delegatorAddr);
     }
     if (message.pagination !== undefined) {
@@ -2035,7 +2035,7 @@ function createBaseQueryDelegatorUnbondingDelegationsRequest(): QueryDelegatorUn
 export const QueryDelegatorUnbondingDelegationsRequest = {
   typeUrl: "/cosmos.staking.v1beta1.QueryDelegatorUnbondingDelegationsRequest",
   encode(message: QueryDelegatorUnbondingDelegationsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddr !== "") {
+    if (message.delegatorAddr !== undefined) {
       writer.uint32(10).string(message.delegatorAddr);
     }
     if (message.pagination !== undefined) {
@@ -2267,13 +2267,13 @@ function createBaseQueryRedelegationsRequest(): QueryRedelegationsRequest {
 export const QueryRedelegationsRequest = {
   typeUrl: "/cosmos.staking.v1beta1.QueryRedelegationsRequest",
   encode(message: QueryRedelegationsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddr !== "") {
+    if (message.delegatorAddr !== undefined) {
       writer.uint32(10).string(message.delegatorAddr);
     }
-    if (message.srcValidatorAddr !== "") {
+    if (message.srcValidatorAddr !== undefined) {
       writer.uint32(18).string(message.srcValidatorAddr);
     }
-    if (message.dstValidatorAddr !== "") {
+    if (message.dstValidatorAddr !== undefined) {
       writer.uint32(26).string(message.dstValidatorAddr);
     }
     if (message.pagination !== undefined) {
@@ -2525,7 +2525,7 @@ function createBaseQueryDelegatorValidatorsRequest(): QueryDelegatorValidatorsRe
 export const QueryDelegatorValidatorsRequest = {
   typeUrl: "/cosmos.staking.v1beta1.QueryDelegatorValidatorsRequest",
   encode(message: QueryDelegatorValidatorsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddr !== "") {
+    if (message.delegatorAddr !== undefined) {
       writer.uint32(10).string(message.delegatorAddr);
     }
     if (message.pagination !== undefined) {
@@ -2755,10 +2755,10 @@ function createBaseQueryDelegatorValidatorRequest(): QueryDelegatorValidatorRequ
 export const QueryDelegatorValidatorRequest = {
   typeUrl: "/cosmos.staking.v1beta1.QueryDelegatorValidatorRequest",
   encode(message: QueryDelegatorValidatorRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddr !== "") {
+    if (message.delegatorAddr !== undefined) {
       writer.uint32(10).string(message.delegatorAddr);
     }
-    if (message.validatorAddr !== "") {
+    if (message.validatorAddr !== undefined) {
       writer.uint32(18).string(message.validatorAddr);
     }
     return writer;
@@ -2955,7 +2955,7 @@ function createBaseQueryHistoricalInfoRequest(): QueryHistoricalInfoRequest {
 export const QueryHistoricalInfoRequest = {
   typeUrl: "/cosmos.staking.v1beta1.QueryHistoricalInfoRequest",
   encode(message: QueryHistoricalInfoRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.height !== BigInt(0)) {
+    if (message.height !== undefined) {
       writer.uint32(8).int64(message.height);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/staking/v1beta1/staking.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/staking/v1beta1/staking.ts
@@ -658,13 +658,13 @@ function createBaseCommissionRates(): CommissionRates {
 export const CommissionRates = {
   typeUrl: "/cosmos.staking.v1beta1.CommissionRates",
   encode(message: CommissionRates, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.rate !== "") {
+    if (message.rate !== undefined) {
       writer.uint32(10).string(Decimal.fromUserInput(message.rate, 18).atomics);
     }
-    if (message.maxRate !== "") {
+    if (message.maxRate !== undefined) {
       writer.uint32(18).string(Decimal.fromUserInput(message.maxRate, 18).atomics);
     }
-    if (message.maxChangeRate !== "") {
+    if (message.maxChangeRate !== undefined) {
       writer.uint32(26).string(Decimal.fromUserInput(message.maxChangeRate, 18).atomics);
     }
     return writer;
@@ -891,19 +891,19 @@ function createBaseDescription(): Description {
 export const Description = {
   typeUrl: "/cosmos.staking.v1beta1.Description",
   encode(message: Description, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.moniker !== "") {
+    if (message.moniker !== undefined) {
       writer.uint32(10).string(message.moniker);
     }
-    if (message.identity !== "") {
+    if (message.identity !== undefined) {
       writer.uint32(18).string(message.identity);
     }
-    if (message.website !== "") {
+    if (message.website !== undefined) {
       writer.uint32(26).string(message.website);
     }
-    if (message.securityContact !== "") {
+    if (message.securityContact !== undefined) {
       writer.uint32(34).string(message.securityContact);
     }
-    if (message.details !== "") {
+    if (message.details !== undefined) {
       writer.uint32(42).string(message.details);
     }
     return writer;
@@ -1049,28 +1049,28 @@ function createBaseValidator(): Validator {
 export const Validator = {
   typeUrl: "/cosmos.staking.v1beta1.Validator",
   encode(message: Validator, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.operatorAddress !== "") {
+    if (message.operatorAddress !== undefined) {
       writer.uint32(10).string(message.operatorAddress);
     }
     if (message.consensusPubkey !== undefined) {
       Any.encode(message.consensusPubkey, writer.uint32(18).fork()).ldelim();
     }
-    if (message.jailed === true) {
+    if (message.jailed !== undefined) {
       writer.uint32(24).bool(message.jailed);
     }
     if (message.status !== 0) {
       writer.uint32(32).int32(message.status);
     }
-    if (message.tokens !== "") {
+    if (message.tokens !== undefined) {
       writer.uint32(42).string(message.tokens);
     }
-    if (message.delegatorShares !== "") {
+    if (message.delegatorShares !== undefined) {
       writer.uint32(50).string(Decimal.fromUserInput(message.delegatorShares, 18).atomics);
     }
     if (message.description !== undefined) {
       Description.encode(message.description, writer.uint32(58).fork()).ldelim();
     }
-    if (message.unbondingHeight !== BigInt(0)) {
+    if (message.unbondingHeight !== undefined) {
       writer.uint32(64).int64(message.unbondingHeight);
     }
     if (message.unbondingTime !== undefined) {
@@ -1079,7 +1079,7 @@ export const Validator = {
     if (message.commission !== undefined) {
       Commission.encode(message.commission, writer.uint32(82).fork()).ldelim();
     }
-    if (message.minSelfDelegation !== "") {
+    if (message.minSelfDelegation !== undefined) {
       writer.uint32(90).string(message.minSelfDelegation);
     }
     return writer;
@@ -1394,10 +1394,10 @@ function createBaseDVPair(): DVPair {
 export const DVPair = {
   typeUrl: "/cosmos.staking.v1beta1.DVPair",
   encode(message: DVPair, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddress !== "") {
+    if (message.delegatorAddress !== undefined) {
       writer.uint32(10).string(message.delegatorAddress);
     }
-    if (message.validatorAddress !== "") {
+    if (message.validatorAddress !== undefined) {
       writer.uint32(18).string(message.validatorAddress);
     }
     return writer;
@@ -1606,13 +1606,13 @@ function createBaseDVVTriplet(): DVVTriplet {
 export const DVVTriplet = {
   typeUrl: "/cosmos.staking.v1beta1.DVVTriplet",
   encode(message: DVVTriplet, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddress !== "") {
+    if (message.delegatorAddress !== undefined) {
       writer.uint32(10).string(message.delegatorAddress);
     }
-    if (message.validatorSrcAddress !== "") {
+    if (message.validatorSrcAddress !== undefined) {
       writer.uint32(18).string(message.validatorSrcAddress);
     }
-    if (message.validatorDstAddress !== "") {
+    if (message.validatorDstAddress !== undefined) {
       writer.uint32(26).string(message.validatorDstAddress);
     }
     return writer;
@@ -1832,13 +1832,13 @@ function createBaseDelegation(): Delegation {
 export const Delegation = {
   typeUrl: "/cosmos.staking.v1beta1.Delegation",
   encode(message: Delegation, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddress !== "") {
+    if (message.delegatorAddress !== undefined) {
       writer.uint32(10).string(message.delegatorAddress);
     }
-    if (message.validatorAddress !== "") {
+    if (message.validatorAddress !== undefined) {
       writer.uint32(18).string(message.validatorAddress);
     }
-    if (message.shares !== "") {
+    if (message.shares !== undefined) {
       writer.uint32(26).string(Decimal.fromUserInput(message.shares, 18).atomics);
     }
     return writer;
@@ -1954,10 +1954,10 @@ function createBaseUnbondingDelegation(): UnbondingDelegation {
 export const UnbondingDelegation = {
   typeUrl: "/cosmos.staking.v1beta1.UnbondingDelegation",
   encode(message: UnbondingDelegation, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddress !== "") {
+    if (message.delegatorAddress !== undefined) {
       writer.uint32(10).string(message.delegatorAddress);
     }
-    if (message.validatorAddress !== "") {
+    if (message.validatorAddress !== undefined) {
       writer.uint32(18).string(message.validatorAddress);
     }
     for (const v of message.entries) {
@@ -2089,16 +2089,16 @@ function createBaseUnbondingDelegationEntry(): UnbondingDelegationEntry {
 export const UnbondingDelegationEntry = {
   typeUrl: "/cosmos.staking.v1beta1.UnbondingDelegationEntry",
   encode(message: UnbondingDelegationEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.creationHeight !== BigInt(0)) {
+    if (message.creationHeight !== undefined) {
       writer.uint32(8).int64(message.creationHeight);
     }
     if (message.completionTime !== undefined) {
       Timestamp.encode(toTimestamp(message.completionTime), writer.uint32(18).fork()).ldelim();
     }
-    if (message.initialBalance !== "") {
+    if (message.initialBalance !== undefined) {
       writer.uint32(26).string(message.initialBalance);
     }
-    if (message.balance !== "") {
+    if (message.balance !== undefined) {
       writer.uint32(34).string(message.balance);
     }
     return writer;
@@ -2228,16 +2228,16 @@ function createBaseRedelegationEntry(): RedelegationEntry {
 export const RedelegationEntry = {
   typeUrl: "/cosmos.staking.v1beta1.RedelegationEntry",
   encode(message: RedelegationEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.creationHeight !== BigInt(0)) {
+    if (message.creationHeight !== undefined) {
       writer.uint32(8).int64(message.creationHeight);
     }
     if (message.completionTime !== undefined) {
       Timestamp.encode(toTimestamp(message.completionTime), writer.uint32(18).fork()).ldelim();
     }
-    if (message.initialBalance !== "") {
+    if (message.initialBalance !== undefined) {
       writer.uint32(26).string(message.initialBalance);
     }
-    if (message.sharesDst !== "") {
+    if (message.sharesDst !== undefined) {
       writer.uint32(34).string(Decimal.fromUserInput(message.sharesDst, 18).atomics);
     }
     return writer;
@@ -2367,13 +2367,13 @@ function createBaseRedelegation(): Redelegation {
 export const Redelegation = {
   typeUrl: "/cosmos.staking.v1beta1.Redelegation",
   encode(message: Redelegation, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddress !== "") {
+    if (message.delegatorAddress !== undefined) {
       writer.uint32(10).string(message.delegatorAddress);
     }
-    if (message.validatorSrcAddress !== "") {
+    if (message.validatorSrcAddress !== undefined) {
       writer.uint32(18).string(message.validatorSrcAddress);
     }
-    if (message.validatorDstAddress !== "") {
+    if (message.validatorDstAddress !== undefined) {
       writer.uint32(26).string(message.validatorDstAddress);
     }
     for (const v of message.entries) {
@@ -2521,19 +2521,19 @@ export const Params = {
     if (message.unbondingTime !== undefined) {
       Duration.encode(message.unbondingTime, writer.uint32(10).fork()).ldelim();
     }
-    if (message.maxValidators !== 0) {
+    if (message.maxValidators !== undefined) {
       writer.uint32(16).uint32(message.maxValidators);
     }
-    if (message.maxEntries !== 0) {
+    if (message.maxEntries !== undefined) {
       writer.uint32(24).uint32(message.maxEntries);
     }
-    if (message.historicalEntries !== 0) {
+    if (message.historicalEntries !== undefined) {
       writer.uint32(32).uint32(message.historicalEntries);
     }
-    if (message.bondDenom !== "") {
+    if (message.bondDenom !== undefined) {
       writer.uint32(42).string(message.bondDenom);
     }
-    if (message.minCommissionRate !== "") {
+    if (message.minCommissionRate !== undefined) {
       writer.uint32(50).string(Decimal.fromUserInput(message.minCommissionRate, 18).atomics);
     }
     return writer;
@@ -2797,7 +2797,7 @@ export const RedelegationEntryResponse = {
     if (message.redelegationEntry !== undefined) {
       RedelegationEntry.encode(message.redelegationEntry, writer.uint32(10).fork()).ldelim();
     }
-    if (message.balance !== "") {
+    if (message.balance !== undefined) {
       writer.uint32(34).string(message.balance);
     }
     return writer;
@@ -3024,10 +3024,10 @@ function createBasePool(): Pool {
 export const Pool = {
   typeUrl: "/cosmos.staking.v1beta1.Pool",
   encode(message: Pool, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.notBondedTokens !== "") {
+    if (message.notBondedTokens !== undefined) {
       writer.uint32(10).string(message.notBondedTokens);
     }
-    if (message.bondedTokens !== "") {
+    if (message.bondedTokens !== undefined) {
       writer.uint32(18).string(message.bondedTokens);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/staking/v1beta1/tx.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/staking/v1beta1/tx.ts
@@ -191,13 +191,13 @@ export const MsgCreateValidator = {
     if (message.commission !== undefined) {
       CommissionRates.encode(message.commission, writer.uint32(18).fork()).ldelim();
     }
-    if (message.minSelfDelegation !== "") {
+    if (message.minSelfDelegation !== undefined) {
       writer.uint32(26).string(message.minSelfDelegation);
     }
-    if (message.delegatorAddress !== "") {
+    if (message.delegatorAddress !== undefined) {
       writer.uint32(34).string(message.delegatorAddress);
     }
-    if (message.validatorAddress !== "") {
+    if (message.validatorAddress !== undefined) {
       writer.uint32(42).string(message.validatorAddress);
     }
     if (message.pubkey !== undefined) {
@@ -448,13 +448,13 @@ export const MsgEditValidator = {
     if (message.description !== undefined) {
       Description.encode(message.description, writer.uint32(10).fork()).ldelim();
     }
-    if (message.validatorAddress !== "") {
+    if (message.validatorAddress !== undefined) {
       writer.uint32(18).string(message.validatorAddress);
     }
-    if (message.commissionRate !== "") {
+    if (message.commissionRate !== undefined) {
       writer.uint32(26).string(Decimal.fromUserInput(message.commissionRate, 18).atomics);
     }
-    if (message.minSelfDelegation !== "") {
+    if (message.minSelfDelegation !== undefined) {
       writer.uint32(34).string(message.minSelfDelegation);
     }
     return writer;
@@ -656,10 +656,10 @@ function createBaseMsgDelegate(): MsgDelegate {
 export const MsgDelegate = {
   typeUrl: "/cosmos.staking.v1beta1.MsgDelegate",
   encode(message: MsgDelegate, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddress !== "") {
+    if (message.delegatorAddress !== undefined) {
       writer.uint32(10).string(message.delegatorAddress);
     }
-    if (message.validatorAddress !== "") {
+    if (message.validatorAddress !== undefined) {
       writer.uint32(18).string(message.validatorAddress);
     }
     if (message.amount !== undefined) {
@@ -854,13 +854,13 @@ function createBaseMsgBeginRedelegate(): MsgBeginRedelegate {
 export const MsgBeginRedelegate = {
   typeUrl: "/cosmos.staking.v1beta1.MsgBeginRedelegate",
   encode(message: MsgBeginRedelegate, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddress !== "") {
+    if (message.delegatorAddress !== undefined) {
       writer.uint32(10).string(message.delegatorAddress);
     }
-    if (message.validatorSrcAddress !== "") {
+    if (message.validatorSrcAddress !== undefined) {
       writer.uint32(18).string(message.validatorSrcAddress);
     }
-    if (message.validatorDstAddress !== "") {
+    if (message.validatorDstAddress !== undefined) {
       writer.uint32(26).string(message.validatorDstAddress);
     }
     if (message.amount !== undefined) {
@@ -1084,10 +1084,10 @@ function createBaseMsgUndelegate(): MsgUndelegate {
 export const MsgUndelegate = {
   typeUrl: "/cosmos.staking.v1beta1.MsgUndelegate",
   encode(message: MsgUndelegate, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddress !== "") {
+    if (message.delegatorAddress !== undefined) {
       writer.uint32(10).string(message.delegatorAddress);
     }
-    if (message.validatorAddress !== "") {
+    if (message.validatorAddress !== undefined) {
       writer.uint32(18).string(message.validatorAddress);
     }
     if (message.amount !== undefined) {

--- a/__fixtures__/v-next/outputv4/cosmos/tx/signing/v1beta1/signing.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/tx/signing/v1beta1/signing.ts
@@ -300,7 +300,7 @@ export const SignatureDescriptor = {
     if (message.data !== undefined) {
       SignatureDescriptor_Data.encode(message.data, writer.uint32(18).fork()).ldelim();
     }
-    if (message.sequence !== BigInt(0)) {
+    if (message.sequence !== undefined) {
       writer.uint32(24).uint64(message.sequence);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/tx/v1beta1/service.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/tx/v1beta1/service.ts
@@ -1048,7 +1048,7 @@ function createBaseGetTxRequest(): GetTxRequest {
 export const GetTxRequest = {
   typeUrl: "/cosmos.tx.v1beta1.GetTxRequest",
   encode(message: GetTxRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.hash !== "") {
+    if (message.hash !== undefined) {
       writer.uint32(10).string(message.hash);
     }
     return writer;
@@ -1252,7 +1252,7 @@ function createBaseGetBlockWithTxsRequest(): GetBlockWithTxsRequest {
 export const GetBlockWithTxsRequest = {
   typeUrl: "/cosmos.tx.v1beta1.GetBlockWithTxsRequest",
   encode(message: GetBlockWithTxsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.height !== BigInt(0)) {
+    if (message.height !== undefined) {
       writer.uint32(8).int64(message.height);
     }
     if (message.pagination !== undefined) {

--- a/__fixtures__/v-next/outputv4/cosmos/tx/v1beta1/tx.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/tx/v1beta1/tx.ts
@@ -729,10 +729,10 @@ export const SignDoc = {
     if (message.authInfoBytes.length !== 0) {
       writer.uint32(18).bytes(message.authInfoBytes);
     }
-    if (message.chainId !== "") {
+    if (message.chainId !== undefined) {
       writer.uint32(26).string(message.chainId);
     }
-    if (message.accountNumber !== BigInt(0)) {
+    if (message.accountNumber !== undefined) {
       writer.uint32(32).uint64(message.accountNumber);
     }
     return writer;
@@ -870,13 +870,13 @@ export const SignDocDirectAux = {
     if (message.publicKey !== undefined) {
       Any.encode(message.publicKey, writer.uint32(18).fork()).ldelim();
     }
-    if (message.chainId !== "") {
+    if (message.chainId !== undefined) {
       writer.uint32(26).string(message.chainId);
     }
-    if (message.accountNumber !== BigInt(0)) {
+    if (message.accountNumber !== undefined) {
       writer.uint32(32).uint64(message.accountNumber);
     }
-    if (message.sequence !== BigInt(0)) {
+    if (message.sequence !== undefined) {
       writer.uint32(40).uint64(message.sequence);
     }
     if (message.tip !== undefined) {
@@ -1041,10 +1041,10 @@ export const TxBody = {
     for (const v of message.messages) {
       Any.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.memo !== "") {
+    if (message.memo !== undefined) {
       writer.uint32(18).string(message.memo);
     }
-    if (message.timeoutHeight !== BigInt(0)) {
+    if (message.timeoutHeight !== undefined) {
       writer.uint32(24).uint64(message.timeoutHeight);
     }
     for (const v of message.extensionOptions) {
@@ -1370,7 +1370,7 @@ export const SignerInfo = {
     if (message.modeInfo !== undefined) {
       ModeInfo.encode(message.modeInfo, writer.uint32(18).fork()).ldelim();
     }
-    if (message.sequence !== BigInt(0)) {
+    if (message.sequence !== undefined) {
       writer.uint32(24).uint64(message.sequence);
     }
     return writer;
@@ -1820,13 +1820,13 @@ export const Fee = {
     for (const v of message.amount) {
       Coin.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.gasLimit !== BigInt(0)) {
+    if (message.gasLimit !== undefined) {
       writer.uint32(16).uint64(message.gasLimit);
     }
-    if (message.payer !== "") {
+    if (message.payer !== undefined) {
       writer.uint32(26).string(message.payer);
     }
-    if (message.granter !== "") {
+    if (message.granter !== undefined) {
       writer.uint32(34).string(message.granter);
     }
     return writer;
@@ -1969,7 +1969,7 @@ export const Tip = {
     for (const v of message.amount) {
       Coin.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.tipper !== "") {
+    if (message.tipper !== undefined) {
       writer.uint32(18).string(message.tipper);
     }
     return writer;
@@ -2087,7 +2087,7 @@ function createBaseAuxSignerData(): AuxSignerData {
 export const AuxSignerData = {
   typeUrl: "/cosmos.tx.v1beta1.AuxSignerData",
   encode(message: AuxSignerData, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     if (message.signDoc !== undefined) {

--- a/__fixtures__/v-next/outputv4/cosmos/upgrade/v1beta1/query.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/upgrade/v1beta1/query.ts
@@ -379,7 +379,7 @@ function createBaseQueryAppliedPlanRequest(): QueryAppliedPlanRequest {
 export const QueryAppliedPlanRequest = {
   typeUrl: "/cosmos.upgrade.v1beta1.QueryAppliedPlanRequest",
   encode(message: QueryAppliedPlanRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     return writer;
@@ -471,7 +471,7 @@ function createBaseQueryAppliedPlanResponse(): QueryAppliedPlanResponse {
 export const QueryAppliedPlanResponse = {
   typeUrl: "/cosmos.upgrade.v1beta1.QueryAppliedPlanResponse",
   encode(message: QueryAppliedPlanResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.height !== BigInt(0)) {
+    if (message.height !== undefined) {
       writer.uint32(8).int64(message.height);
     }
     return writer;
@@ -565,7 +565,7 @@ function createBaseQueryUpgradedConsensusStateRequest(): QueryUpgradedConsensusS
 export const QueryUpgradedConsensusStateRequest = {
   typeUrl: "/cosmos.upgrade.v1beta1.QueryUpgradedConsensusStateRequest",
   encode(message: QueryUpgradedConsensusStateRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.lastHeight !== BigInt(0)) {
+    if (message.lastHeight !== undefined) {
       writer.uint32(8).int64(message.lastHeight);
     }
     return writer;
@@ -751,7 +751,7 @@ function createBaseQueryModuleVersionsRequest(): QueryModuleVersionsRequest {
 export const QueryModuleVersionsRequest = {
   typeUrl: "/cosmos.upgrade.v1beta1.QueryModuleVersionsRequest",
   encode(message: QueryModuleVersionsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.moduleName !== "") {
+    if (message.moduleName !== undefined) {
       writer.uint32(10).string(message.moduleName);
     }
     return writer;
@@ -1020,7 +1020,7 @@ function createBaseQueryAuthorityResponse(): QueryAuthorityResponse {
 export const QueryAuthorityResponse = {
   typeUrl: "/cosmos.upgrade.v1beta1.QueryAuthorityResponse",
   encode(message: QueryAuthorityResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/upgrade/v1beta1/tx.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/upgrade/v1beta1/tx.ts
@@ -88,7 +88,7 @@ function createBaseMsgSoftwareUpgrade(): MsgSoftwareUpgrade {
 export const MsgSoftwareUpgrade = {
   typeUrl: "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
   encode(message: MsgSoftwareUpgrade, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.authority !== "") {
+    if (message.authority !== undefined) {
       writer.uint32(10).string(message.authority);
     }
     if (message.plan !== undefined) {
@@ -269,7 +269,7 @@ function createBaseMsgCancelUpgrade(): MsgCancelUpgrade {
 export const MsgCancelUpgrade = {
   typeUrl: "/cosmos.upgrade.v1beta1.MsgCancelUpgrade",
   encode(message: MsgCancelUpgrade, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.authority !== "") {
+    if (message.authority !== undefined) {
       writer.uint32(10).string(message.authority);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/upgrade/v1beta1/upgrade.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/upgrade/v1beta1/upgrade.ts
@@ -144,16 +144,16 @@ function createBasePlan(): Plan {
 export const Plan = {
   typeUrl: "/cosmos.upgrade.v1beta1.Plan",
   encode(message: Plan, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     if (message.time !== undefined) {
       Timestamp.encode(toTimestamp(message.time), writer.uint32(18).fork()).ldelim();
     }
-    if (message.height !== BigInt(0)) {
+    if (message.height !== undefined) {
       writer.uint32(24).int64(message.height);
     }
-    if (message.info !== "") {
+    if (message.info !== undefined) {
       writer.uint32(34).string(message.info);
     }
     if (message.upgradedClientState !== undefined) {
@@ -298,10 +298,10 @@ function createBaseSoftwareUpgradeProposal(): SoftwareUpgradeProposal {
 export const SoftwareUpgradeProposal = {
   typeUrl: "/cosmos.upgrade.v1beta1.SoftwareUpgradeProposal",
   encode(message: SoftwareUpgradeProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
     if (message.plan !== undefined) {
@@ -421,10 +421,10 @@ function createBaseCancelSoftwareUpgradeProposal(): CancelSoftwareUpgradeProposa
 export const CancelSoftwareUpgradeProposal = {
   typeUrl: "/cosmos.upgrade.v1beta1.CancelSoftwareUpgradeProposal",
   encode(message: CancelSoftwareUpgradeProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
     return writer;
@@ -528,10 +528,10 @@ function createBaseModuleVersion(): ModuleVersion {
 export const ModuleVersion = {
   typeUrl: "/cosmos.upgrade.v1beta1.ModuleVersion",
   encode(message: ModuleVersion, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.version !== BigInt(0)) {
+    if (message.version !== undefined) {
       writer.uint32(16).uint64(message.version);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmos/vesting/v1beta1/tx.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/vesting/v1beta1/tx.ts
@@ -117,19 +117,19 @@ function createBaseMsgCreateVestingAccount(): MsgCreateVestingAccount {
 export const MsgCreateVestingAccount = {
   typeUrl: "/cosmos.vesting.v1beta1.MsgCreateVestingAccount",
   encode(message: MsgCreateVestingAccount, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.fromAddress !== "") {
+    if (message.fromAddress !== undefined) {
       writer.uint32(10).string(message.fromAddress);
     }
-    if (message.toAddress !== "") {
+    if (message.toAddress !== undefined) {
       writer.uint32(18).string(message.toAddress);
     }
     for (const v of message.amount) {
       Coin.encode(v!, writer.uint32(26).fork()).ldelim();
     }
-    if (message.endTime !== BigInt(0)) {
+    if (message.endTime !== undefined) {
       writer.uint32(32).int64(message.endTime);
     }
-    if (message.delayed === true) {
+    if (message.delayed !== undefined) {
       writer.uint32(40).bool(message.delayed);
     }
     return writer;
@@ -354,10 +354,10 @@ function createBaseMsgCreatePermanentLockedAccount(): MsgCreatePermanentLockedAc
 export const MsgCreatePermanentLockedAccount = {
   typeUrl: "/cosmos.vesting.v1beta1.MsgCreatePermanentLockedAccount",
   encode(message: MsgCreatePermanentLockedAccount, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.fromAddress !== "") {
+    if (message.fromAddress !== undefined) {
       writer.uint32(10).string(message.fromAddress);
     }
-    if (message.toAddress !== "") {
+    if (message.toAddress !== undefined) {
       writer.uint32(18).string(message.toAddress);
     }
     for (const v of message.amount) {
@@ -562,13 +562,13 @@ function createBaseMsgCreatePeriodicVestingAccount(): MsgCreatePeriodicVestingAc
 export const MsgCreatePeriodicVestingAccount = {
   typeUrl: "/cosmos.vesting.v1beta1.MsgCreatePeriodicVestingAccount",
   encode(message: MsgCreatePeriodicVestingAccount, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.fromAddress !== "") {
+    if (message.fromAddress !== undefined) {
       writer.uint32(10).string(message.fromAddress);
     }
-    if (message.toAddress !== "") {
+    if (message.toAddress !== undefined) {
       writer.uint32(18).string(message.toAddress);
     }
-    if (message.startTime !== BigInt(0)) {
+    if (message.startTime !== undefined) {
       writer.uint32(24).int64(message.startTime);
     }
     for (const v of message.vestingPeriods) {

--- a/__fixtures__/v-next/outputv4/cosmos/vesting/v1beta1/vesting.ts
+++ b/__fixtures__/v-next/outputv4/cosmos/vesting/v1beta1/vesting.ts
@@ -153,7 +153,7 @@ export const BaseVestingAccount = {
     for (const v of message.delegatedVesting) {
       Coin.encode(v!, writer.uint32(34).fork()).ldelim();
     }
-    if (message.endTime !== BigInt(0)) {
+    if (message.endTime !== undefined) {
       writer.uint32(40).int64(message.endTime);
     }
     return writer;
@@ -333,7 +333,7 @@ export const ContinuousVestingAccount = {
     if (message.baseVestingAccount !== undefined) {
       BaseVestingAccount.encode(message.baseVestingAccount, writer.uint32(10).fork()).ldelim();
     }
-    if (message.startTime !== BigInt(0)) {
+    if (message.startTime !== undefined) {
       writer.uint32(16).int64(message.startTime);
     }
     return writer;
@@ -535,7 +535,7 @@ function createBasePeriod(): Period {
 export const Period = {
   typeUrl: "/cosmos.vesting.v1beta1.Period",
   encode(message: Period, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.length !== BigInt(0)) {
+    if (message.length !== undefined) {
       writer.uint32(8).int64(message.length);
     }
     for (const v of message.amount) {
@@ -660,7 +660,7 @@ export const PeriodicVestingAccount = {
     if (message.baseVestingAccount !== undefined) {
       BaseVestingAccount.encode(message.baseVestingAccount, writer.uint32(10).fork()).ldelim();
     }
-    if (message.startTime !== BigInt(0)) {
+    if (message.startTime !== undefined) {
       writer.uint32(16).int64(message.startTime);
     }
     for (const v of message.vestingPeriods) {

--- a/__fixtures__/v-next/outputv4/cosmos_proto/cosmos.ts
+++ b/__fixtures__/v-next/outputv4/cosmos_proto/cosmos.ts
@@ -126,10 +126,10 @@ function createBaseInterfaceDescriptor(): InterfaceDescriptor {
 export const InterfaceDescriptor = {
   typeUrl: "/cosmos_proto.InterfaceDescriptor",
   encode(message: InterfaceDescriptor, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
     return writer;
@@ -228,10 +228,10 @@ function createBaseScalarDescriptor(): ScalarDescriptor {
 export const ScalarDescriptor = {
   typeUrl: "/cosmos_proto.ScalarDescriptor",
   encode(message: ScalarDescriptor, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
     writer.uint32(26).fork();

--- a/__fixtures__/v-next/outputv4/cosmwasm/wasm/v1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/cosmwasm/wasm/v1/genesis.ts
@@ -435,7 +435,7 @@ function createBaseCode(): Code {
 export const Code = {
   typeUrl: "/cosmwasm.wasm.v1.Code",
   encode(message: Code, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.codeId !== BigInt(0)) {
+    if (message.codeId !== undefined) {
       writer.uint32(8).uint64(message.codeId);
     }
     if (message.codeInfo !== undefined) {
@@ -444,7 +444,7 @@ export const Code = {
     if (message.codeBytes.length !== 0) {
       writer.uint32(26).bytes(message.codeBytes);
     }
-    if (message.pinned === true) {
+    if (message.pinned !== undefined) {
       writer.uint32(32).bool(message.pinned);
     }
     return writer;
@@ -575,7 +575,7 @@ function createBaseContract(): Contract {
 export const Contract = {
   typeUrl: "/cosmwasm.wasm.v1.Contract",
   encode(message: Contract, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.contractAddress !== "") {
+    if (message.contractAddress !== undefined) {
       writer.uint32(10).string(message.contractAddress);
     }
     if (message.contractInfo !== undefined) {
@@ -713,7 +713,7 @@ export const Sequence = {
     if (message.idKey.length !== 0) {
       writer.uint32(10).bytes(message.idKey);
     }
-    if (message.value !== BigInt(0)) {
+    if (message.value !== undefined) {
       writer.uint32(16).uint64(message.value);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmwasm/wasm/v1/ibc.ts
+++ b/__fixtures__/v-next/outputv4/cosmwasm/wasm/v1/ibc.ts
@@ -55,13 +55,13 @@ function createBaseMsgIBCSend(): MsgIBCSend {
 export const MsgIBCSend = {
   typeUrl: "/cosmwasm.wasm.v1.MsgIBCSend",
   encode(message: MsgIBCSend, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.channel !== "") {
+    if (message.channel !== undefined) {
       writer.uint32(18).string(message.channel);
     }
-    if (message.timeoutHeight !== BigInt(0)) {
+    if (message.timeoutHeight !== undefined) {
       writer.uint32(32).uint64(message.timeoutHeight);
     }
-    if (message.timeoutTimestamp !== BigInt(0)) {
+    if (message.timeoutTimestamp !== undefined) {
       writer.uint32(40).uint64(message.timeoutTimestamp);
     }
     if (message.data.length !== 0) {
@@ -193,7 +193,7 @@ function createBaseMsgIBCCloseChannel(): MsgIBCCloseChannel {
 export const MsgIBCCloseChannel = {
   typeUrl: "/cosmwasm.wasm.v1.MsgIBCCloseChannel",
   encode(message: MsgIBCCloseChannel, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.channel !== "") {
+    if (message.channel !== undefined) {
       writer.uint32(18).string(message.channel);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmwasm/wasm/v1/proposal.ts
+++ b/__fixtures__/v-next/outputv4/cosmwasm/wasm/v1/proposal.ts
@@ -259,13 +259,13 @@ function createBaseStoreCodeProposal(): StoreCodeProposal {
 export const StoreCodeProposal = {
   typeUrl: "/cosmwasm.wasm.v1.StoreCodeProposal",
   encode(message: StoreCodeProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
-    if (message.runAs !== "") {
+    if (message.runAs !== undefined) {
       writer.uint32(26).string(message.runAs);
     }
     if (message.wasmByteCode.length !== 0) {
@@ -416,22 +416,22 @@ function createBaseInstantiateContractProposal(): InstantiateContractProposal {
 export const InstantiateContractProposal = {
   typeUrl: "/cosmwasm.wasm.v1.InstantiateContractProposal",
   encode(message: InstantiateContractProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
-    if (message.runAs !== "") {
+    if (message.runAs !== undefined) {
       writer.uint32(26).string(message.runAs);
     }
-    if (message.admin !== "") {
+    if (message.admin !== undefined) {
       writer.uint32(34).string(message.admin);
     }
-    if (message.codeId !== BigInt(0)) {
+    if (message.codeId !== undefined) {
       writer.uint32(40).uint64(message.codeId);
     }
-    if (message.label !== "") {
+    if (message.label !== undefined) {
       writer.uint32(50).string(message.label);
     }
     if (message.msg.length !== 0) {
@@ -624,16 +624,16 @@ function createBaseMigrateContractProposal(): MigrateContractProposal {
 export const MigrateContractProposal = {
   typeUrl: "/cosmwasm.wasm.v1.MigrateContractProposal",
   encode(message: MigrateContractProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
-    if (message.contract !== "") {
+    if (message.contract !== undefined) {
       writer.uint32(34).string(message.contract);
     }
-    if (message.codeId !== BigInt(0)) {
+    if (message.codeId !== undefined) {
       writer.uint32(40).uint64(message.codeId);
     }
     if (message.msg.length !== 0) {
@@ -777,13 +777,13 @@ function createBaseSudoContractProposal(): SudoContractProposal {
 export const SudoContractProposal = {
   typeUrl: "/cosmwasm.wasm.v1.SudoContractProposal",
   encode(message: SudoContractProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
-    if (message.contract !== "") {
+    if (message.contract !== undefined) {
       writer.uint32(26).string(message.contract);
     }
     if (message.msg.length !== 0) {
@@ -916,16 +916,16 @@ function createBaseExecuteContractProposal(): ExecuteContractProposal {
 export const ExecuteContractProposal = {
   typeUrl: "/cosmwasm.wasm.v1.ExecuteContractProposal",
   encode(message: ExecuteContractProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
-    if (message.runAs !== "") {
+    if (message.runAs !== undefined) {
       writer.uint32(26).string(message.runAs);
     }
-    if (message.contract !== "") {
+    if (message.contract !== undefined) {
       writer.uint32(34).string(message.contract);
     }
     if (message.msg.length !== 0) {
@@ -1093,16 +1093,16 @@ function createBaseUpdateAdminProposal(): UpdateAdminProposal {
 export const UpdateAdminProposal = {
   typeUrl: "/cosmwasm.wasm.v1.UpdateAdminProposal",
   encode(message: UpdateAdminProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
-    if (message.newAdmin !== "") {
+    if (message.newAdmin !== undefined) {
       writer.uint32(26).string(message.newAdmin);
     }
-    if (message.contract !== "") {
+    if (message.contract !== undefined) {
       writer.uint32(34).string(message.contract);
     }
     return writer;
@@ -1229,13 +1229,13 @@ function createBaseClearAdminProposal(): ClearAdminProposal {
 export const ClearAdminProposal = {
   typeUrl: "/cosmwasm.wasm.v1.ClearAdminProposal",
   encode(message: ClearAdminProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
-    if (message.contract !== "") {
+    if (message.contract !== undefined) {
       writer.uint32(26).string(message.contract);
     }
     return writer;
@@ -1351,10 +1351,10 @@ function createBasePinCodesProposal(): PinCodesProposal {
 export const PinCodesProposal = {
   typeUrl: "/cosmwasm.wasm.v1.PinCodesProposal",
   encode(message: PinCodesProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
     writer.uint32(26).fork();
@@ -1494,10 +1494,10 @@ function createBaseUnpinCodesProposal(): UnpinCodesProposal {
 export const UnpinCodesProposal = {
   typeUrl: "/cosmwasm.wasm.v1.UnpinCodesProposal",
   encode(message: UnpinCodesProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
     writer.uint32(26).fork();

--- a/__fixtures__/v-next/outputv4/cosmwasm/wasm/v1/query.ts
+++ b/__fixtures__/v-next/outputv4/cosmwasm/wasm/v1/query.ts
@@ -376,7 +376,7 @@ function createBaseQueryContractInfoRequest(): QueryContractInfoRequest {
 export const QueryContractInfoRequest = {
   typeUrl: "/cosmwasm.wasm.v1.QueryContractInfoRequest",
   encode(message: QueryContractInfoRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     return writer;
@@ -469,7 +469,7 @@ function createBaseQueryContractInfoResponse(): QueryContractInfoResponse {
 export const QueryContractInfoResponse = {
   typeUrl: "/cosmwasm.wasm.v1.QueryContractInfoResponse",
   encode(message: QueryContractInfoResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     if (message.contractInfo !== undefined) {
@@ -578,7 +578,7 @@ function createBaseQueryContractHistoryRequest(): QueryContractHistoryRequest {
 export const QueryContractHistoryRequest = {
   typeUrl: "/cosmwasm.wasm.v1.QueryContractHistoryRequest",
   encode(message: QueryContractHistoryRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     if (message.pagination !== undefined) {
@@ -808,7 +808,7 @@ function createBaseQueryContractsByCodeRequest(): QueryContractsByCodeRequest {
 export const QueryContractsByCodeRequest = {
   typeUrl: "/cosmwasm.wasm.v1.QueryContractsByCodeRequest",
   encode(message: QueryContractsByCodeRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.codeId !== BigInt(0)) {
+    if (message.codeId !== undefined) {
       writer.uint32(8).uint64(message.codeId);
     }
     if (message.pagination !== undefined) {
@@ -1040,7 +1040,7 @@ function createBaseQueryAllContractStateRequest(): QueryAllContractStateRequest 
 export const QueryAllContractStateRequest = {
   typeUrl: "/cosmwasm.wasm.v1.QueryAllContractStateRequest",
   encode(message: QueryAllContractStateRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     if (message.pagination !== undefined) {
@@ -1270,7 +1270,7 @@ function createBaseQueryRawContractStateRequest(): QueryRawContractStateRequest 
 export const QueryRawContractStateRequest = {
   typeUrl: "/cosmwasm.wasm.v1.QueryRawContractStateRequest",
   encode(message: QueryRawContractStateRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     if (message.queryData.length !== 0) {
@@ -1469,7 +1469,7 @@ function createBaseQuerySmartContractStateRequest(): QuerySmartContractStateRequ
 export const QuerySmartContractStateRequest = {
   typeUrl: "/cosmwasm.wasm.v1.QuerySmartContractStateRequest",
   encode(message: QuerySmartContractStateRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     if (message.queryData.length !== 0) {
@@ -1667,7 +1667,7 @@ function createBaseQueryCodeRequest(): QueryCodeRequest {
 export const QueryCodeRequest = {
   typeUrl: "/cosmwasm.wasm.v1.QueryCodeRequest",
   encode(message: QueryCodeRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.codeId !== BigInt(0)) {
+    if (message.codeId !== undefined) {
       writer.uint32(8).uint64(message.codeId);
     }
     return writer;
@@ -1763,10 +1763,10 @@ function createBaseCodeInfoResponse(): CodeInfoResponse {
 export const CodeInfoResponse = {
   typeUrl: "/cosmwasm.wasm.v1.CodeInfoResponse",
   encode(message: CodeInfoResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.codeId !== BigInt(0)) {
+    if (message.codeId !== undefined) {
       writer.uint32(8).uint64(message.codeId);
     }
-    if (message.creator !== "") {
+    if (message.creator !== undefined) {
       writer.uint32(18).string(message.creator);
     }
     if (message.dataHash.length !== 0) {

--- a/__fixtures__/v-next/outputv4/cosmwasm/wasm/v1/tx.ts
+++ b/__fixtures__/v-next/outputv4/cosmwasm/wasm/v1/tx.ts
@@ -223,7 +223,7 @@ function createBaseMsgStoreCode(): MsgStoreCode {
 export const MsgStoreCode = {
   typeUrl: "/cosmwasm.wasm.v1.MsgStoreCode",
   encode(message: MsgStoreCode, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
     if (message.wasmByteCode.length !== 0) {
@@ -345,7 +345,7 @@ function createBaseMsgStoreCodeResponse(): MsgStoreCodeResponse {
 export const MsgStoreCodeResponse = {
   typeUrl: "/cosmwasm.wasm.v1.MsgStoreCodeResponse",
   encode(message: MsgStoreCodeResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.codeId !== BigInt(0)) {
+    if (message.codeId !== undefined) {
       writer.uint32(8).uint64(message.codeId);
     }
     return writer;
@@ -444,16 +444,16 @@ function createBaseMsgInstantiateContract(): MsgInstantiateContract {
 export const MsgInstantiateContract = {
   typeUrl: "/cosmwasm.wasm.v1.MsgInstantiateContract",
   encode(message: MsgInstantiateContract, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
-    if (message.admin !== "") {
+    if (message.admin !== undefined) {
       writer.uint32(18).string(message.admin);
     }
-    if (message.codeId !== BigInt(0)) {
+    if (message.codeId !== undefined) {
       writer.uint32(24).uint64(message.codeId);
     }
-    if (message.label !== "") {
+    if (message.label !== undefined) {
       writer.uint32(34).string(message.label);
     }
     if (message.msg.length !== 0) {
@@ -621,7 +621,7 @@ function createBaseMsgInstantiateContractResponse(): MsgInstantiateContractRespo
 export const MsgInstantiateContractResponse = {
   typeUrl: "/cosmwasm.wasm.v1.MsgInstantiateContractResponse",
   encode(message: MsgInstantiateContractResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     if (message.data.length !== 0) {
@@ -730,10 +730,10 @@ function createBaseMsgExecuteContract(): MsgExecuteContract {
 export const MsgExecuteContract = {
   typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
   encode(message: MsgExecuteContract, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
-    if (message.contract !== "") {
+    if (message.contract !== undefined) {
       writer.uint32(18).string(message.contract);
     }
     if (message.msg.length !== 0) {
@@ -971,13 +971,13 @@ function createBaseMsgMigrateContract(): MsgMigrateContract {
 export const MsgMigrateContract = {
   typeUrl: "/cosmwasm.wasm.v1.MsgMigrateContract",
   encode(message: MsgMigrateContract, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
-    if (message.contract !== "") {
+    if (message.contract !== undefined) {
       writer.uint32(18).string(message.contract);
     }
-    if (message.codeId !== BigInt(0)) {
+    if (message.codeId !== undefined) {
       writer.uint32(24).uint64(message.codeId);
     }
     if (message.msg.length !== 0) {
@@ -1201,13 +1201,13 @@ function createBaseMsgUpdateAdmin(): MsgUpdateAdmin {
 export const MsgUpdateAdmin = {
   typeUrl: "/cosmwasm.wasm.v1.MsgUpdateAdmin",
   encode(message: MsgUpdateAdmin, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
-    if (message.newAdmin !== "") {
+    if (message.newAdmin !== undefined) {
       writer.uint32(18).string(message.newAdmin);
     }
-    if (message.contract !== "") {
+    if (message.contract !== undefined) {
       writer.uint32(26).string(message.contract);
     }
     return writer;
@@ -1395,10 +1395,10 @@ function createBaseMsgClearAdmin(): MsgClearAdmin {
 export const MsgClearAdmin = {
   typeUrl: "/cosmwasm.wasm.v1.MsgClearAdmin",
   encode(message: MsgClearAdmin, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
-    if (message.contract !== "") {
+    if (message.contract !== undefined) {
       writer.uint32(26).string(message.contract);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/cosmwasm/wasm/v1/types.ts
+++ b/__fixtures__/v-next/outputv4/cosmwasm/wasm/v1/types.ts
@@ -362,7 +362,7 @@ export const AccessConfig = {
     if (message.permission !== 0) {
       writer.uint32(8).int32(message.permission);
     }
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(18).string(message.address);
     }
     return writer;
@@ -473,7 +473,7 @@ export const Params = {
     if (message.instantiateDefaultPermission !== 0) {
       writer.uint32(16).int32(message.instantiateDefaultPermission);
     }
-    if (message.maxWasmCodeSize !== BigInt(0)) {
+    if (message.maxWasmCodeSize !== undefined) {
       writer.uint32(24).uint64(message.maxWasmCodeSize);
     }
     return writer;
@@ -596,7 +596,7 @@ export const CodeInfo = {
     if (message.codeHash.length !== 0) {
       writer.uint32(10).bytes(message.codeHash);
     }
-    if (message.creator !== "") {
+    if (message.creator !== undefined) {
       writer.uint32(18).string(message.creator);
     }
     if (message.instantiateConfig !== undefined) {
@@ -721,22 +721,22 @@ function createBaseContractInfo(): ContractInfo {
 export const ContractInfo = {
   typeUrl: "/cosmwasm.wasm.v1.ContractInfo",
   encode(message: ContractInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.codeId !== BigInt(0)) {
+    if (message.codeId !== undefined) {
       writer.uint32(8).uint64(message.codeId);
     }
-    if (message.creator !== "") {
+    if (message.creator !== undefined) {
       writer.uint32(18).string(message.creator);
     }
-    if (message.admin !== "") {
+    if (message.admin !== undefined) {
       writer.uint32(26).string(message.admin);
     }
-    if (message.label !== "") {
+    if (message.label !== undefined) {
       writer.uint32(34).string(message.label);
     }
     if (message.created !== undefined) {
       AbsoluteTxPosition.encode(message.created, writer.uint32(42).fork()).ldelim();
     }
-    if (message.ibcPortId !== "") {
+    if (message.ibcPortId !== undefined) {
       writer.uint32(50).string(message.ibcPortId);
     }
     if (message.extension !== undefined) {
@@ -909,7 +909,7 @@ export const ContractCodeHistoryEntry = {
     if (message.operation !== 0) {
       writer.uint32(8).int32(message.operation);
     }
-    if (message.codeId !== BigInt(0)) {
+    if (message.codeId !== undefined) {
       writer.uint32(16).uint64(message.codeId);
     }
     if (message.updated !== undefined) {
@@ -1045,10 +1045,10 @@ function createBaseAbsoluteTxPosition(): AbsoluteTxPosition {
 export const AbsoluteTxPosition = {
   typeUrl: "/cosmwasm.wasm.v1.AbsoluteTxPosition",
   encode(message: AbsoluteTxPosition, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.blockHeight !== BigInt(0)) {
+    if (message.blockHeight !== undefined) {
       writer.uint32(8).uint64(message.blockHeight);
     }
-    if (message.txIndex !== BigInt(0)) {
+    if (message.txIndex !== undefined) {
       writer.uint32(16).uint64(message.txIndex);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/evmos/claims/v1/claims.ts
+++ b/__fixtures__/v-next/outputv4/evmos/claims/v1/claims.ts
@@ -135,10 +135,10 @@ export const Claim = {
     if (message.action !== 0) {
       writer.uint32(8).int32(message.action);
     }
-    if (message.completed === true) {
+    if (message.completed !== undefined) {
       writer.uint32(16).bool(message.completed);
     }
-    if (message.claimableAmount !== "") {
+    if (message.claimableAmount !== undefined) {
       writer.uint32(26).string(message.claimableAmount);
     }
     return writer;
@@ -248,10 +248,10 @@ function createBaseClaimsRecordAddress(): ClaimsRecordAddress {
 export const ClaimsRecordAddress = {
   typeUrl: "/evmos.claims.v1.ClaimsRecordAddress",
   encode(message: ClaimsRecordAddress, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
-    if (message.initialClaimableAmount !== "") {
+    if (message.initialClaimableAmount !== undefined) {
       writer.uint32(18).string(message.initialClaimableAmount);
     }
     writer.uint32(26).fork();
@@ -384,7 +384,7 @@ function createBaseClaimsRecord(): ClaimsRecord {
 export const ClaimsRecord = {
   typeUrl: "/evmos.claims.v1.ClaimsRecord",
   encode(message: ClaimsRecord, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.initialClaimableAmount !== "") {
+    if (message.initialClaimableAmount !== undefined) {
       writer.uint32(10).string(message.initialClaimableAmount);
     }
     writer.uint32(18).fork();

--- a/__fixtures__/v-next/outputv4/evmos/claims/v1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/evmos/claims/v1/genesis.ts
@@ -183,7 +183,7 @@ function createBaseParams(): Params {
 export const Params = {
   typeUrl: "/evmos.claims.v1.Params",
   encode(message: Params, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.enableClaims === true) {
+    if (message.enableClaims !== undefined) {
       writer.uint32(8).bool(message.enableClaims);
     }
     if (message.airdropStartTime !== undefined) {
@@ -195,7 +195,7 @@ export const Params = {
     if (message.durationOfDecay !== undefined) {
       Duration.encode(message.durationOfDecay, writer.uint32(34).fork()).ldelim();
     }
-    if (message.claimsDenom !== "") {
+    if (message.claimsDenom !== undefined) {
       writer.uint32(42).string(message.claimsDenom);
     }
     for (const v of message.authorizedChannels) {

--- a/__fixtures__/v-next/outputv4/evmos/claims/v1/query.ts
+++ b/__fixtures__/v-next/outputv4/evmos/claims/v1/query.ts
@@ -672,7 +672,7 @@ function createBaseQueryClaimsRecordRequest(): QueryClaimsRecordRequest {
 export const QueryClaimsRecordRequest = {
   typeUrl: "/evmos.claims.v1.QueryClaimsRecordRequest",
   encode(message: QueryClaimsRecordRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     return writer;
@@ -759,7 +759,7 @@ function createBaseQueryClaimsRecordResponse(): QueryClaimsRecordResponse {
 export const QueryClaimsRecordResponse = {
   typeUrl: "/evmos.claims.v1.QueryClaimsRecordResponse",
   encode(message: QueryClaimsRecordResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.initialClaimableAmount !== "") {
+    if (message.initialClaimableAmount !== undefined) {
       writer.uint32(10).string(message.initialClaimableAmount);
     }
     for (const v of message.claims) {

--- a/__fixtures__/v-next/outputv4/evmos/epochs/v1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/evmos/epochs/v1/genesis.ts
@@ -51,7 +51,7 @@ function createBaseEpochInfo(): EpochInfo {
 export const EpochInfo = {
   typeUrl: "/evmos.epochs.v1.EpochInfo",
   encode(message: EpochInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.identifier !== "") {
+    if (message.identifier !== undefined) {
       writer.uint32(10).string(message.identifier);
     }
     if (message.startTime !== undefined) {
@@ -60,16 +60,16 @@ export const EpochInfo = {
     if (message.duration !== undefined) {
       Duration.encode(message.duration, writer.uint32(26).fork()).ldelim();
     }
-    if (message.currentEpoch !== BigInt(0)) {
+    if (message.currentEpoch !== undefined) {
       writer.uint32(32).int64(message.currentEpoch);
     }
     if (message.currentEpochStartTime !== undefined) {
       Timestamp.encode(toTimestamp(message.currentEpochStartTime), writer.uint32(42).fork()).ldelim();
     }
-    if (message.epochCountingStarted === true) {
+    if (message.epochCountingStarted !== undefined) {
       writer.uint32(48).bool(message.epochCountingStarted);
     }
-    if (message.currentEpochStartHeight !== BigInt(0)) {
+    if (message.currentEpochStartHeight !== undefined) {
       writer.uint32(56).int64(message.currentEpochStartHeight);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/evmos/epochs/v1/query.ts
+++ b/__fixtures__/v-next/outputv4/evmos/epochs/v1/query.ts
@@ -256,7 +256,7 @@ function createBaseQueryCurrentEpochRequest(): QueryCurrentEpochRequest {
 export const QueryCurrentEpochRequest = {
   typeUrl: "/evmos.epochs.v1.QueryCurrentEpochRequest",
   encode(message: QueryCurrentEpochRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.identifier !== "") {
+    if (message.identifier !== undefined) {
       writer.uint32(10).string(message.identifier);
     }
     return writer;
@@ -342,7 +342,7 @@ function createBaseQueryCurrentEpochResponse(): QueryCurrentEpochResponse {
 export const QueryCurrentEpochResponse = {
   typeUrl: "/evmos.epochs.v1.QueryCurrentEpochResponse",
   encode(message: QueryCurrentEpochResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.currentEpoch !== BigInt(0)) {
+    if (message.currentEpoch !== undefined) {
       writer.uint32(8).int64(message.currentEpoch);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/evmos/erc20/v1/erc20.ts
+++ b/__fixtures__/v-next/outputv4/evmos/erc20/v1/erc20.ts
@@ -160,13 +160,13 @@ function createBaseTokenPair(): TokenPair {
 export const TokenPair = {
   typeUrl: "/evmos.erc20.v1.TokenPair",
   encode(message: TokenPair, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.erc20Address !== "") {
+    if (message.erc20Address !== undefined) {
       writer.uint32(10).string(message.erc20Address);
     }
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(18).string(message.denom);
     }
-    if (message.enabled === true) {
+    if (message.enabled !== undefined) {
       writer.uint32(24).bool(message.enabled);
     }
     if (message.contractOwner !== 0) {
@@ -290,10 +290,10 @@ function createBaseRegisterCoinProposal(): RegisterCoinProposal {
 export const RegisterCoinProposal = {
   typeUrl: "/evmos.erc20.v1.RegisterCoinProposal",
   encode(message: RegisterCoinProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
     if (message.metadata !== undefined) {
@@ -408,13 +408,13 @@ function createBaseRegisterERC20Proposal(): RegisterERC20Proposal {
 export const RegisterERC20Proposal = {
   typeUrl: "/evmos.erc20.v1.RegisterERC20Proposal",
   encode(message: RegisterERC20Proposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
-    if (message.erc20address !== "") {
+    if (message.erc20address !== undefined) {
       writer.uint32(26).string(message.erc20address);
     }
     return writer;
@@ -524,13 +524,13 @@ function createBaseToggleTokenConversionProposal(): ToggleTokenConversionProposa
 export const ToggleTokenConversionProposal = {
   typeUrl: "/evmos.erc20.v1.ToggleTokenConversionProposal",
   encode(message: ToggleTokenConversionProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
-    if (message.token !== "") {
+    if (message.token !== undefined) {
       writer.uint32(26).string(message.token);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/evmos/erc20/v1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/evmos/erc20/v1/genesis.ts
@@ -162,10 +162,10 @@ function createBaseParams(): Params {
 export const Params = {
   typeUrl: "/evmos.erc20.v1.Params",
   encode(message: Params, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.enableErc20 === true) {
+    if (message.enableErc20 !== undefined) {
       writer.uint32(8).bool(message.enableErc20);
     }
-    if (message.enableEvmHook === true) {
+    if (message.enableEvmHook !== undefined) {
       writer.uint32(16).bool(message.enableEvmHook);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/evmos/erc20/v1/query.ts
+++ b/__fixtures__/v-next/outputv4/evmos/erc20/v1/query.ts
@@ -315,7 +315,7 @@ function createBaseQueryTokenPairRequest(): QueryTokenPairRequest {
 export const QueryTokenPairRequest = {
   typeUrl: "/evmos.erc20.v1.QueryTokenPairRequest",
   encode(message: QueryTokenPairRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.token !== "") {
+    if (message.token !== undefined) {
       writer.uint32(10).string(message.token);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/evmos/erc20/v1/tx.ts
+++ b/__fixtures__/v-next/outputv4/evmos/erc20/v1/tx.ts
@@ -81,10 +81,10 @@ export const MsgConvertCoin = {
     if (message.coin !== undefined) {
       Coin.encode(message.coin, writer.uint32(10).fork()).ldelim();
     }
-    if (message.receiver !== "") {
+    if (message.receiver !== undefined) {
       writer.uint32(18).string(message.receiver);
     }
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(26).string(message.sender);
     }
     return writer;
@@ -264,16 +264,16 @@ function createBaseMsgConvertERC20(): MsgConvertERC20 {
 export const MsgConvertERC20 = {
   typeUrl: "/evmos.erc20.v1.MsgConvertERC20",
   encode(message: MsgConvertERC20, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.contractAddress !== "") {
+    if (message.contractAddress !== undefined) {
       writer.uint32(10).string(message.contractAddress);
     }
-    if (message.amount !== "") {
+    if (message.amount !== undefined) {
       writer.uint32(18).string(message.amount);
     }
-    if (message.receiver !== "") {
+    if (message.receiver !== undefined) {
       writer.uint32(26).string(message.receiver);
     }
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(34).string(message.sender);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/evmos/fees/v1/fees.ts
+++ b/__fixtures__/v-next/outputv4/evmos/fees/v1/fees.ts
@@ -39,13 +39,13 @@ function createBaseDevFeeInfo(): DevFeeInfo {
 export const DevFeeInfo = {
   typeUrl: "/evmos.fees.v1.DevFeeInfo",
   encode(message: DevFeeInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.contractAddress !== "") {
+    if (message.contractAddress !== undefined) {
       writer.uint32(10).string(message.contractAddress);
     }
-    if (message.deployerAddress !== "") {
+    if (message.deployerAddress !== undefined) {
       writer.uint32(18).string(message.deployerAddress);
     }
-    if (message.withdrawAddress !== "") {
+    if (message.withdrawAddress !== undefined) {
       writer.uint32(26).string(message.withdrawAddress);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/evmos/fees/v1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/evmos/fees/v1/genesis.ts
@@ -180,19 +180,19 @@ function createBaseParams(): Params {
 export const Params = {
   typeUrl: "/evmos.fees.v1.Params",
   encode(message: Params, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.enableFees === true) {
+    if (message.enableFees !== undefined) {
       writer.uint32(8).bool(message.enableFees);
     }
-    if (message.developerShares !== "") {
+    if (message.developerShares !== undefined) {
       writer.uint32(18).string(Decimal.fromUserInput(message.developerShares, 18).atomics);
     }
-    if (message.validatorShares !== "") {
+    if (message.validatorShares !== undefined) {
       writer.uint32(26).string(Decimal.fromUserInput(message.validatorShares, 18).atomics);
     }
-    if (message.addrDerivationCostCreate !== BigInt(0)) {
+    if (message.addrDerivationCostCreate !== undefined) {
       writer.uint32(32).uint64(message.addrDerivationCostCreate);
     }
-    if (message.minGasPrice !== "") {
+    if (message.minGasPrice !== undefined) {
       writer.uint32(42).string(Decimal.fromUserInput(message.minGasPrice, 18).atomics);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/evmos/fees/v1/query.ts
+++ b/__fixtures__/v-next/outputv4/evmos/fees/v1/query.ts
@@ -361,7 +361,7 @@ function createBaseQueryDevFeeInfoRequest(): QueryDevFeeInfoRequest {
 export const QueryDevFeeInfoRequest = {
   typeUrl: "/evmos.fees.v1.QueryDevFeeInfoRequest",
   encode(message: QueryDevFeeInfoRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.contractAddress !== "") {
+    if (message.contractAddress !== undefined) {
       writer.uint32(10).string(message.contractAddress);
     }
     return writer;
@@ -691,7 +691,7 @@ function createBaseQueryDevFeeInfosPerDeployerRequest(): QueryDevFeeInfosPerDepl
 export const QueryDevFeeInfosPerDeployerRequest = {
   typeUrl: "/evmos.fees.v1.QueryDevFeeInfosPerDeployerRequest",
   encode(message: QueryDevFeeInfosPerDeployerRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.deployerAddress !== "") {
+    if (message.deployerAddress !== undefined) {
       writer.uint32(10).string(message.deployerAddress);
     }
     if (message.pagination !== undefined) {

--- a/__fixtures__/v-next/outputv4/evmos/fees/v1/tx.ts
+++ b/__fixtures__/v-next/outputv4/evmos/fees/v1/tx.ts
@@ -118,13 +118,13 @@ function createBaseMsgRegisterDevFeeInfo(): MsgRegisterDevFeeInfo {
 export const MsgRegisterDevFeeInfo = {
   typeUrl: "/evmos.fees.v1.MsgRegisterDevFeeInfo",
   encode(message: MsgRegisterDevFeeInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.contractAddress !== "") {
+    if (message.contractAddress !== undefined) {
       writer.uint32(10).string(message.contractAddress);
     }
-    if (message.deployerAddress !== "") {
+    if (message.deployerAddress !== undefined) {
       writer.uint32(18).string(message.deployerAddress);
     }
-    if (message.withdrawAddress !== "") {
+    if (message.withdrawAddress !== undefined) {
       writer.uint32(26).string(message.withdrawAddress);
     }
     writer.uint32(34).fork();
@@ -335,10 +335,10 @@ function createBaseMsgCancelDevFeeInfo(): MsgCancelDevFeeInfo {
 export const MsgCancelDevFeeInfo = {
   typeUrl: "/evmos.fees.v1.MsgCancelDevFeeInfo",
   encode(message: MsgCancelDevFeeInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.contractAddress !== "") {
+    if (message.contractAddress !== undefined) {
       writer.uint32(10).string(message.contractAddress);
     }
-    if (message.deployerAddress !== "") {
+    if (message.deployerAddress !== undefined) {
       writer.uint32(18).string(message.deployerAddress);
     }
     return writer;
@@ -504,13 +504,13 @@ function createBaseMsgUpdateDevFeeInfo(): MsgUpdateDevFeeInfo {
 export const MsgUpdateDevFeeInfo = {
   typeUrl: "/evmos.fees.v1.MsgUpdateDevFeeInfo",
   encode(message: MsgUpdateDevFeeInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.contractAddress !== "") {
+    if (message.contractAddress !== undefined) {
       writer.uint32(10).string(message.contractAddress);
     }
-    if (message.deployerAddress !== "") {
+    if (message.deployerAddress !== undefined) {
       writer.uint32(18).string(message.deployerAddress);
     }
-    if (message.withdrawAddress !== "") {
+    if (message.withdrawAddress !== undefined) {
       writer.uint32(26).string(message.withdrawAddress);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/evmos/incentives/v1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/evmos/incentives/v1/genesis.ts
@@ -197,16 +197,16 @@ function createBaseParams(): Params {
 export const Params = {
   typeUrl: "/evmos.incentives.v1.Params",
   encode(message: Params, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.enableIncentives === true) {
+    if (message.enableIncentives !== undefined) {
       writer.uint32(8).bool(message.enableIncentives);
     }
-    if (message.allocationLimit !== "") {
+    if (message.allocationLimit !== undefined) {
       writer.uint32(18).string(Decimal.fromUserInput(message.allocationLimit, 18).atomics);
     }
-    if (message.incentivesEpochIdentifier !== "") {
+    if (message.incentivesEpochIdentifier !== undefined) {
       writer.uint32(26).string(message.incentivesEpochIdentifier);
     }
-    if (message.rewardScaler !== "") {
+    if (message.rewardScaler !== undefined) {
       writer.uint32(34).string(Decimal.fromUserInput(message.rewardScaler, 18).atomics);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/evmos/incentives/v1/incentives.ts
+++ b/__fixtures__/v-next/outputv4/evmos/incentives/v1/incentives.ts
@@ -109,19 +109,19 @@ function createBaseIncentive(): Incentive {
 export const Incentive = {
   typeUrl: "/evmos.incentives.v1.Incentive",
   encode(message: Incentive, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.contract !== "") {
+    if (message.contract !== undefined) {
       writer.uint32(10).string(message.contract);
     }
     for (const v of message.allocations) {
       DecCoin.encode(v!, writer.uint32(18).fork()).ldelim();
     }
-    if (message.epochs !== 0) {
+    if (message.epochs !== undefined) {
       writer.uint32(24).uint32(message.epochs);
     }
     if (message.startTime !== undefined) {
       Timestamp.encode(toTimestamp(message.startTime), writer.uint32(34).fork()).ldelim();
     }
-    if (message.totalGas !== BigInt(0)) {
+    if (message.totalGas !== undefined) {
       writer.uint32(40).uint64(message.totalGas);
     }
     return writer;
@@ -267,13 +267,13 @@ function createBaseGasMeter(): GasMeter {
 export const GasMeter = {
   typeUrl: "/evmos.incentives.v1.GasMeter",
   encode(message: GasMeter, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.contract !== "") {
+    if (message.contract !== undefined) {
       writer.uint32(10).string(message.contract);
     }
-    if (message.participant !== "") {
+    if (message.participant !== undefined) {
       writer.uint32(18).string(message.participant);
     }
-    if (message.cumulativeGas !== BigInt(0)) {
+    if (message.cumulativeGas !== undefined) {
       writer.uint32(24).uint64(message.cumulativeGas);
     }
     return writer;
@@ -387,19 +387,19 @@ function createBaseRegisterIncentiveProposal(): RegisterIncentiveProposal {
 export const RegisterIncentiveProposal = {
   typeUrl: "/evmos.incentives.v1.RegisterIncentiveProposal",
   encode(message: RegisterIncentiveProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
-    if (message.contract !== "") {
+    if (message.contract !== undefined) {
       writer.uint32(26).string(message.contract);
     }
     for (const v of message.allocations) {
       DecCoin.encode(v!, writer.uint32(34).fork()).ldelim();
     }
-    if (message.epochs !== 0) {
+    if (message.epochs !== undefined) {
       writer.uint32(40).uint32(message.epochs);
     }
     return writer;
@@ -543,13 +543,13 @@ function createBaseCancelIncentiveProposal(): CancelIncentiveProposal {
 export const CancelIncentiveProposal = {
   typeUrl: "/evmos.incentives.v1.CancelIncentiveProposal",
   encode(message: CancelIncentiveProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
-    if (message.contract !== "") {
+    if (message.contract !== undefined) {
       writer.uint32(26).string(message.contract);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/evmos/incentives/v1/query.ts
+++ b/__fixtures__/v-next/outputv4/evmos/incentives/v1/query.ts
@@ -471,7 +471,7 @@ function createBaseQueryIncentiveRequest(): QueryIncentiveRequest {
 export const QueryIncentiveRequest = {
   typeUrl: "/evmos.incentives.v1.QueryIncentiveRequest",
   encode(message: QueryIncentiveRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.contract !== "") {
+    if (message.contract !== undefined) {
       writer.uint32(10).string(message.contract);
     }
     return writer;
@@ -646,7 +646,7 @@ function createBaseQueryGasMetersRequest(): QueryGasMetersRequest {
 export const QueryGasMetersRequest = {
   typeUrl: "/evmos.incentives.v1.QueryGasMetersRequest",
   encode(message: QueryGasMetersRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.contract !== "") {
+    if (message.contract !== undefined) {
       writer.uint32(10).string(message.contract);
     }
     if (message.pagination !== undefined) {
@@ -864,10 +864,10 @@ function createBaseQueryGasMeterRequest(): QueryGasMeterRequest {
 export const QueryGasMeterRequest = {
   typeUrl: "/evmos.incentives.v1.QueryGasMeterRequest",
   encode(message: QueryGasMeterRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.contract !== "") {
+    if (message.contract !== undefined) {
       writer.uint32(10).string(message.contract);
     }
-    if (message.participant !== "") {
+    if (message.participant !== undefined) {
       writer.uint32(18).string(message.participant);
     }
     return writer;
@@ -964,7 +964,7 @@ function createBaseQueryGasMeterResponse(): QueryGasMeterResponse {
 export const QueryGasMeterResponse = {
   typeUrl: "/evmos.incentives.v1.QueryGasMeterResponse",
   encode(message: QueryGasMeterResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.gasMeter !== BigInt(0)) {
+    if (message.gasMeter !== undefined) {
       writer.uint32(8).uint64(message.gasMeter);
     }
     return writer;
@@ -1255,7 +1255,7 @@ function createBaseQueryAllocationMeterRequest(): QueryAllocationMeterRequest {
 export const QueryAllocationMeterRequest = {
   typeUrl: "/evmos.incentives.v1.QueryAllocationMeterRequest",
   encode(message: QueryAllocationMeterRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(10).string(message.denom);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/evmos/inflation/v1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/evmos/inflation/v1/genesis.ts
@@ -64,16 +64,16 @@ export const GenesisState = {
     if (message.params !== undefined) {
       Params.encode(message.params, writer.uint32(10).fork()).ldelim();
     }
-    if (message.period !== BigInt(0)) {
+    if (message.period !== undefined) {
       writer.uint32(16).uint64(message.period);
     }
-    if (message.epochIdentifier !== "") {
+    if (message.epochIdentifier !== undefined) {
       writer.uint32(26).string(message.epochIdentifier);
     }
-    if (message.epochsPerPeriod !== BigInt(0)) {
+    if (message.epochsPerPeriod !== undefined) {
       writer.uint32(32).int64(message.epochsPerPeriod);
     }
-    if (message.skippedEpochs !== BigInt(0)) {
+    if (message.skippedEpochs !== undefined) {
       writer.uint32(40).uint64(message.skippedEpochs);
     }
     return writer;
@@ -214,7 +214,7 @@ function createBaseParams(): Params {
 export const Params = {
   typeUrl: "/evmos.inflation.v1.Params",
   encode(message: Params, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.mintDenom !== "") {
+    if (message.mintDenom !== undefined) {
       writer.uint32(10).string(message.mintDenom);
     }
     if (message.exponentialCalculation !== undefined) {
@@ -223,7 +223,7 @@ export const Params = {
     if (message.inflationDistribution !== undefined) {
       InflationDistribution.encode(message.inflationDistribution, writer.uint32(26).fork()).ldelim();
     }
-    if (message.enableInflation === true) {
+    if (message.enableInflation !== undefined) {
       writer.uint32(32).bool(message.enableInflation);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/evmos/inflation/v1/inflation.ts
+++ b/__fixtures__/v-next/outputv4/evmos/inflation/v1/inflation.ts
@@ -93,13 +93,13 @@ function createBaseInflationDistribution(): InflationDistribution {
 export const InflationDistribution = {
   typeUrl: "/evmos.inflation.v1.InflationDistribution",
   encode(message: InflationDistribution, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.stakingRewards !== "") {
+    if (message.stakingRewards !== undefined) {
       writer.uint32(10).string(Decimal.fromUserInput(message.stakingRewards, 18).atomics);
     }
-    if (message.usageIncentives !== "") {
+    if (message.usageIncentives !== undefined) {
       writer.uint32(18).string(Decimal.fromUserInput(message.usageIncentives, 18).atomics);
     }
-    if (message.communityPool !== "") {
+    if (message.communityPool !== undefined) {
       writer.uint32(26).string(Decimal.fromUserInput(message.communityPool, 18).atomics);
     }
     return writer;
@@ -211,19 +211,19 @@ function createBaseExponentialCalculation(): ExponentialCalculation {
 export const ExponentialCalculation = {
   typeUrl: "/evmos.inflation.v1.ExponentialCalculation",
   encode(message: ExponentialCalculation, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.a !== "") {
+    if (message.a !== undefined) {
       writer.uint32(10).string(Decimal.fromUserInput(message.a, 18).atomics);
     }
-    if (message.r !== "") {
+    if (message.r !== undefined) {
       writer.uint32(18).string(Decimal.fromUserInput(message.r, 18).atomics);
     }
-    if (message.c !== "") {
+    if (message.c !== undefined) {
       writer.uint32(26).string(Decimal.fromUserInput(message.c, 18).atomics);
     }
-    if (message.bondingTarget !== "") {
+    if (message.bondingTarget !== undefined) {
       writer.uint32(34).string(Decimal.fromUserInput(message.bondingTarget, 18).atomics);
     }
-    if (message.maxVariance !== "") {
+    if (message.maxVariance !== undefined) {
       writer.uint32(42).string(Decimal.fromUserInput(message.maxVariance, 18).atomics);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/evmos/inflation/v1/query.ts
+++ b/__fixtures__/v-next/outputv4/evmos/inflation/v1/query.ts
@@ -253,7 +253,7 @@ function createBaseQueryPeriodResponse(): QueryPeriodResponse {
 export const QueryPeriodResponse = {
   typeUrl: "/evmos.inflation.v1.QueryPeriodResponse",
   encode(message: QueryPeriodResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.period !== BigInt(0)) {
+    if (message.period !== undefined) {
       writer.uint32(8).uint64(message.period);
     }
     return writer;
@@ -563,7 +563,7 @@ function createBaseQuerySkippedEpochsResponse(): QuerySkippedEpochsResponse {
 export const QuerySkippedEpochsResponse = {
   typeUrl: "/evmos.inflation.v1.QuerySkippedEpochsResponse",
   encode(message: QuerySkippedEpochsResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.skippedEpochs !== BigInt(0)) {
+    if (message.skippedEpochs !== undefined) {
       writer.uint32(8).uint64(message.skippedEpochs);
     }
     return writer;
@@ -873,7 +873,7 @@ function createBaseQueryInflationRateResponse(): QueryInflationRateResponse {
 export const QueryInflationRateResponse = {
   typeUrl: "/evmos.inflation.v1.QueryInflationRateResponse",
   encode(message: QueryInflationRateResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.inflationRate !== "") {
+    if (message.inflationRate !== undefined) {
       writer.uint32(10).string(Decimal.fromUserInput(message.inflationRate, 18).atomics);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/evmos/recovery/v1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/evmos/recovery/v1/genesis.ts
@@ -128,7 +128,7 @@ function createBaseParams(): Params {
 export const Params = {
   typeUrl: "/evmos.recovery.v1.Params",
   encode(message: Params, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.enableRecovery === true) {
+    if (message.enableRecovery !== undefined) {
       writer.uint32(8).bool(message.enableRecovery);
     }
     if (message.packetTimeoutDuration !== undefined) {

--- a/__fixtures__/v-next/outputv4/evmos/vesting/v1/query.ts
+++ b/__fixtures__/v-next/outputv4/evmos/vesting/v1/query.ts
@@ -48,7 +48,7 @@ function createBaseQueryBalancesRequest(): QueryBalancesRequest {
 export const QueryBalancesRequest = {
   typeUrl: "/evmos.vesting.v1.QueryBalancesRequest",
   encode(message: QueryBalancesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/evmos/vesting/v1/tx.ts
+++ b/__fixtures__/v-next/outputv4/evmos/vesting/v1/tx.ts
@@ -104,10 +104,10 @@ function createBaseMsgCreateClawbackVestingAccount(): MsgCreateClawbackVestingAc
 export const MsgCreateClawbackVestingAccount = {
   typeUrl: "/evmos.vesting.v1.MsgCreateClawbackVestingAccount",
   encode(message: MsgCreateClawbackVestingAccount, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.fromAddress !== "") {
+    if (message.fromAddress !== undefined) {
       writer.uint32(10).string(message.fromAddress);
     }
-    if (message.toAddress !== "") {
+    if (message.toAddress !== undefined) {
       writer.uint32(18).string(message.toAddress);
     }
     if (message.startTime !== undefined) {
@@ -119,7 +119,7 @@ export const MsgCreateClawbackVestingAccount = {
     for (const v of message.vestingPeriods) {
       Period.encode(v!, writer.uint32(42).fork()).ldelim();
     }
-    if (message.merge === true) {
+    if (message.merge !== undefined) {
       writer.uint32(48).bool(message.merge);
     }
     return writer;
@@ -353,13 +353,13 @@ function createBaseMsgClawback(): MsgClawback {
 export const MsgClawback = {
   typeUrl: "/evmos.vesting.v1.MsgClawback",
   encode(message: MsgClawback, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.funderAddress !== "") {
+    if (message.funderAddress !== undefined) {
       writer.uint32(10).string(message.funderAddress);
     }
-    if (message.accountAddress !== "") {
+    if (message.accountAddress !== undefined) {
       writer.uint32(18).string(message.accountAddress);
     }
-    if (message.destAddress !== "") {
+    if (message.destAddress !== undefined) {
       writer.uint32(26).string(message.destAddress);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/evmos/vesting/v1/vesting.ts
+++ b/__fixtures__/v-next/outputv4/evmos/vesting/v1/vesting.ts
@@ -56,7 +56,7 @@ export const ClawbackVestingAccount = {
     if (message.baseVestingAccount !== undefined) {
       BaseVestingAccount.encode(message.baseVestingAccount, writer.uint32(10).fork()).ldelim();
     }
-    if (message.funderAddress !== "") {
+    if (message.funderAddress !== undefined) {
       writer.uint32(18).string(message.funderAddress);
     }
     if (message.startTime !== undefined) {

--- a/__fixtures__/v-next/outputv4/google/api/auth.ts
+++ b/__fixtures__/v-next/outputv4/google/api/auth.ts
@@ -478,13 +478,13 @@ function createBaseAuthenticationRule(): AuthenticationRule {
 export const AuthenticationRule = {
   typeUrl: "/google.api.AuthenticationRule",
   encode(message: AuthenticationRule, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.selector !== "") {
+    if (message.selector !== undefined) {
       writer.uint32(10).string(message.selector);
     }
     if (message.oauth !== undefined) {
       OAuthRequirements.encode(message.oauth, writer.uint32(18).fork()).ldelim();
     }
-    if (message.allowWithoutCredential === true) {
+    if (message.allowWithoutCredential !== undefined) {
       writer.uint32(40).bool(message.allowWithoutCredential);
     }
     for (const v of message.requirements) {
@@ -628,7 +628,7 @@ export const JwtLocation = {
     if (message.query !== undefined) {
       writer.uint32(18).string(message.query);
     }
-    if (message.valuePrefix !== "") {
+    if (message.valuePrefix !== undefined) {
       writer.uint32(26).string(message.valuePrefix);
     }
     return writer;
@@ -741,19 +741,19 @@ function createBaseAuthProvider(): AuthProvider {
 export const AuthProvider = {
   typeUrl: "/google.api.AuthProvider",
   encode(message: AuthProvider, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.id !== "") {
+    if (message.id !== undefined) {
       writer.uint32(10).string(message.id);
     }
-    if (message.issuer !== "") {
+    if (message.issuer !== undefined) {
       writer.uint32(18).string(message.issuer);
     }
-    if (message.jwksUri !== "") {
+    if (message.jwksUri !== undefined) {
       writer.uint32(26).string(message.jwksUri);
     }
-    if (message.audiences !== "") {
+    if (message.audiences !== undefined) {
       writer.uint32(34).string(message.audiences);
     }
-    if (message.authorizationUrl !== "") {
+    if (message.authorizationUrl !== undefined) {
       writer.uint32(42).string(message.authorizationUrl);
     }
     for (const v of message.jwtLocations) {
@@ -909,7 +909,7 @@ function createBaseOAuthRequirements(): OAuthRequirements {
 export const OAuthRequirements = {
   typeUrl: "/google.api.OAuthRequirements",
   encode(message: OAuthRequirements, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.canonicalScopes !== "") {
+    if (message.canonicalScopes !== undefined) {
       writer.uint32(10).string(message.canonicalScopes);
     }
     return writer;
@@ -996,10 +996,10 @@ function createBaseAuthRequirement(): AuthRequirement {
 export const AuthRequirement = {
   typeUrl: "/google.api.AuthRequirement",
   encode(message: AuthRequirement, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.providerId !== "") {
+    if (message.providerId !== undefined) {
       writer.uint32(10).string(message.providerId);
     }
-    if (message.audiences !== "") {
+    if (message.audiences !== undefined) {
       writer.uint32(18).string(message.audiences);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/backend.ts
+++ b/__fixtures__/v-next/outputv4/google/api/backend.ts
@@ -325,19 +325,19 @@ function createBaseBackendRule(): BackendRule {
 export const BackendRule = {
   typeUrl: "/google.api.BackendRule",
   encode(message: BackendRule, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.selector !== "") {
+    if (message.selector !== undefined) {
       writer.uint32(10).string(message.selector);
     }
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(18).string(message.address);
     }
-    if (message.deadline !== 0) {
+    if (message.deadline !== undefined) {
       writer.uint32(25).double(message.deadline);
     }
-    if (message.minDeadline !== 0) {
+    if (message.minDeadline !== undefined) {
       writer.uint32(33).double(message.minDeadline);
     }
-    if (message.operationDeadline !== 0) {
+    if (message.operationDeadline !== undefined) {
       writer.uint32(41).double(message.operationDeadline);
     }
     if (message.pathTranslation !== 0) {
@@ -349,7 +349,7 @@ export const BackendRule = {
     if (message.disableAuth !== undefined) {
       writer.uint32(64).bool(message.disableAuth);
     }
-    if (message.protocol !== "") {
+    if (message.protocol !== undefined) {
       writer.uint32(74).string(message.protocol);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/billing.ts
+++ b/__fixtures__/v-next/outputv4/google/api/billing.ts
@@ -220,7 +220,7 @@ function createBaseBilling_BillingDestination(): Billing_BillingDestination {
 export const Billing_BillingDestination = {
   typeUrl: "/google.api.BillingDestination",
   encode(message: Billing_BillingDestination, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.monitoredResource !== "") {
+    if (message.monitoredResource !== undefined) {
       writer.uint32(10).string(message.monitoredResource);
     }
     for (const v of message.metrics) {

--- a/__fixtures__/v-next/outputv4/google/api/config_change.ts
+++ b/__fixtures__/v-next/outputv4/google/api/config_change.ts
@@ -153,13 +153,13 @@ function createBaseConfigChange(): ConfigChange {
 export const ConfigChange = {
   typeUrl: "/google.api.ConfigChange",
   encode(message: ConfigChange, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.element !== "") {
+    if (message.element !== undefined) {
       writer.uint32(10).string(message.element);
     }
-    if (message.oldValue !== "") {
+    if (message.oldValue !== undefined) {
       writer.uint32(18).string(message.oldValue);
     }
-    if (message.newValue !== "") {
+    if (message.newValue !== undefined) {
       writer.uint32(26).string(message.newValue);
     }
     if (message.changeType !== 0) {
@@ -307,7 +307,7 @@ function createBaseAdvice(): Advice {
 export const Advice = {
   typeUrl: "/google.api.Advice",
   encode(message: Advice, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/consumer.ts
+++ b/__fixtures__/v-next/outputv4/google/api/consumer.ts
@@ -252,13 +252,13 @@ function createBaseProperty(): Property {
 export const Property = {
   typeUrl: "/google.api.Property",
   encode(message: Property, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     if (message.type !== 0) {
       writer.uint32(16).int32(message.type);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(26).string(message.description);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/context.ts
+++ b/__fixtures__/v-next/outputv4/google/api/context.ts
@@ -243,7 +243,7 @@ function createBaseContextRule(): ContextRule {
 export const ContextRule = {
   typeUrl: "/google.api.ContextRule",
   encode(message: ContextRule, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.selector !== "") {
+    if (message.selector !== undefined) {
       writer.uint32(10).string(message.selector);
     }
     for (const v of message.requested) {

--- a/__fixtures__/v-next/outputv4/google/api/control.ts
+++ b/__fixtures__/v-next/outputv4/google/api/control.ts
@@ -33,7 +33,7 @@ function createBaseControl(): Control {
 export const Control = {
   typeUrl: "/google.api.Control",
   encode(message: Control, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.environment !== "") {
+    if (message.environment !== undefined) {
       writer.uint32(10).string(message.environment);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/distribution.ts
+++ b/__fixtures__/v-next/outputv4/google/api/distribution.ts
@@ -345,13 +345,13 @@ function createBaseDistribution(): Distribution {
 export const Distribution = {
   typeUrl: "/google.api.Distribution",
   encode(message: Distribution, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.count !== BigInt(0)) {
+    if (message.count !== undefined) {
       writer.uint32(8).int64(message.count);
     }
-    if (message.mean !== 0) {
+    if (message.mean !== undefined) {
       writer.uint32(17).double(message.mean);
     }
-    if (message.sumOfSquaredDeviation !== 0) {
+    if (message.sumOfSquaredDeviation !== undefined) {
       writer.uint32(25).double(message.sumOfSquaredDeviation);
     }
     if (message.range !== undefined) {
@@ -555,10 +555,10 @@ function createBaseDistribution_Range(): Distribution_Range {
 export const Distribution_Range = {
   typeUrl: "/google.api.Range",
   encode(message: Distribution_Range, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.min !== 0) {
+    if (message.min !== undefined) {
       writer.uint32(9).double(message.min);
     }
-    if (message.max !== 0) {
+    if (message.max !== undefined) {
       writer.uint32(17).double(message.max);
     }
     return writer;
@@ -779,13 +779,13 @@ function createBaseDistribution_BucketOptions_Linear(): Distribution_BucketOptio
 export const Distribution_BucketOptions_Linear = {
   typeUrl: "/google.api.Linear",
   encode(message: Distribution_BucketOptions_Linear, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.numFiniteBuckets !== 0) {
+    if (message.numFiniteBuckets !== undefined) {
       writer.uint32(8).int32(message.numFiniteBuckets);
     }
-    if (message.width !== 0) {
+    if (message.width !== undefined) {
       writer.uint32(17).double(message.width);
     }
-    if (message.offset !== 0) {
+    if (message.offset !== undefined) {
       writer.uint32(25).double(message.offset);
     }
     return writer;
@@ -895,13 +895,13 @@ function createBaseDistribution_BucketOptions_Exponential(): Distribution_Bucket
 export const Distribution_BucketOptions_Exponential = {
   typeUrl: "/google.api.Exponential",
   encode(message: Distribution_BucketOptions_Exponential, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.numFiniteBuckets !== 0) {
+    if (message.numFiniteBuckets !== undefined) {
       writer.uint32(8).int32(message.numFiniteBuckets);
     }
-    if (message.growthFactor !== 0) {
+    if (message.growthFactor !== undefined) {
       writer.uint32(17).double(message.growthFactor);
     }
-    if (message.scale !== 0) {
+    if (message.scale !== undefined) {
       writer.uint32(25).double(message.scale);
     }
     return writer;
@@ -1118,7 +1118,7 @@ function createBaseDistribution_Exemplar(): Distribution_Exemplar {
 export const Distribution_Exemplar = {
   typeUrl: "/google.api.Exemplar",
   encode(message: Distribution_Exemplar, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.value !== 0) {
+    if (message.value !== undefined) {
       writer.uint32(9).double(message.value);
     }
     if (message.timestamp !== undefined) {

--- a/__fixtures__/v-next/outputv4/google/api/documentation.ts
+++ b/__fixtures__/v-next/outputv4/google/api/documentation.ts
@@ -255,7 +255,7 @@ function createBaseDocumentation(): Documentation {
 export const Documentation = {
   typeUrl: "/google.api.Documentation",
   encode(message: Documentation, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.summary !== "") {
+    if (message.summary !== undefined) {
       writer.uint32(10).string(message.summary);
     }
     for (const v of message.pages) {
@@ -264,13 +264,13 @@ export const Documentation = {
     for (const v of message.rules) {
       DocumentationRule.encode(v!, writer.uint32(26).fork()).ldelim();
     }
-    if (message.documentationRootUrl !== "") {
+    if (message.documentationRootUrl !== undefined) {
       writer.uint32(34).string(message.documentationRootUrl);
     }
-    if (message.serviceRootUrl !== "") {
+    if (message.serviceRootUrl !== undefined) {
       writer.uint32(50).string(message.serviceRootUrl);
     }
-    if (message.overview !== "") {
+    if (message.overview !== undefined) {
       writer.uint32(18).string(message.overview);
     }
     return writer;
@@ -437,13 +437,13 @@ function createBaseDocumentationRule(): DocumentationRule {
 export const DocumentationRule = {
   typeUrl: "/google.api.DocumentationRule",
   encode(message: DocumentationRule, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.selector !== "") {
+    if (message.selector !== undefined) {
       writer.uint32(10).string(message.selector);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
-    if (message.deprecationDescription !== "") {
+    if (message.deprecationDescription !== undefined) {
       writer.uint32(26).string(message.deprecationDescription);
     }
     return writer;
@@ -553,10 +553,10 @@ function createBasePage(): Page {
 export const Page = {
   typeUrl: "/google.api.Page",
   encode(message: Page, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.content !== "") {
+    if (message.content !== undefined) {
       writer.uint32(18).string(message.content);
     }
     for (const v of message.subpages) {

--- a/__fixtures__/v-next/outputv4/google/api/endpoint.ts
+++ b/__fixtures__/v-next/outputv4/google/api/endpoint.ts
@@ -91,16 +91,16 @@ function createBaseEndpoint(): Endpoint {
 export const Endpoint = {
   typeUrl: "/google.api.Endpoint",
   encode(message: Endpoint, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     for (const v of message.aliases) {
       writer.uint32(18).string(v!);
     }
-    if (message.target !== "") {
+    if (message.target !== undefined) {
       writer.uint32(810).string(message.target);
     }
-    if (message.allowCors === true) {
+    if (message.allowCors !== undefined) {
       writer.uint32(40).bool(message.allowCors);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/expr/conformance/v1alpha1/conformance_service.ts
+++ b/__fixtures__/v-next/outputv4/google/api/expr/conformance/v1alpha1/conformance_service.ts
@@ -243,16 +243,16 @@ function createBaseParseRequest(): ParseRequest {
 export const ParseRequest = {
   typeUrl: "/google.api.expr.conformance.v1alpha1.ParseRequest",
   encode(message: ParseRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.celSource !== "") {
+    if (message.celSource !== undefined) {
       writer.uint32(10).string(message.celSource);
     }
-    if (message.syntaxVersion !== "") {
+    if (message.syntaxVersion !== undefined) {
       writer.uint32(18).string(message.syntaxVersion);
     }
-    if (message.sourceLocation !== "") {
+    if (message.sourceLocation !== undefined) {
       writer.uint32(26).string(message.sourceLocation);
     }
-    if (message.disableMacros === true) {
+    if (message.disableMacros !== undefined) {
       writer.uint32(32).bool(message.disableMacros);
     }
     return writer;
@@ -495,10 +495,10 @@ export const CheckRequest = {
     for (const v of message.typeEnv) {
       Decl.encode(v!, writer.uint32(18).fork()).ldelim();
     }
-    if (message.container !== "") {
+    if (message.container !== undefined) {
       writer.uint32(26).string(message.container);
     }
-    if (message.noStdEnv === true) {
+    if (message.noStdEnv !== undefined) {
       writer.uint32(32).bool(message.noStdEnv);
     }
     return writer;
@@ -746,7 +746,7 @@ function createBaseEvalRequest_BindingsEntry(): EvalRequest_BindingsEntry {
 }
 export const EvalRequest_BindingsEntry = {
   encode(message: EvalRequest_BindingsEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
     if (message.value !== undefined) {
@@ -857,7 +857,7 @@ export const EvalRequest = {
         value
       }, writer.uint32(26).fork()).ldelim();
     });
-    if (message.container !== "") {
+    if (message.container !== undefined) {
       writer.uint32(34).string(message.container);
     }
     return writer;
@@ -1148,7 +1148,7 @@ export const IssueDetails = {
     if (message.position !== undefined) {
       SourcePosition.encode(message.position, writer.uint32(18).fork()).ldelim();
     }
-    if (message.id !== BigInt(0)) {
+    if (message.id !== undefined) {
       writer.uint32(24).int64(message.id);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/expr/v1alpha1/checked.ts
+++ b/__fixtures__/v-next/outputv4/google/api/expr/v1alpha1/checked.ts
@@ -583,7 +583,7 @@ function createBaseCheckedExpr_ReferenceMapEntry(): CheckedExpr_ReferenceMapEntr
 }
 export const CheckedExpr_ReferenceMapEntry = {
   encode(message: CheckedExpr_ReferenceMapEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== BigInt(0)) {
+    if (message.key !== undefined) {
       writer.uint32(8).int64(message.key);
     }
     if (message.value !== undefined) {
@@ -681,7 +681,7 @@ function createBaseCheckedExpr_TypeMapEntry(): CheckedExpr_TypeMapEntry {
 }
 export const CheckedExpr_TypeMapEntry = {
   encode(message: CheckedExpr_TypeMapEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== BigInt(0)) {
+    if (message.key !== undefined) {
       writer.uint32(8).int64(message.key);
     }
     if (message.value !== undefined) {
@@ -798,7 +798,7 @@ export const CheckedExpr = {
     if (message.sourceInfo !== undefined) {
       SourceInfo.encode(message.sourceInfo, writer.uint32(42).fork()).ldelim();
     }
-    if (message.exprVersion !== "") {
+    if (message.exprVersion !== undefined) {
       writer.uint32(50).string(message.exprVersion);
     }
     if (message.expr !== undefined) {
@@ -1614,7 +1614,7 @@ function createBaseType_AbstractType(): Type_AbstractType {
 export const Type_AbstractType = {
   typeUrl: "/google.api.expr.v1alpha1.AbstractType",
   encode(message: Type_AbstractType, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     for (const v of message.parameterTypes) {
@@ -1728,7 +1728,7 @@ function createBaseDecl(): Decl {
 export const Decl = {
   typeUrl: "/google.api.expr.v1alpha1.Decl",
   encode(message: Decl, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     if (message.ident !== undefined) {
@@ -1854,7 +1854,7 @@ export const Decl_IdentDecl = {
     if (message.value !== undefined) {
       Constant.encode(message.value, writer.uint32(18).fork()).ldelim();
     }
-    if (message.doc !== "") {
+    if (message.doc !== undefined) {
       writer.uint32(26).string(message.doc);
     }
     return writer;
@@ -2069,7 +2069,7 @@ function createBaseDecl_FunctionDecl_Overload(): Decl_FunctionDecl_Overload {
 export const Decl_FunctionDecl_Overload = {
   typeUrl: "/google.api.expr.v1alpha1.Overload",
   encode(message: Decl_FunctionDecl_Overload, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.overloadId !== "") {
+    if (message.overloadId !== undefined) {
       writer.uint32(10).string(message.overloadId);
     }
     for (const v of message.params) {
@@ -2081,10 +2081,10 @@ export const Decl_FunctionDecl_Overload = {
     if (message.resultType !== undefined) {
       Type.encode(message.resultType, writer.uint32(34).fork()).ldelim();
     }
-    if (message.isInstanceFunction === true) {
+    if (message.isInstanceFunction !== undefined) {
       writer.uint32(40).bool(message.isInstanceFunction);
     }
-    if (message.doc !== "") {
+    if (message.doc !== undefined) {
       writer.uint32(50).string(message.doc);
     }
     return writer;
@@ -2253,7 +2253,7 @@ function createBaseReference(): Reference {
 export const Reference = {
   typeUrl: "/google.api.expr.v1alpha1.Reference",
   encode(message: Reference, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     for (const v of message.overloadId) {

--- a/__fixtures__/v-next/outputv4/google/api/expr/v1alpha1/eval.ts
+++ b/__fixtures__/v-next/outputv4/google/api/expr/v1alpha1/eval.ts
@@ -285,10 +285,10 @@ function createBaseEvalState_Result(): EvalState_Result {
 export const EvalState_Result = {
   typeUrl: "/google.api.expr.v1alpha1.Result",
   encode(message: EvalState_Result, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.expr !== BigInt(0)) {
+    if (message.expr !== undefined) {
       writer.uint32(8).int64(message.expr);
     }
-    if (message.value !== BigInt(0)) {
+    if (message.value !== undefined) {
       writer.uint32(16).int64(message.value);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/expr/v1alpha1/explain.ts
+++ b/__fixtures__/v-next/outputv4/google/api/expr/v1alpha1/explain.ts
@@ -187,10 +187,10 @@ function createBaseExplain_ExprStep(): Explain_ExprStep {
 export const Explain_ExprStep = {
   typeUrl: "/google.api.expr.v1alpha1.ExprStep",
   encode(message: Explain_ExprStep, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.id !== BigInt(0)) {
+    if (message.id !== undefined) {
       writer.uint32(8).int64(message.id);
     }
-    if (message.valueIndex !== 0) {
+    if (message.valueIndex !== undefined) {
       writer.uint32(16).int32(message.valueIndex);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/expr/v1alpha1/syntax.ts
+++ b/__fixtures__/v-next/outputv4/google/api/expr/v1alpha1/syntax.ts
@@ -656,7 +656,7 @@ function createBaseExpr(): Expr {
 export const Expr = {
   typeUrl: "/google.api.expr.v1alpha1.Expr",
   encode(message: Expr, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.id !== BigInt(0)) {
+    if (message.id !== undefined) {
       writer.uint32(16).int64(message.id);
     }
     if (message.constExpr !== undefined) {
@@ -856,7 +856,7 @@ function createBaseExpr_Ident(): Expr_Ident {
 export const Expr_Ident = {
   typeUrl: "/google.api.expr.v1alpha1.Ident",
   encode(message: Expr_Ident, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     return writer;
@@ -947,10 +947,10 @@ export const Expr_Select = {
     if (message.operand !== undefined) {
       Expr.encode(message.operand, writer.uint32(10).fork()).ldelim();
     }
-    if (message.field !== "") {
+    if (message.field !== undefined) {
       writer.uint32(18).string(message.field);
     }
-    if (message.testOnly === true) {
+    if (message.testOnly !== undefined) {
       writer.uint32(24).bool(message.testOnly);
     }
     return writer;
@@ -1065,7 +1065,7 @@ export const Expr_Call = {
     if (message.target !== undefined) {
       Expr.encode(message.target, writer.uint32(10).fork()).ldelim();
     }
-    if (message.function !== "") {
+    if (message.function !== undefined) {
       writer.uint32(18).string(message.function);
     }
     for (const v of message.args) {
@@ -1289,7 +1289,7 @@ function createBaseExpr_CreateStruct(): Expr_CreateStruct {
 export const Expr_CreateStruct = {
   typeUrl: "/google.api.expr.v1alpha1.CreateStruct",
   encode(message: Expr_CreateStruct, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.messageName !== "") {
+    if (message.messageName !== undefined) {
       writer.uint32(10).string(message.messageName);
     }
     for (const v of message.entries) {
@@ -1404,7 +1404,7 @@ function createBaseExpr_CreateStruct_Entry(): Expr_CreateStruct_Entry {
 export const Expr_CreateStruct_Entry = {
   typeUrl: "/google.api.expr.v1alpha1.Entry",
   encode(message: Expr_CreateStruct_Entry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.id !== BigInt(0)) {
+    if (message.id !== undefined) {
       writer.uint32(8).int64(message.id);
     }
     if (message.fieldKey !== undefined) {
@@ -1544,13 +1544,13 @@ function createBaseExpr_Comprehension(): Expr_Comprehension {
 export const Expr_Comprehension = {
   typeUrl: "/google.api.expr.v1alpha1.Comprehension",
   encode(message: Expr_Comprehension, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.iterVar !== "") {
+    if (message.iterVar !== undefined) {
       writer.uint32(10).string(message.iterVar);
     }
     if (message.iterRange !== undefined) {
       Expr.encode(message.iterRange, writer.uint32(18).fork()).ldelim();
     }
-    if (message.accuVar !== "") {
+    if (message.accuVar !== undefined) {
       writer.uint32(26).string(message.accuVar);
     }
     if (message.accuInit !== undefined) {
@@ -1940,10 +1940,10 @@ function createBaseSourceInfo_PositionsEntry(): SourceInfo_PositionsEntry {
 }
 export const SourceInfo_PositionsEntry = {
   encode(message: SourceInfo_PositionsEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== BigInt(0)) {
+    if (message.key !== undefined) {
       writer.uint32(8).int64(message.key);
     }
-    if (message.value !== 0) {
+    if (message.value !== undefined) {
       writer.uint32(16).int32(message.value);
     }
     return writer;
@@ -2036,7 +2036,7 @@ function createBaseSourceInfo_MacroCallsEntry(): SourceInfo_MacroCallsEntry {
 }
 export const SourceInfo_MacroCallsEntry = {
   encode(message: SourceInfo_MacroCallsEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== BigInt(0)) {
+    if (message.key !== undefined) {
       writer.uint32(8).int64(message.key);
     }
     if (message.value !== undefined) {
@@ -2138,10 +2138,10 @@ function createBaseSourceInfo(): SourceInfo {
 export const SourceInfo = {
   typeUrl: "/google.api.expr.v1alpha1.SourceInfo",
   encode(message: SourceInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.syntaxVersion !== "") {
+    if (message.syntaxVersion !== undefined) {
       writer.uint32(10).string(message.syntaxVersion);
     }
-    if (message.location !== "") {
+    if (message.location !== undefined) {
       writer.uint32(18).string(message.location);
     }
     writer.uint32(26).fork();
@@ -2400,16 +2400,16 @@ function createBaseSourcePosition(): SourcePosition {
 export const SourcePosition = {
   typeUrl: "/google.api.expr.v1alpha1.SourcePosition",
   encode(message: SourcePosition, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.location !== "") {
+    if (message.location !== undefined) {
       writer.uint32(10).string(message.location);
     }
-    if (message.offset !== 0) {
+    if (message.offset !== undefined) {
       writer.uint32(16).int32(message.offset);
     }
-    if (message.line !== 0) {
+    if (message.line !== undefined) {
       writer.uint32(24).int32(message.line);
     }
-    if (message.column !== 0) {
+    if (message.column !== undefined) {
       writer.uint32(32).int32(message.column);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/expr/v1alpha1/value.ts
+++ b/__fixtures__/v-next/outputv4/google/api/expr/v1alpha1/value.ts
@@ -423,10 +423,10 @@ function createBaseEnumValue(): EnumValue {
 export const EnumValue = {
   typeUrl: "/google.api.expr.v1alpha1.EnumValue",
   encode(message: EnumValue, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.type !== "") {
+    if (message.type !== undefined) {
       writer.uint32(10).string(message.type);
     }
-    if (message.value !== 0) {
+    if (message.value !== undefined) {
       writer.uint32(16).int32(message.value);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/expr/v1beta1/decl.ts
+++ b/__fixtures__/v-next/outputv4/google/api/expr/v1beta1/decl.ts
@@ -106,13 +106,13 @@ function createBaseDecl(): Decl {
 export const Decl = {
   typeUrl: "/google.api.expr.v1beta1.Decl",
   encode(message: Decl, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.id !== 0) {
+    if (message.id !== undefined) {
       writer.uint32(8).int32(message.id);
     }
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(18).string(message.name);
     }
-    if (message.doc !== "") {
+    if (message.doc !== undefined) {
       writer.uint32(26).string(message.doc);
     }
     if (message.ident !== undefined) {
@@ -254,10 +254,10 @@ function createBaseDeclType(): DeclType {
 export const DeclType = {
   typeUrl: "/google.api.expr.v1beta1.DeclType",
   encode(message: DeclType, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.id !== 0) {
+    if (message.id !== undefined) {
       writer.uint32(8).int32(message.id);
     }
-    if (message.type !== "") {
+    if (message.type !== undefined) {
       writer.uint32(18).string(message.type);
     }
     for (const v of message.typeParams) {
@@ -493,7 +493,7 @@ export const FunctionDecl = {
     if (message.returnType !== undefined) {
       DeclType.encode(message.returnType, writer.uint32(18).fork()).ldelim();
     }
-    if (message.receiverFunction === true) {
+    if (message.receiverFunction !== undefined) {
       writer.uint32(24).bool(message.receiverFunction);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/expr/v1beta1/eval.ts
+++ b/__fixtures__/v-next/outputv4/google/api/expr/v1beta1/eval.ts
@@ -301,7 +301,7 @@ export const EvalState_Result = {
     if (message.expr !== undefined) {
       IdRef.encode(message.expr, writer.uint32(10).fork()).ldelim();
     }
-    if (message.value !== 0) {
+    if (message.value !== undefined) {
       writer.uint32(16).int32(message.value);
     }
     return writer;
@@ -718,7 +718,7 @@ function createBaseIdRef(): IdRef {
 export const IdRef = {
   typeUrl: "/google.api.expr.v1beta1.IdRef",
   encode(message: IdRef, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.id !== 0) {
+    if (message.id !== undefined) {
       writer.uint32(8).int32(message.id);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/expr/v1beta1/expr.ts
+++ b/__fixtures__/v-next/outputv4/google/api/expr/v1beta1/expr.ts
@@ -422,7 +422,7 @@ export const ParsedExpr = {
     if (message.sourceInfo !== undefined) {
       SourceInfo.encode(message.sourceInfo, writer.uint32(26).fork()).ldelim();
     }
-    if (message.syntaxVersion !== "") {
+    if (message.syntaxVersion !== undefined) {
       writer.uint32(34).string(message.syntaxVersion);
     }
     return writer;
@@ -541,7 +541,7 @@ function createBaseExpr(): Expr {
 export const Expr = {
   typeUrl: "/google.api.expr.v1beta1.Expr",
   encode(message: Expr, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.id !== 0) {
+    if (message.id !== undefined) {
       writer.uint32(16).int32(message.id);
     }
     if (message.literalExpr !== undefined) {
@@ -739,7 +739,7 @@ function createBaseExpr_Ident(): Expr_Ident {
 export const Expr_Ident = {
   typeUrl: "/google.api.expr.v1beta1.Ident",
   encode(message: Expr_Ident, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     return writer;
@@ -830,10 +830,10 @@ export const Expr_Select = {
     if (message.operand !== undefined) {
       Expr.encode(message.operand, writer.uint32(10).fork()).ldelim();
     }
-    if (message.field !== "") {
+    if (message.field !== undefined) {
       writer.uint32(18).string(message.field);
     }
-    if (message.testOnly === true) {
+    if (message.testOnly !== undefined) {
       writer.uint32(24).bool(message.testOnly);
     }
     return writer;
@@ -948,7 +948,7 @@ export const Expr_Call = {
     if (message.target !== undefined) {
       Expr.encode(message.target, writer.uint32(10).fork()).ldelim();
     }
-    if (message.function !== "") {
+    if (message.function !== undefined) {
       writer.uint32(18).string(message.function);
     }
     for (const v of message.args) {
@@ -1172,7 +1172,7 @@ function createBaseExpr_CreateStruct(): Expr_CreateStruct {
 export const Expr_CreateStruct = {
   typeUrl: "/google.api.expr.v1beta1.CreateStruct",
   encode(message: Expr_CreateStruct, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.type !== "") {
+    if (message.type !== undefined) {
       writer.uint32(10).string(message.type);
     }
     for (const v of message.entries) {
@@ -1287,7 +1287,7 @@ function createBaseExpr_CreateStruct_Entry(): Expr_CreateStruct_Entry {
 export const Expr_CreateStruct_Entry = {
   typeUrl: "/google.api.expr.v1beta1.Entry",
   encode(message: Expr_CreateStruct_Entry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.id !== 0) {
+    if (message.id !== undefined) {
       writer.uint32(8).int32(message.id);
     }
     if (message.fieldKey !== undefined) {
@@ -1425,13 +1425,13 @@ function createBaseExpr_Comprehension(): Expr_Comprehension {
 export const Expr_Comprehension = {
   typeUrl: "/google.api.expr.v1beta1.Comprehension",
   encode(message: Expr_Comprehension, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.iterVar !== "") {
+    if (message.iterVar !== undefined) {
       writer.uint32(10).string(message.iterVar);
     }
     if (message.iterRange !== undefined) {
       Expr.encode(message.iterRange, writer.uint32(18).fork()).ldelim();
     }
-    if (message.accuVar !== "") {
+    if (message.accuVar !== undefined) {
       writer.uint32(26).string(message.accuVar);
     }
     if (message.accuInit !== undefined) {

--- a/__fixtures__/v-next/outputv4/google/api/expr/v1beta1/source.ts
+++ b/__fixtures__/v-next/outputv4/google/api/expr/v1beta1/source.ts
@@ -87,10 +87,10 @@ function createBaseSourceInfo_PositionsEntry(): SourceInfo_PositionsEntry {
 }
 export const SourceInfo_PositionsEntry = {
   encode(message: SourceInfo_PositionsEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== 0) {
+    if (message.key !== undefined) {
       writer.uint32(8).int32(message.key);
     }
-    if (message.value !== 0) {
+    if (message.value !== undefined) {
       writer.uint32(16).int32(message.value);
     }
     return writer;
@@ -183,7 +183,7 @@ function createBaseSourceInfo(): SourceInfo {
 export const SourceInfo = {
   typeUrl: "/google.api.expr.v1beta1.SourceInfo",
   encode(message: SourceInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.location !== "") {
+    if (message.location !== undefined) {
       writer.uint32(18).string(message.location);
     }
     writer.uint32(26).fork();
@@ -369,16 +369,16 @@ function createBaseSourcePosition(): SourcePosition {
 export const SourcePosition = {
   typeUrl: "/google.api.expr.v1beta1.SourcePosition",
   encode(message: SourcePosition, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.location !== "") {
+    if (message.location !== undefined) {
       writer.uint32(10).string(message.location);
     }
-    if (message.offset !== 0) {
+    if (message.offset !== undefined) {
       writer.uint32(16).int32(message.offset);
     }
-    if (message.line !== 0) {
+    if (message.line !== undefined) {
       writer.uint32(24).int32(message.line);
     }
-    if (message.column !== 0) {
+    if (message.column !== undefined) {
       writer.uint32(32).int32(message.column);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/expr/v1beta1/value.ts
+++ b/__fixtures__/v-next/outputv4/google/api/expr/v1beta1/value.ts
@@ -423,10 +423,10 @@ function createBaseEnumValue(): EnumValue {
 export const EnumValue = {
   typeUrl: "/google.api.expr.v1beta1.EnumValue",
   encode(message: EnumValue, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.type !== "") {
+    if (message.type !== undefined) {
       writer.uint32(10).string(message.type);
     }
-    if (message.value !== 0) {
+    if (message.value !== undefined) {
       writer.uint32(16).int32(message.value);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/http.ts
+++ b/__fixtures__/v-next/outputv4/google/api/http.ts
@@ -674,7 +674,7 @@ export const Http = {
     for (const v of message.rules) {
       HttpRule.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.fullyDecodeReservedExpansion === true) {
+    if (message.fullyDecodeReservedExpansion !== undefined) {
       writer.uint32(16).bool(message.fullyDecodeReservedExpansion);
     }
     return writer;
@@ -792,7 +792,7 @@ function createBaseHttpRule(): HttpRule {
 export const HttpRule = {
   typeUrl: "/google.api.HttpRule",
   encode(message: HttpRule, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.selector !== "") {
+    if (message.selector !== undefined) {
       writer.uint32(10).string(message.selector);
     }
     if (message.get !== undefined) {
@@ -813,10 +813,10 @@ export const HttpRule = {
     if (message.custom !== undefined) {
       CustomHttpPattern.encode(message.custom, writer.uint32(66).fork()).ldelim();
     }
-    if (message.body !== "") {
+    if (message.body !== undefined) {
       writer.uint32(58).string(message.body);
     }
-    if (message.responseBody !== "") {
+    if (message.responseBody !== undefined) {
       writer.uint32(98).string(message.responseBody);
     }
     for (const v of message.additionalBindings) {
@@ -1019,10 +1019,10 @@ function createBaseCustomHttpPattern(): CustomHttpPattern {
 export const CustomHttpPattern = {
   typeUrl: "/google.api.CustomHttpPattern",
   encode(message: CustomHttpPattern, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.kind !== "") {
+    if (message.kind !== undefined) {
       writer.uint32(10).string(message.kind);
     }
-    if (message.path !== "") {
+    if (message.path !== undefined) {
       writer.uint32(18).string(message.path);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/httpbody.ts
+++ b/__fixtures__/v-next/outputv4/google/api/httpbody.ts
@@ -122,7 +122,7 @@ function createBaseHttpBody(): HttpBody {
 export const HttpBody = {
   typeUrl: "/google.api.HttpBody",
   encode(message: HttpBody, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.contentType !== "") {
+    if (message.contentType !== undefined) {
       writer.uint32(10).string(message.contentType);
     }
     if (message.data.length !== 0) {

--- a/__fixtures__/v-next/outputv4/google/api/label.ts
+++ b/__fixtures__/v-next/outputv4/google/api/label.ts
@@ -71,13 +71,13 @@ function createBaseLabelDescriptor(): LabelDescriptor {
 export const LabelDescriptor = {
   typeUrl: "/google.api.LabelDescriptor",
   encode(message: LabelDescriptor, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
     if (message.valueType !== 0) {
       writer.uint32(16).int32(message.valueType);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(26).string(message.description);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/log.ts
+++ b/__fixtures__/v-next/outputv4/google/api/log.ts
@@ -68,16 +68,16 @@ function createBaseLogDescriptor(): LogDescriptor {
 export const LogDescriptor = {
   typeUrl: "/google.api.LogDescriptor",
   encode(message: LogDescriptor, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     for (const v of message.labels) {
       LabelDescriptor.encode(v!, writer.uint32(18).fork()).ldelim();
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(26).string(message.description);
     }
-    if (message.displayName !== "") {
+    if (message.displayName !== undefined) {
       writer.uint32(34).string(message.displayName);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/logging.ts
+++ b/__fixtures__/v-next/outputv4/google/api/logging.ts
@@ -251,7 +251,7 @@ function createBaseLogging_LoggingDestination(): Logging_LoggingDestination {
 export const Logging_LoggingDestination = {
   typeUrl: "/google.api.LoggingDestination",
   encode(message: Logging_LoggingDestination, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.monitoredResource !== "") {
+    if (message.monitoredResource !== undefined) {
       writer.uint32(26).string(message.monitoredResource);
     }
     for (const v of message.logs) {

--- a/__fixtures__/v-next/outputv4/google/api/metric.ts
+++ b/__fixtures__/v-next/outputv4/google/api/metric.ts
@@ -416,10 +416,10 @@ function createBaseMetricDescriptor(): MetricDescriptor {
 export const MetricDescriptor = {
   typeUrl: "/google.api.MetricDescriptor",
   encode(message: MetricDescriptor, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.type !== "") {
+    if (message.type !== undefined) {
       writer.uint32(66).string(message.type);
     }
     for (const v of message.labels) {
@@ -431,13 +431,13 @@ export const MetricDescriptor = {
     if (message.valueType !== 0) {
       writer.uint32(32).int32(message.valueType);
     }
-    if (message.unit !== "") {
+    if (message.unit !== undefined) {
       writer.uint32(42).string(message.unit);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(50).string(message.description);
     }
-    if (message.displayName !== "") {
+    if (message.displayName !== undefined) {
       writer.uint32(58).string(message.displayName);
     }
     if (message.metadata !== undefined) {
@@ -788,10 +788,10 @@ function createBaseMetric_LabelsEntry(): Metric_LabelsEntry {
 }
 export const Metric_LabelsEntry = {
   encode(message: Metric_LabelsEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(18).string(message.value);
     }
     return writer;
@@ -883,7 +883,7 @@ function createBaseMetric(): Metric {
 export const Metric = {
   typeUrl: "/google.api.Metric",
   encode(message: Metric, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.type !== "") {
+    if (message.type !== undefined) {
       writer.uint32(26).string(message.type);
     }
     Object.entries(message.labels).forEach(([key, value]) => {

--- a/__fixtures__/v-next/outputv4/google/api/monitored_resource.ts
+++ b/__fixtures__/v-next/outputv4/google/api/monitored_resource.ts
@@ -212,16 +212,16 @@ function createBaseMonitoredResourceDescriptor(): MonitoredResourceDescriptor {
 export const MonitoredResourceDescriptor = {
   typeUrl: "/google.api.MonitoredResourceDescriptor",
   encode(message: MonitoredResourceDescriptor, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(42).string(message.name);
     }
-    if (message.type !== "") {
+    if (message.type !== undefined) {
       writer.uint32(10).string(message.type);
     }
-    if (message.displayName !== "") {
+    if (message.displayName !== undefined) {
       writer.uint32(18).string(message.displayName);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(26).string(message.description);
     }
     for (const v of message.labels) {
@@ -380,10 +380,10 @@ function createBaseMonitoredResource_LabelsEntry(): MonitoredResource_LabelsEntr
 }
 export const MonitoredResource_LabelsEntry = {
   encode(message: MonitoredResource_LabelsEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(18).string(message.value);
     }
     return writer;
@@ -475,7 +475,7 @@ function createBaseMonitoredResource(): MonitoredResource {
 export const MonitoredResource = {
   typeUrl: "/google.api.MonitoredResource",
   encode(message: MonitoredResource, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.type !== "") {
+    if (message.type !== undefined) {
       writer.uint32(10).string(message.type);
     }
     Object.entries(message.labels).forEach(([key, value]) => {
@@ -623,10 +623,10 @@ function createBaseMonitoredResourceMetadata_UserLabelsEntry(): MonitoredResourc
 }
 export const MonitoredResourceMetadata_UserLabelsEntry = {
   encode(message: MonitoredResourceMetadata_UserLabelsEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(18).string(message.value);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/monitoring.ts
+++ b/__fixtures__/v-next/outputv4/google/api/monitoring.ts
@@ -299,7 +299,7 @@ function createBaseMonitoring_MonitoringDestination(): Monitoring_MonitoringDest
 export const Monitoring_MonitoringDestination = {
   typeUrl: "/google.api.MonitoringDestination",
   encode(message: Monitoring_MonitoringDestination, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.monitoredResource !== "") {
+    if (message.monitoredResource !== undefined) {
       writer.uint32(10).string(message.monitoredResource);
     }
     for (const v of message.metrics) {

--- a/__fixtures__/v-next/outputv4/google/api/quota.ts
+++ b/__fixtures__/v-next/outputv4/google/api/quota.ts
@@ -434,10 +434,10 @@ function createBaseMetricRule_MetricCostsEntry(): MetricRule_MetricCostsEntry {
 }
 export const MetricRule_MetricCostsEntry = {
   encode(message: MetricRule_MetricCostsEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== BigInt(0)) {
+    if (message.value !== undefined) {
       writer.uint32(16).int64(message.value);
     }
     return writer;
@@ -531,7 +531,7 @@ function createBaseMetricRule(): MetricRule {
 export const MetricRule = {
   typeUrl: "/google.api.MetricRule",
   encode(message: MetricRule, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.selector !== "") {
+    if (message.selector !== undefined) {
       writer.uint32(10).string(message.selector);
     }
     Object.entries(message.metricCosts).forEach(([key, value]) => {
@@ -679,10 +679,10 @@ function createBaseQuotaLimit_ValuesEntry(): QuotaLimit_ValuesEntry {
 }
 export const QuotaLimit_ValuesEntry = {
   encode(message: QuotaLimit_ValuesEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== BigInt(0)) {
+    if (message.value !== undefined) {
       writer.uint32(16).int64(message.value);
     }
     return writer;
@@ -784,28 +784,28 @@ function createBaseQuotaLimit(): QuotaLimit {
 export const QuotaLimit = {
   typeUrl: "/google.api.QuotaLimit",
   encode(message: QuotaLimit, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(50).string(message.name);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
-    if (message.defaultLimit !== BigInt(0)) {
+    if (message.defaultLimit !== undefined) {
       writer.uint32(24).int64(message.defaultLimit);
     }
-    if (message.maxLimit !== BigInt(0)) {
+    if (message.maxLimit !== undefined) {
       writer.uint32(32).int64(message.maxLimit);
     }
-    if (message.freeTier !== BigInt(0)) {
+    if (message.freeTier !== undefined) {
       writer.uint32(56).int64(message.freeTier);
     }
-    if (message.duration !== "") {
+    if (message.duration !== undefined) {
       writer.uint32(42).string(message.duration);
     }
-    if (message.metric !== "") {
+    if (message.metric !== undefined) {
       writer.uint32(66).string(message.metric);
     }
-    if (message.unit !== "") {
+    if (message.unit !== undefined) {
       writer.uint32(74).string(message.unit);
     }
     Object.entries(message.values).forEach(([key, value]) => {
@@ -814,7 +814,7 @@ export const QuotaLimit = {
         value
       }, writer.uint32(80).fork()).ldelim();
     });
-    if (message.displayName !== "") {
+    if (message.displayName !== undefined) {
       writer.uint32(98).string(message.displayName);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/resource.ts
+++ b/__fixtures__/v-next/outputv4/google/api/resource.ts
@@ -358,22 +358,22 @@ function createBaseResourceDescriptor(): ResourceDescriptor {
 export const ResourceDescriptor = {
   typeUrl: "/google.api.ResourceDescriptor",
   encode(message: ResourceDescriptor, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.type !== "") {
+    if (message.type !== undefined) {
       writer.uint32(10).string(message.type);
     }
     for (const v of message.pattern) {
       writer.uint32(18).string(v!);
     }
-    if (message.nameField !== "") {
+    if (message.nameField !== undefined) {
       writer.uint32(26).string(message.nameField);
     }
     if (message.history !== 0) {
       writer.uint32(32).int32(message.history);
     }
-    if (message.plural !== "") {
+    if (message.plural !== undefined) {
       writer.uint32(42).string(message.plural);
     }
-    if (message.singular !== "") {
+    if (message.singular !== undefined) {
       writer.uint32(50).string(message.singular);
     }
     writer.uint32(82).fork();
@@ -562,10 +562,10 @@ function createBaseResourceReference(): ResourceReference {
 export const ResourceReference = {
   typeUrl: "/google.api.ResourceReference",
   encode(message: ResourceReference, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.type !== "") {
+    if (message.type !== undefined) {
       writer.uint32(10).string(message.type);
     }
-    if (message.childType !== "") {
+    if (message.childType !== undefined) {
       writer.uint32(18).string(message.childType);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/routing.ts
+++ b/__fixtures__/v-next/outputv4/google/api/routing.ts
@@ -919,10 +919,10 @@ function createBaseRoutingParameter(): RoutingParameter {
 export const RoutingParameter = {
   typeUrl: "/google.api.RoutingParameter",
   encode(message: RoutingParameter, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.field !== "") {
+    if (message.field !== undefined) {
       writer.uint32(10).string(message.field);
     }
-    if (message.pathTemplate !== "") {
+    if (message.pathTemplate !== undefined) {
       writer.uint32(18).string(message.pathTemplate);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/service.ts
+++ b/__fixtures__/v-next/outputv4/google/api/service.ts
@@ -231,16 +231,16 @@ function createBaseService(): Service {
 export const Service = {
   typeUrl: "/google.api.Service",
   encode(message: Service, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(18).string(message.title);
     }
-    if (message.producerProjectId !== "") {
+    if (message.producerProjectId !== undefined) {
       writer.uint32(178).string(message.producerProjectId);
     }
-    if (message.id !== "") {
+    if (message.id !== undefined) {
       writer.uint32(266).string(message.id);
     }
     for (const v of message.apis) {

--- a/__fixtures__/v-next/outputv4/google/api/servicecontrol/v1/check_error.ts
+++ b/__fixtures__/v-next/outputv4/google/api/servicecontrol/v1/check_error.ts
@@ -243,10 +243,10 @@ export const CheckError = {
     if (message.code !== 0) {
       writer.uint32(8).int32(message.code);
     }
-    if (message.subject !== "") {
+    if (message.subject !== undefined) {
       writer.uint32(34).string(message.subject);
     }
-    if (message.detail !== "") {
+    if (message.detail !== undefined) {
       writer.uint32(18).string(message.detail);
     }
     if (message.status !== undefined) {

--- a/__fixtures__/v-next/outputv4/google/api/servicecontrol/v1/distribution.ts
+++ b/__fixtures__/v-next/outputv4/google/api/servicecontrol/v1/distribution.ts
@@ -191,19 +191,19 @@ function createBaseDistribution(): Distribution {
 export const Distribution = {
   typeUrl: "/google.api.servicecontrol.v1.Distribution",
   encode(message: Distribution, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.count !== BigInt(0)) {
+    if (message.count !== undefined) {
       writer.uint32(8).int64(message.count);
     }
-    if (message.mean !== 0) {
+    if (message.mean !== undefined) {
       writer.uint32(17).double(message.mean);
     }
-    if (message.minimum !== 0) {
+    if (message.minimum !== undefined) {
       writer.uint32(25).double(message.minimum);
     }
-    if (message.maximum !== 0) {
+    if (message.maximum !== undefined) {
       writer.uint32(33).double(message.maximum);
     }
-    if (message.sumOfSquaredDeviation !== 0) {
+    if (message.sumOfSquaredDeviation !== undefined) {
       writer.uint32(41).double(message.sumOfSquaredDeviation);
     }
     writer.uint32(50).fork();
@@ -446,13 +446,13 @@ function createBaseDistribution_LinearBuckets(): Distribution_LinearBuckets {
 export const Distribution_LinearBuckets = {
   typeUrl: "/google.api.servicecontrol.v1.LinearBuckets",
   encode(message: Distribution_LinearBuckets, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.numFiniteBuckets !== 0) {
+    if (message.numFiniteBuckets !== undefined) {
       writer.uint32(8).int32(message.numFiniteBuckets);
     }
-    if (message.width !== 0) {
+    if (message.width !== undefined) {
       writer.uint32(17).double(message.width);
     }
-    if (message.offset !== 0) {
+    if (message.offset !== undefined) {
       writer.uint32(25).double(message.offset);
     }
     return writer;
@@ -562,13 +562,13 @@ function createBaseDistribution_ExponentialBuckets(): Distribution_ExponentialBu
 export const Distribution_ExponentialBuckets = {
   typeUrl: "/google.api.servicecontrol.v1.ExponentialBuckets",
   encode(message: Distribution_ExponentialBuckets, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.numFiniteBuckets !== 0) {
+    if (message.numFiniteBuckets !== undefined) {
       writer.uint32(8).int32(message.numFiniteBuckets);
     }
-    if (message.growthFactor !== 0) {
+    if (message.growthFactor !== undefined) {
       writer.uint32(17).double(message.growthFactor);
     }
-    if (message.scale !== 0) {
+    if (message.scale !== undefined) {
       writer.uint32(25).double(message.scale);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/servicecontrol/v1/http_request.ts
+++ b/__fixtures__/v-next/outputv4/google/api/servicecontrol/v1/http_request.ts
@@ -127,49 +127,49 @@ function createBaseHttpRequest(): HttpRequest {
 export const HttpRequest = {
   typeUrl: "/google.api.servicecontrol.v1.HttpRequest",
   encode(message: HttpRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.requestMethod !== "") {
+    if (message.requestMethod !== undefined) {
       writer.uint32(10).string(message.requestMethod);
     }
-    if (message.requestUrl !== "") {
+    if (message.requestUrl !== undefined) {
       writer.uint32(18).string(message.requestUrl);
     }
-    if (message.requestSize !== BigInt(0)) {
+    if (message.requestSize !== undefined) {
       writer.uint32(24).int64(message.requestSize);
     }
-    if (message.status !== 0) {
+    if (message.status !== undefined) {
       writer.uint32(32).int32(message.status);
     }
-    if (message.responseSize !== BigInt(0)) {
+    if (message.responseSize !== undefined) {
       writer.uint32(40).int64(message.responseSize);
     }
-    if (message.userAgent !== "") {
+    if (message.userAgent !== undefined) {
       writer.uint32(50).string(message.userAgent);
     }
-    if (message.remoteIp !== "") {
+    if (message.remoteIp !== undefined) {
       writer.uint32(58).string(message.remoteIp);
     }
-    if (message.serverIp !== "") {
+    if (message.serverIp !== undefined) {
       writer.uint32(106).string(message.serverIp);
     }
-    if (message.referer !== "") {
+    if (message.referer !== undefined) {
       writer.uint32(66).string(message.referer);
     }
     if (message.latency !== undefined) {
       Duration.encode(message.latency, writer.uint32(114).fork()).ldelim();
     }
-    if (message.cacheLookup === true) {
+    if (message.cacheLookup !== undefined) {
       writer.uint32(88).bool(message.cacheLookup);
     }
-    if (message.cacheHit === true) {
+    if (message.cacheHit !== undefined) {
       writer.uint32(72).bool(message.cacheHit);
     }
-    if (message.cacheValidatedWithOriginServer === true) {
+    if (message.cacheValidatedWithOriginServer !== undefined) {
       writer.uint32(80).bool(message.cacheValidatedWithOriginServer);
     }
-    if (message.cacheFillBytes !== BigInt(0)) {
+    if (message.cacheFillBytes !== undefined) {
       writer.uint32(96).int64(message.cacheFillBytes);
     }
-    if (message.protocol !== "") {
+    if (message.protocol !== undefined) {
       writer.uint32(122).string(message.protocol);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/servicecontrol/v1/log_entry.ts
+++ b/__fixtures__/v-next/outputv4/google/api/servicecontrol/v1/log_entry.ts
@@ -185,10 +185,10 @@ function createBaseLogEntry_LabelsEntry(): LogEntry_LabelsEntry {
 }
 export const LogEntry_LabelsEntry = {
   encode(message: LogEntry_LabelsEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(18).string(message.value);
     }
     return writer;
@@ -290,7 +290,7 @@ function createBaseLogEntry(): LogEntry {
 export const LogEntry = {
   typeUrl: "/google.api.servicecontrol.v1.LogEntry",
   encode(message: LogEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(82).string(message.name);
     }
     if (message.timestamp !== undefined) {
@@ -302,10 +302,10 @@ export const LogEntry = {
     if (message.httpRequest !== undefined) {
       HttpRequest.encode(message.httpRequest, writer.uint32(114).fork()).ldelim();
     }
-    if (message.trace !== "") {
+    if (message.trace !== undefined) {
       writer.uint32(122).string(message.trace);
     }
-    if (message.insertId !== "") {
+    if (message.insertId !== undefined) {
       writer.uint32(34).string(message.insertId);
     }
     Object.entries(message.labels).forEach(([key, value]) => {
@@ -591,16 +591,16 @@ function createBaseLogEntryOperation(): LogEntryOperation {
 export const LogEntryOperation = {
   typeUrl: "/google.api.servicecontrol.v1.LogEntryOperation",
   encode(message: LogEntryOperation, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.id !== "") {
+    if (message.id !== undefined) {
       writer.uint32(10).string(message.id);
     }
-    if (message.producer !== "") {
+    if (message.producer !== undefined) {
       writer.uint32(18).string(message.producer);
     }
-    if (message.first === true) {
+    if (message.first !== undefined) {
       writer.uint32(24).bool(message.first);
     }
-    if (message.last === true) {
+    if (message.last !== undefined) {
       writer.uint32(32).bool(message.last);
     }
     return writer;
@@ -721,13 +721,13 @@ function createBaseLogEntrySourceLocation(): LogEntrySourceLocation {
 export const LogEntrySourceLocation = {
   typeUrl: "/google.api.servicecontrol.v1.LogEntrySourceLocation",
   encode(message: LogEntrySourceLocation, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.file !== "") {
+    if (message.file !== undefined) {
       writer.uint32(10).string(message.file);
     }
-    if (message.line !== BigInt(0)) {
+    if (message.line !== undefined) {
       writer.uint32(16).int64(message.line);
     }
-    if (message.function !== "") {
+    if (message.function !== undefined) {
       writer.uint32(26).string(message.function);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/servicecontrol/v1/metric_value.ts
+++ b/__fixtures__/v-next/outputv4/google/api/servicecontrol/v1/metric_value.ts
@@ -100,10 +100,10 @@ function createBaseMetricValue_LabelsEntry(): MetricValue_LabelsEntry {
 }
 export const MetricValue_LabelsEntry = {
   encode(message: MetricValue_LabelsEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(18).string(message.value);
     }
     return writer;
@@ -440,7 +440,7 @@ function createBaseMetricValueSet(): MetricValueSet {
 export const MetricValueSet = {
   typeUrl: "/google.api.servicecontrol.v1.MetricValueSet",
   encode(message: MetricValueSet, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.metricName !== "") {
+    if (message.metricName !== undefined) {
       writer.uint32(10).string(message.metricName);
     }
     for (const v of message.metricValues) {

--- a/__fixtures__/v-next/outputv4/google/api/servicecontrol/v1/operation.ts
+++ b/__fixtures__/v-next/outputv4/google/api/servicecontrol/v1/operation.ts
@@ -167,10 +167,10 @@ function createBaseOperation_LabelsEntry(): Operation_LabelsEntry {
 }
 export const Operation_LabelsEntry = {
   encode(message: Operation_LabelsEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(18).string(message.value);
     }
     return writer;
@@ -270,13 +270,13 @@ function createBaseOperation(): Operation {
 export const Operation = {
   typeUrl: "/google.api.servicecontrol.v1.Operation",
   encode(message: Operation, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.operationId !== "") {
+    if (message.operationId !== undefined) {
       writer.uint32(10).string(message.operationId);
     }
-    if (message.operationName !== "") {
+    if (message.operationName !== undefined) {
       writer.uint32(18).string(message.operationName);
     }
-    if (message.consumerId !== "") {
+    if (message.consumerId !== undefined) {
       writer.uint32(26).string(message.consumerId);
     }
     if (message.startTime !== undefined) {

--- a/__fixtures__/v-next/outputv4/google/api/servicecontrol/v1/quota_controller.ts
+++ b/__fixtures__/v-next/outputv4/google/api/servicecontrol/v1/quota_controller.ts
@@ -360,13 +360,13 @@ function createBaseAllocateQuotaRequest(): AllocateQuotaRequest {
 export const AllocateQuotaRequest = {
   typeUrl: "/google.api.servicecontrol.v1.AllocateQuotaRequest",
   encode(message: AllocateQuotaRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.serviceName !== "") {
+    if (message.serviceName !== undefined) {
       writer.uint32(10).string(message.serviceName);
     }
     if (message.allocateOperation !== undefined) {
       QuotaOperation.encode(message.allocateOperation, writer.uint32(18).fork()).ldelim();
     }
-    if (message.serviceConfigId !== "") {
+    if (message.serviceConfigId !== undefined) {
       writer.uint32(34).string(message.serviceConfigId);
     }
     return writer;
@@ -476,10 +476,10 @@ function createBaseQuotaOperation_LabelsEntry(): QuotaOperation_LabelsEntry {
 }
 export const QuotaOperation_LabelsEntry = {
   encode(message: QuotaOperation_LabelsEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(18).string(message.value);
     }
     return writer;
@@ -575,13 +575,13 @@ function createBaseQuotaOperation(): QuotaOperation {
 export const QuotaOperation = {
   typeUrl: "/google.api.servicecontrol.v1.QuotaOperation",
   encode(message: QuotaOperation, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.operationId !== "") {
+    if (message.operationId !== undefined) {
       writer.uint32(10).string(message.operationId);
     }
-    if (message.methodName !== "") {
+    if (message.methodName !== undefined) {
       writer.uint32(18).string(message.methodName);
     }
-    if (message.consumerId !== "") {
+    if (message.consumerId !== undefined) {
       writer.uint32(26).string(message.consumerId);
     }
     Object.entries(message.labels).forEach(([key, value]) => {
@@ -794,7 +794,7 @@ function createBaseAllocateQuotaResponse(): AllocateQuotaResponse {
 export const AllocateQuotaResponse = {
   typeUrl: "/google.api.servicecontrol.v1.AllocateQuotaResponse",
   encode(message: AllocateQuotaResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.operationId !== "") {
+    if (message.operationId !== undefined) {
       writer.uint32(10).string(message.operationId);
     }
     for (const v of message.allocateErrors) {
@@ -803,7 +803,7 @@ export const AllocateQuotaResponse = {
     for (const v of message.quotaMetrics) {
       MetricValueSet.encode(v!, writer.uint32(26).fork()).ldelim();
     }
-    if (message.serviceConfigId !== "") {
+    if (message.serviceConfigId !== undefined) {
       writer.uint32(34).string(message.serviceConfigId);
     }
     return writer;
@@ -952,10 +952,10 @@ export const QuotaError = {
     if (message.code !== 0) {
       writer.uint32(8).int32(message.code);
     }
-    if (message.subject !== "") {
+    if (message.subject !== undefined) {
       writer.uint32(18).string(message.subject);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(26).string(message.description);
     }
     if (message.status !== undefined) {

--- a/__fixtures__/v-next/outputv4/google/api/servicecontrol/v1/service_controller.ts
+++ b/__fixtures__/v-next/outputv4/google/api/servicecontrol/v1/service_controller.ts
@@ -302,13 +302,13 @@ function createBaseCheckRequest(): CheckRequest {
 export const CheckRequest = {
   typeUrl: "/google.api.servicecontrol.v1.CheckRequest",
   encode(message: CheckRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.serviceName !== "") {
+    if (message.serviceName !== undefined) {
       writer.uint32(10).string(message.serviceName);
     }
     if (message.operation !== undefined) {
       Operation.encode(message.operation, writer.uint32(18).fork()).ldelim();
     }
-    if (message.serviceConfigId !== "") {
+    if (message.serviceConfigId !== undefined) {
       writer.uint32(34).string(message.serviceConfigId);
     }
     return writer;
@@ -422,16 +422,16 @@ function createBaseCheckResponse(): CheckResponse {
 export const CheckResponse = {
   typeUrl: "/google.api.servicecontrol.v1.CheckResponse",
   encode(message: CheckResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.operationId !== "") {
+    if (message.operationId !== undefined) {
       writer.uint32(10).string(message.operationId);
     }
     for (const v of message.checkErrors) {
       CheckError.encode(v!, writer.uint32(18).fork()).ldelim();
     }
-    if (message.serviceConfigId !== "") {
+    if (message.serviceConfigId !== undefined) {
       writer.uint32(42).string(message.serviceConfigId);
     }
-    if (message.serviceRolloutId !== "") {
+    if (message.serviceRolloutId !== undefined) {
       writer.uint32(90).string(message.serviceRolloutId);
     }
     if (message.checkInfo !== undefined) {
@@ -695,13 +695,13 @@ function createBaseCheckResponse_ConsumerInfo(): CheckResponse_ConsumerInfo {
 export const CheckResponse_ConsumerInfo = {
   typeUrl: "/google.api.servicecontrol.v1.ConsumerInfo",
   encode(message: CheckResponse_ConsumerInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.projectNumber !== BigInt(0)) {
+    if (message.projectNumber !== undefined) {
       writer.uint32(8).int64(message.projectNumber);
     }
     if (message.type !== 0) {
       writer.uint32(16).int32(message.type);
     }
-    if (message.consumerNumber !== BigInt(0)) {
+    if (message.consumerNumber !== undefined) {
       writer.uint32(24).int64(message.consumerNumber);
     }
     return writer;
@@ -815,13 +815,13 @@ function createBaseReportRequest(): ReportRequest {
 export const ReportRequest = {
   typeUrl: "/google.api.servicecontrol.v1.ReportRequest",
   encode(message: ReportRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.serviceName !== "") {
+    if (message.serviceName !== undefined) {
       writer.uint32(10).string(message.serviceName);
     }
     for (const v of message.operations) {
       Operation.encode(v!, writer.uint32(18).fork()).ldelim();
     }
-    if (message.serviceConfigId !== "") {
+    if (message.serviceConfigId !== undefined) {
       writer.uint32(26).string(message.serviceConfigId);
     }
     return writer;
@@ -946,10 +946,10 @@ export const ReportResponse = {
     for (const v of message.reportErrors) {
       ReportResponse_ReportError.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.serviceConfigId !== "") {
+    if (message.serviceConfigId !== undefined) {
       writer.uint32(18).string(message.serviceConfigId);
     }
-    if (message.serviceRolloutId !== "") {
+    if (message.serviceRolloutId !== undefined) {
       writer.uint32(34).string(message.serviceRolloutId);
     }
     return writer;
@@ -1070,7 +1070,7 @@ function createBaseReportResponse_ReportError(): ReportResponse_ReportError {
 export const ReportResponse_ReportError = {
   typeUrl: "/google.api.servicecontrol.v1.ReportError",
   encode(message: ReportResponse_ReportError, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.operationId !== "") {
+    if (message.operationId !== undefined) {
       writer.uint32(10).string(message.operationId);
     }
     if (message.status !== undefined) {

--- a/__fixtures__/v-next/outputv4/google/api/servicecontrol/v2/service_controller.ts
+++ b/__fixtures__/v-next/outputv4/google/api/servicecontrol/v2/service_controller.ts
@@ -176,10 +176,10 @@ function createBaseCheckRequest(): CheckRequest {
 export const CheckRequest = {
   typeUrl: "/google.api.servicecontrol.v2.CheckRequest",
   encode(message: CheckRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.serviceName !== "") {
+    if (message.serviceName !== undefined) {
       writer.uint32(10).string(message.serviceName);
     }
-    if (message.serviceConfigId !== "") {
+    if (message.serviceConfigId !== undefined) {
       writer.uint32(18).string(message.serviceConfigId);
     }
     if (message.attributes !== undefined) {
@@ -188,7 +188,7 @@ export const CheckRequest = {
     for (const v of message.resources) {
       ResourceInfo.encode(v!, writer.uint32(34).fork()).ldelim();
     }
-    if (message.flags !== "") {
+    if (message.flags !== undefined) {
       writer.uint32(42).string(message.flags);
     }
     return writer;
@@ -336,19 +336,19 @@ function createBaseResourceInfo(): ResourceInfo {
 export const ResourceInfo = {
   typeUrl: "/google.api.servicecontrol.v2.ResourceInfo",
   encode(message: ResourceInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.type !== "") {
+    if (message.type !== undefined) {
       writer.uint32(18).string(message.type);
     }
-    if (message.permission !== "") {
+    if (message.permission !== undefined) {
       writer.uint32(26).string(message.permission);
     }
-    if (message.container !== "") {
+    if (message.container !== undefined) {
       writer.uint32(34).string(message.container);
     }
-    if (message.location !== "") {
+    if (message.location !== undefined) {
       writer.uint32(42).string(message.location);
     }
     return writer;
@@ -478,10 +478,10 @@ function createBaseCheckResponse_HeadersEntry(): CheckResponse_HeadersEntry {
 }
 export const CheckResponse_HeadersEntry = {
   encode(message: CheckResponse_HeadersEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(18).string(message.value);
     }
     return writer;
@@ -725,10 +725,10 @@ function createBaseReportRequest(): ReportRequest {
 export const ReportRequest = {
   typeUrl: "/google.api.servicecontrol.v2.ReportRequest",
   encode(message: ReportRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.serviceName !== "") {
+    if (message.serviceName !== undefined) {
       writer.uint32(10).string(message.serviceName);
     }
-    if (message.serviceConfigId !== "") {
+    if (message.serviceConfigId !== undefined) {
       writer.uint32(18).string(message.serviceConfigId);
     }
     for (const v of message.operations) {

--- a/__fixtures__/v-next/outputv4/google/api/servicemanagement/v1/resources.ts
+++ b/__fixtures__/v-next/outputv4/google/api/servicemanagement/v1/resources.ts
@@ -606,10 +606,10 @@ function createBaseManagedService(): ManagedService {
 export const ManagedService = {
   typeUrl: "/google.api.servicemanagement.v1.ManagedService",
   encode(message: ManagedService, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.serviceName !== "") {
+    if (message.serviceName !== undefined) {
       writer.uint32(18).string(message.serviceName);
     }
-    if (message.producerProjectId !== "") {
+    if (message.producerProjectId !== undefined) {
       writer.uint32(26).string(message.producerProjectId);
     }
     return writer;
@@ -715,7 +715,7 @@ export const OperationMetadata = {
     for (const v of message.steps) {
       OperationMetadata_Step.encode(v!, writer.uint32(18).fork()).ldelim();
     }
-    if (message.progressPercentage !== 0) {
+    if (message.progressPercentage !== undefined) {
       writer.uint32(24).int32(message.progressPercentage);
     }
     if (message.startTime !== undefined) {
@@ -862,7 +862,7 @@ function createBaseOperationMetadata_Step(): OperationMetadata_Step {
 export const OperationMetadata_Step = {
   typeUrl: "/google.api.servicemanagement.v1.Step",
   encode(message: OperationMetadata_Step, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
     if (message.status !== 0) {
@@ -964,13 +964,13 @@ function createBaseDiagnostic(): Diagnostic {
 export const Diagnostic = {
   typeUrl: "/google.api.servicemanagement.v1.Diagnostic",
   encode(message: Diagnostic, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.location !== "") {
+    if (message.location !== undefined) {
       writer.uint32(10).string(message.location);
     }
     if (message.kind !== 0) {
       writer.uint32(16).int32(message.kind);
     }
-    if (message.message !== "") {
+    if (message.message !== undefined) {
       writer.uint32(26).string(message.message);
     }
     return writer;
@@ -1079,7 +1079,7 @@ function createBaseConfigSource(): ConfigSource {
 export const ConfigSource = {
   typeUrl: "/google.api.servicemanagement.v1.ConfigSource",
   encode(message: ConfigSource, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.id !== "") {
+    if (message.id !== undefined) {
       writer.uint32(42).string(message.id);
     }
     for (const v of message.files) {
@@ -1193,7 +1193,7 @@ function createBaseConfigFile(): ConfigFile {
 export const ConfigFile = {
   typeUrl: "/google.api.servicemanagement.v1.ConfigFile",
   encode(message: ConfigFile, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.filePath !== "") {
+    if (message.filePath !== undefined) {
       writer.uint32(10).string(message.filePath);
     }
     if (message.fileContents.length !== 0) {
@@ -1307,7 +1307,7 @@ function createBaseConfigRef(): ConfigRef {
 export const ConfigRef = {
   typeUrl: "/google.api.servicemanagement.v1.ConfigRef",
   encode(message: ConfigRef, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     return writer;
@@ -1497,13 +1497,13 @@ function createBaseRollout(): Rollout {
 export const Rollout = {
   typeUrl: "/google.api.servicemanagement.v1.Rollout",
   encode(message: Rollout, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.rolloutId !== "") {
+    if (message.rolloutId !== undefined) {
       writer.uint32(10).string(message.rolloutId);
     }
     if (message.createTime !== undefined) {
       Timestamp.encode(toTimestamp(message.createTime), writer.uint32(18).fork()).ldelim();
     }
-    if (message.createdBy !== "") {
+    if (message.createdBy !== undefined) {
       writer.uint32(26).string(message.createdBy);
     }
     if (message.status !== 0) {
@@ -1515,7 +1515,7 @@ export const Rollout = {
     if (message.deleteServiceStrategy !== undefined) {
       Rollout_DeleteServiceStrategy.encode(message.deleteServiceStrategy, writer.uint32(1602).fork()).ldelim();
     }
-    if (message.serviceName !== "") {
+    if (message.serviceName !== undefined) {
       writer.uint32(66).string(message.serviceName);
     }
     return writer;
@@ -1671,10 +1671,10 @@ function createBaseRollout_TrafficPercentStrategy_PercentagesEntry(): Rollout_Tr
 }
 export const Rollout_TrafficPercentStrategy_PercentagesEntry = {
   encode(message: Rollout_TrafficPercentStrategy_PercentagesEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== 0) {
+    if (message.value !== undefined) {
       writer.uint32(17).double(message.value);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/servicemanagement/v1/servicemanager.ts
+++ b/__fixtures__/v-next/outputv4/google/api/servicemanagement/v1/servicemanager.ts
@@ -456,16 +456,16 @@ function createBaseListServicesRequest(): ListServicesRequest {
 export const ListServicesRequest = {
   typeUrl: "/google.api.servicemanagement.v1.ListServicesRequest",
   encode(message: ListServicesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.producerProjectId !== "") {
+    if (message.producerProjectId !== undefined) {
       writer.uint32(10).string(message.producerProjectId);
     }
-    if (message.pageSize !== 0) {
+    if (message.pageSize !== undefined) {
       writer.uint32(40).int32(message.pageSize);
     }
-    if (message.pageToken !== "") {
+    if (message.pageToken !== undefined) {
       writer.uint32(50).string(message.pageToken);
     }
-    if (message.consumerId !== "") {
+    if (message.consumerId !== undefined) {
       writer.uint32(58).string(message.consumerId);
     }
     return writer;
@@ -588,7 +588,7 @@ export const ListServicesResponse = {
     for (const v of message.services) {
       ManagedService.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.nextPageToken !== "") {
+    if (message.nextPageToken !== undefined) {
       writer.uint32(18).string(message.nextPageToken);
     }
     return writer;
@@ -697,7 +697,7 @@ function createBaseGetServiceRequest(): GetServiceRequest {
 export const GetServiceRequest = {
   typeUrl: "/google.api.servicemanagement.v1.GetServiceRequest",
   encode(message: GetServiceRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.serviceName !== "") {
+    if (message.serviceName !== undefined) {
       writer.uint32(10).string(message.serviceName);
     }
     return writer;
@@ -871,7 +871,7 @@ function createBaseDeleteServiceRequest(): DeleteServiceRequest {
 export const DeleteServiceRequest = {
   typeUrl: "/google.api.servicemanagement.v1.DeleteServiceRequest",
   encode(message: DeleteServiceRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.serviceName !== "") {
+    if (message.serviceName !== undefined) {
       writer.uint32(10).string(message.serviceName);
     }
     return writer;
@@ -957,7 +957,7 @@ function createBaseUndeleteServiceRequest(): UndeleteServiceRequest {
 export const UndeleteServiceRequest = {
   typeUrl: "/google.api.servicemanagement.v1.UndeleteServiceRequest",
   encode(message: UndeleteServiceRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.serviceName !== "") {
+    if (message.serviceName !== undefined) {
       writer.uint32(10).string(message.serviceName);
     }
     return writer;
@@ -1133,10 +1133,10 @@ function createBaseGetServiceConfigRequest(): GetServiceConfigRequest {
 export const GetServiceConfigRequest = {
   typeUrl: "/google.api.servicemanagement.v1.GetServiceConfigRequest",
   encode(message: GetServiceConfigRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.serviceName !== "") {
+    if (message.serviceName !== undefined) {
       writer.uint32(10).string(message.serviceName);
     }
-    if (message.configId !== "") {
+    if (message.configId !== undefined) {
       writer.uint32(18).string(message.configId);
     }
     if (message.view !== 0) {
@@ -1249,13 +1249,13 @@ function createBaseListServiceConfigsRequest(): ListServiceConfigsRequest {
 export const ListServiceConfigsRequest = {
   typeUrl: "/google.api.servicemanagement.v1.ListServiceConfigsRequest",
   encode(message: ListServiceConfigsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.serviceName !== "") {
+    if (message.serviceName !== undefined) {
       writer.uint32(10).string(message.serviceName);
     }
-    if (message.pageToken !== "") {
+    if (message.pageToken !== undefined) {
       writer.uint32(18).string(message.pageToken);
     }
-    if (message.pageSize !== 0) {
+    if (message.pageSize !== undefined) {
       writer.uint32(24).int32(message.pageSize);
     }
     return writer;
@@ -1367,7 +1367,7 @@ export const ListServiceConfigsResponse = {
     for (const v of message.serviceConfigs) {
       Service.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.nextPageToken !== "") {
+    if (message.nextPageToken !== undefined) {
       writer.uint32(18).string(message.nextPageToken);
     }
     return writer;
@@ -1477,7 +1477,7 @@ function createBaseCreateServiceConfigRequest(): CreateServiceConfigRequest {
 export const CreateServiceConfigRequest = {
   typeUrl: "/google.api.servicemanagement.v1.CreateServiceConfigRequest",
   encode(message: CreateServiceConfigRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.serviceName !== "") {
+    if (message.serviceName !== undefined) {
       writer.uint32(10).string(message.serviceName);
     }
     if (message.serviceConfig !== undefined) {
@@ -1581,13 +1581,13 @@ function createBaseSubmitConfigSourceRequest(): SubmitConfigSourceRequest {
 export const SubmitConfigSourceRequest = {
   typeUrl: "/google.api.servicemanagement.v1.SubmitConfigSourceRequest",
   encode(message: SubmitConfigSourceRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.serviceName !== "") {
+    if (message.serviceName !== undefined) {
       writer.uint32(10).string(message.serviceName);
     }
     if (message.configSource !== undefined) {
       ConfigSource.encode(message.configSource, writer.uint32(18).fork()).ldelim();
     }
-    if (message.validateOnly === true) {
+    if (message.validateOnly !== undefined) {
       writer.uint32(24).bool(message.validateOnly);
     }
     return writer;
@@ -1786,7 +1786,7 @@ function createBaseCreateServiceRolloutRequest(): CreateServiceRolloutRequest {
 export const CreateServiceRolloutRequest = {
   typeUrl: "/google.api.servicemanagement.v1.CreateServiceRolloutRequest",
   encode(message: CreateServiceRolloutRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.serviceName !== "") {
+    if (message.serviceName !== undefined) {
       writer.uint32(10).string(message.serviceName);
     }
     if (message.rollout !== undefined) {
@@ -1891,16 +1891,16 @@ function createBaseListServiceRolloutsRequest(): ListServiceRolloutsRequest {
 export const ListServiceRolloutsRequest = {
   typeUrl: "/google.api.servicemanagement.v1.ListServiceRolloutsRequest",
   encode(message: ListServiceRolloutsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.serviceName !== "") {
+    if (message.serviceName !== undefined) {
       writer.uint32(10).string(message.serviceName);
     }
-    if (message.pageToken !== "") {
+    if (message.pageToken !== undefined) {
       writer.uint32(18).string(message.pageToken);
     }
-    if (message.pageSize !== 0) {
+    if (message.pageSize !== undefined) {
       writer.uint32(24).int32(message.pageSize);
     }
-    if (message.filter !== "") {
+    if (message.filter !== undefined) {
       writer.uint32(34).string(message.filter);
     }
     return writer;
@@ -2023,7 +2023,7 @@ export const ListServiceRolloutsResponse = {
     for (const v of message.rollouts) {
       Rollout.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.nextPageToken !== "") {
+    if (message.nextPageToken !== undefined) {
       writer.uint32(18).string(message.nextPageToken);
     }
     return writer;
@@ -2133,10 +2133,10 @@ function createBaseGetServiceRolloutRequest(): GetServiceRolloutRequest {
 export const GetServiceRolloutRequest = {
   typeUrl: "/google.api.servicemanagement.v1.GetServiceRolloutRequest",
   encode(message: GetServiceRolloutRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.serviceName !== "") {
+    if (message.serviceName !== undefined) {
       writer.uint32(10).string(message.serviceName);
     }
-    if (message.rolloutId !== "") {
+    if (message.rolloutId !== undefined) {
       writer.uint32(18).string(message.rolloutId);
     }
     return writer;
@@ -2341,10 +2341,10 @@ function createBaseGenerateConfigReportResponse(): GenerateConfigReportResponse 
 export const GenerateConfigReportResponse = {
   typeUrl: "/google.api.servicemanagement.v1.GenerateConfigReportResponse",
   encode(message: GenerateConfigReportResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.serviceName !== "") {
+    if (message.serviceName !== undefined) {
       writer.uint32(10).string(message.serviceName);
     }
-    if (message.id !== "") {
+    if (message.id !== undefined) {
       writer.uint32(18).string(message.id);
     }
     for (const v of message.changeReports) {

--- a/__fixtures__/v-next/outputv4/google/api/serviceusage/v1/resources.ts
+++ b/__fixtures__/v-next/outputv4/google/api/serviceusage/v1/resources.ts
@@ -181,10 +181,10 @@ function createBaseService(): Service {
 export const Service = {
   typeUrl: "/google.api.serviceusage.v1.Service",
   encode(message: Service, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(42).string(message.parent);
     }
     if (message.config !== undefined) {
@@ -320,10 +320,10 @@ function createBaseServiceConfig(): ServiceConfig {
 export const ServiceConfig = {
   typeUrl: "/google.api.serviceusage.v1.ServiceConfig",
   encode(message: ServiceConfig, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(18).string(message.title);
     }
     for (const v of message.apis) {

--- a/__fixtures__/v-next/outputv4/google/api/serviceusage/v1/serviceusage.ts
+++ b/__fixtures__/v-next/outputv4/google/api/serviceusage/v1/serviceusage.ts
@@ -353,7 +353,7 @@ function createBaseEnableServiceRequest(): EnableServiceRequest {
 export const EnableServiceRequest = {
   typeUrl: "/google.api.serviceusage.v1.EnableServiceRequest",
   encode(message: EnableServiceRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     return writer;
@@ -529,10 +529,10 @@ function createBaseDisableServiceRequest(): DisableServiceRequest {
 export const DisableServiceRequest = {
   typeUrl: "/google.api.serviceusage.v1.DisableServiceRequest",
   encode(message: DisableServiceRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.disableDependentServices === true) {
+    if (message.disableDependentServices !== undefined) {
       writer.uint32(16).bool(message.disableDependentServices);
     }
     if (message.checkIfServiceHasUsage !== 0) {
@@ -731,7 +731,7 @@ function createBaseGetServiceRequest(): GetServiceRequest {
 export const GetServiceRequest = {
   typeUrl: "/google.api.serviceusage.v1.GetServiceRequest",
   encode(message: GetServiceRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     return writer;
@@ -820,16 +820,16 @@ function createBaseListServicesRequest(): ListServicesRequest {
 export const ListServicesRequest = {
   typeUrl: "/google.api.serviceusage.v1.ListServicesRequest",
   encode(message: ListServicesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(10).string(message.parent);
     }
-    if (message.pageSize !== 0) {
+    if (message.pageSize !== undefined) {
       writer.uint32(16).int32(message.pageSize);
     }
-    if (message.pageToken !== "") {
+    if (message.pageToken !== undefined) {
       writer.uint32(26).string(message.pageToken);
     }
-    if (message.filter !== "") {
+    if (message.filter !== undefined) {
       writer.uint32(34).string(message.filter);
     }
     return writer;
@@ -952,7 +952,7 @@ export const ListServicesResponse = {
     for (const v of message.services) {
       Service.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.nextPageToken !== "") {
+    if (message.nextPageToken !== undefined) {
       writer.uint32(18).string(message.nextPageToken);
     }
     return writer;
@@ -1062,7 +1062,7 @@ function createBaseBatchEnableServicesRequest(): BatchEnableServicesRequest {
 export const BatchEnableServicesRequest = {
   typeUrl: "/google.api.serviceusage.v1.BatchEnableServicesRequest",
   encode(message: BatchEnableServicesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(10).string(message.parent);
     }
     for (const v of message.serviceIds) {
@@ -1300,10 +1300,10 @@ function createBaseBatchEnableServicesResponse_EnableFailure(): BatchEnableServi
 export const BatchEnableServicesResponse_EnableFailure = {
   typeUrl: "/google.api.serviceusage.v1.EnableFailure",
   encode(message: BatchEnableServicesResponse_EnableFailure, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.serviceId !== "") {
+    if (message.serviceId !== undefined) {
       writer.uint32(10).string(message.serviceId);
     }
-    if (message.errorMessage !== "") {
+    if (message.errorMessage !== undefined) {
       writer.uint32(18).string(message.errorMessage);
     }
     return writer;
@@ -1401,7 +1401,7 @@ function createBaseBatchGetServicesRequest(): BatchGetServicesRequest {
 export const BatchGetServicesRequest = {
   typeUrl: "/google.api.serviceusage.v1.BatchGetServicesRequest",
   encode(message: BatchGetServicesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(10).string(message.parent);
     }
     for (const v of message.names) {

--- a/__fixtures__/v-next/outputv4/google/api/serviceusage/v1beta1/resources.ts
+++ b/__fixtures__/v-next/outputv4/google/api/serviceusage/v1beta1/resources.ts
@@ -675,10 +675,10 @@ function createBaseService(): Service {
 export const Service = {
   typeUrl: "/google.api.serviceusage.v1beta1.Service",
   encode(message: Service, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(42).string(message.parent);
     }
     if (message.config !== undefined) {
@@ -814,10 +814,10 @@ function createBaseServiceConfig(): ServiceConfig {
 export const ServiceConfig = {
   typeUrl: "/google.api.serviceusage.v1beta1.ServiceConfig",
   encode(message: ServiceConfig, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(18).string(message.title);
     }
     for (const v of message.apis) {
@@ -1175,13 +1175,13 @@ function createBaseConsumerQuotaMetric(): ConsumerQuotaMetric {
 export const ConsumerQuotaMetric = {
   typeUrl: "/google.api.serviceusage.v1beta1.ConsumerQuotaMetric",
   encode(message: ConsumerQuotaMetric, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.metric !== "") {
+    if (message.metric !== undefined) {
       writer.uint32(34).string(message.metric);
     }
-    if (message.displayName !== "") {
+    if (message.displayName !== undefined) {
       writer.uint32(18).string(message.displayName);
     }
     for (const v of message.consumerQuotaLimits) {
@@ -1190,7 +1190,7 @@ export const ConsumerQuotaMetric = {
     for (const v of message.descendantConsumerQuotaLimits) {
       ConsumerQuotaLimit.encode(v!, writer.uint32(50).fork()).ldelim();
     }
-    if (message.unit !== "") {
+    if (message.unit !== undefined) {
       writer.uint32(42).string(message.unit);
     }
     return writer;
@@ -1360,19 +1360,19 @@ function createBaseConsumerQuotaLimit(): ConsumerQuotaLimit {
 export const ConsumerQuotaLimit = {
   typeUrl: "/google.api.serviceusage.v1beta1.ConsumerQuotaLimit",
   encode(message: ConsumerQuotaLimit, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.metric !== "") {
+    if (message.metric !== undefined) {
       writer.uint32(66).string(message.metric);
     }
-    if (message.unit !== "") {
+    if (message.unit !== undefined) {
       writer.uint32(18).string(message.unit);
     }
-    if (message.isPrecise === true) {
+    if (message.isPrecise !== undefined) {
       writer.uint32(24).bool(message.isPrecise);
     }
-    if (message.allowsAdminOverrides === true) {
+    if (message.allowsAdminOverrides !== undefined) {
       writer.uint32(56).bool(message.allowsAdminOverrides);
     }
     for (const v of message.quotaBuckets) {
@@ -1528,10 +1528,10 @@ function createBaseQuotaBucket_DimensionsEntry(): QuotaBucket_DimensionsEntry {
 }
 export const QuotaBucket_DimensionsEntry = {
   encode(message: QuotaBucket_DimensionsEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(18).string(message.value);
     }
     return writer;
@@ -1627,10 +1627,10 @@ function createBaseQuotaBucket(): QuotaBucket {
 export const QuotaBucket = {
   typeUrl: "/google.api.serviceusage.v1beta1.QuotaBucket",
   encode(message: QuotaBucket, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.effectiveLimit !== BigInt(0)) {
+    if (message.effectiveLimit !== undefined) {
       writer.uint32(8).int64(message.effectiveLimit);
     }
-    if (message.defaultLimit !== BigInt(0)) {
+    if (message.defaultLimit !== undefined) {
       writer.uint32(16).int64(message.defaultLimit);
     }
     if (message.producerOverride !== undefined) {
@@ -1841,10 +1841,10 @@ function createBaseQuotaOverride_DimensionsEntry(): QuotaOverride_DimensionsEntr
 }
 export const QuotaOverride_DimensionsEntry = {
   encode(message: QuotaOverride_DimensionsEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(18).string(message.value);
     }
     return writer;
@@ -1940,10 +1940,10 @@ function createBaseQuotaOverride(): QuotaOverride {
 export const QuotaOverride = {
   typeUrl: "/google.api.serviceusage.v1beta1.QuotaOverride",
   encode(message: QuotaOverride, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.overrideValue !== BigInt(0)) {
+    if (message.overrideValue !== undefined) {
       writer.uint32(16).int64(message.overrideValue);
     }
     Object.entries(message.dimensions).forEach(([key, value]) => {
@@ -1952,13 +1952,13 @@ export const QuotaOverride = {
         value
       }, writer.uint32(26).fork()).ldelim();
     });
-    if (message.metric !== "") {
+    if (message.metric !== undefined) {
       writer.uint32(34).string(message.metric);
     }
-    if (message.unit !== "") {
+    if (message.unit !== undefined) {
       writer.uint32(42).string(message.unit);
     }
-    if (message.adminOverrideAncestor !== "") {
+    if (message.adminOverrideAncestor !== undefined) {
       writer.uint32(50).string(message.adminOverrideAncestor);
     }
     return writer;
@@ -2244,10 +2244,10 @@ function createBaseAdminQuotaPolicy_DimensionsEntry(): AdminQuotaPolicy_Dimensio
 }
 export const AdminQuotaPolicy_DimensionsEntry = {
   encode(message: AdminQuotaPolicy_DimensionsEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(18).string(message.value);
     }
     return writer;
@@ -2343,10 +2343,10 @@ function createBaseAdminQuotaPolicy(): AdminQuotaPolicy {
 export const AdminQuotaPolicy = {
   typeUrl: "/google.api.serviceusage.v1beta1.AdminQuotaPolicy",
   encode(message: AdminQuotaPolicy, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.policyValue !== BigInt(0)) {
+    if (message.policyValue !== undefined) {
       writer.uint32(16).int64(message.policyValue);
     }
     Object.entries(message.dimensions).forEach(([key, value]) => {
@@ -2355,13 +2355,13 @@ export const AdminQuotaPolicy = {
         value
       }, writer.uint32(26).fork()).ldelim();
     });
-    if (message.metric !== "") {
+    if (message.metric !== undefined) {
       writer.uint32(34).string(message.metric);
     }
-    if (message.unit !== "") {
+    if (message.unit !== undefined) {
       writer.uint32(42).string(message.unit);
     }
-    if (message.container !== "") {
+    if (message.container !== undefined) {
       writer.uint32(50).string(message.container);
     }
     return writer;
@@ -2550,10 +2550,10 @@ function createBaseServiceIdentity(): ServiceIdentity {
 export const ServiceIdentity = {
   typeUrl: "/google.api.serviceusage.v1beta1.ServiceIdentity",
   encode(message: ServiceIdentity, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.email !== "") {
+    if (message.email !== undefined) {
       writer.uint32(10).string(message.email);
     }
-    if (message.uniqueId !== "") {
+    if (message.uniqueId !== undefined) {
       writer.uint32(18).string(message.uniqueId);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/serviceusage/v1beta1/serviceusage.ts
+++ b/__fixtures__/v-next/outputv4/google/api/serviceusage/v1beta1/serviceusage.ts
@@ -908,7 +908,7 @@ function createBaseEnableServiceRequest(): EnableServiceRequest {
 export const EnableServiceRequest = {
   typeUrl: "/google.api.serviceusage.v1beta1.EnableServiceRequest",
   encode(message: EnableServiceRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     return writer;
@@ -994,7 +994,7 @@ function createBaseDisableServiceRequest(): DisableServiceRequest {
 export const DisableServiceRequest = {
   typeUrl: "/google.api.serviceusage.v1beta1.DisableServiceRequest",
   encode(message: DisableServiceRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     return writer;
@@ -1080,7 +1080,7 @@ function createBaseGetServiceRequest(): GetServiceRequest {
 export const GetServiceRequest = {
   typeUrl: "/google.api.serviceusage.v1beta1.GetServiceRequest",
   encode(message: GetServiceRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     return writer;
@@ -1169,16 +1169,16 @@ function createBaseListServicesRequest(): ListServicesRequest {
 export const ListServicesRequest = {
   typeUrl: "/google.api.serviceusage.v1beta1.ListServicesRequest",
   encode(message: ListServicesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(10).string(message.parent);
     }
-    if (message.pageSize !== 0) {
+    if (message.pageSize !== undefined) {
       writer.uint32(16).int32(message.pageSize);
     }
-    if (message.pageToken !== "") {
+    if (message.pageToken !== undefined) {
       writer.uint32(26).string(message.pageToken);
     }
-    if (message.filter !== "") {
+    if (message.filter !== undefined) {
       writer.uint32(34).string(message.filter);
     }
     return writer;
@@ -1301,7 +1301,7 @@ export const ListServicesResponse = {
     for (const v of message.services) {
       Service.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.nextPageToken !== "") {
+    if (message.nextPageToken !== undefined) {
       writer.uint32(18).string(message.nextPageToken);
     }
     return writer;
@@ -1411,7 +1411,7 @@ function createBaseBatchEnableServicesRequest(): BatchEnableServicesRequest {
 export const BatchEnableServicesRequest = {
   typeUrl: "/google.api.serviceusage.v1beta1.BatchEnableServicesRequest",
   encode(message: BatchEnableServicesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(10).string(message.parent);
     }
     for (const v of message.serviceIds) {
@@ -1526,13 +1526,13 @@ function createBaseListConsumerQuotaMetricsRequest(): ListConsumerQuotaMetricsRe
 export const ListConsumerQuotaMetricsRequest = {
   typeUrl: "/google.api.serviceusage.v1beta1.ListConsumerQuotaMetricsRequest",
   encode(message: ListConsumerQuotaMetricsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(10).string(message.parent);
     }
-    if (message.pageSize !== 0) {
+    if (message.pageSize !== undefined) {
       writer.uint32(16).int32(message.pageSize);
     }
-    if (message.pageToken !== "") {
+    if (message.pageToken !== undefined) {
       writer.uint32(26).string(message.pageToken);
     }
     if (message.view !== 0) {
@@ -1658,7 +1658,7 @@ export const ListConsumerQuotaMetricsResponse = {
     for (const v of message.metrics) {
       ConsumerQuotaMetric.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.nextPageToken !== "") {
+    if (message.nextPageToken !== undefined) {
       writer.uint32(18).string(message.nextPageToken);
     }
     return writer;
@@ -1768,7 +1768,7 @@ function createBaseGetConsumerQuotaMetricRequest(): GetConsumerQuotaMetricReques
 export const GetConsumerQuotaMetricRequest = {
   typeUrl: "/google.api.serviceusage.v1beta1.GetConsumerQuotaMetricRequest",
   encode(message: GetConsumerQuotaMetricRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     if (message.view !== 0) {
@@ -1869,7 +1869,7 @@ function createBaseGetConsumerQuotaLimitRequest(): GetConsumerQuotaLimitRequest 
 export const GetConsumerQuotaLimitRequest = {
   typeUrl: "/google.api.serviceusage.v1beta1.GetConsumerQuotaLimitRequest",
   encode(message: GetConsumerQuotaLimitRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     if (message.view !== 0) {
@@ -1972,13 +1972,13 @@ function createBaseCreateAdminOverrideRequest(): CreateAdminOverrideRequest {
 export const CreateAdminOverrideRequest = {
   typeUrl: "/google.api.serviceusage.v1beta1.CreateAdminOverrideRequest",
   encode(message: CreateAdminOverrideRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(10).string(message.parent);
     }
     if (message.override !== undefined) {
       QuotaOverride.encode(message.override, writer.uint32(18).fork()).ldelim();
     }
-    if (message.force === true) {
+    if (message.force !== undefined) {
       writer.uint32(24).bool(message.force);
     }
     writer.uint32(34).fork();
@@ -2127,13 +2127,13 @@ function createBaseUpdateAdminOverrideRequest(): UpdateAdminOverrideRequest {
 export const UpdateAdminOverrideRequest = {
   typeUrl: "/google.api.serviceusage.v1beta1.UpdateAdminOverrideRequest",
   encode(message: UpdateAdminOverrideRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     if (message.override !== undefined) {
       QuotaOverride.encode(message.override, writer.uint32(18).fork()).ldelim();
     }
-    if (message.force === true) {
+    if (message.force !== undefined) {
       writer.uint32(24).bool(message.force);
     }
     if (message.updateMask !== undefined) {
@@ -2296,10 +2296,10 @@ function createBaseDeleteAdminOverrideRequest(): DeleteAdminOverrideRequest {
 export const DeleteAdminOverrideRequest = {
   typeUrl: "/google.api.serviceusage.v1beta1.DeleteAdminOverrideRequest",
   encode(message: DeleteAdminOverrideRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.force === true) {
+    if (message.force !== undefined) {
       writer.uint32(16).bool(message.force);
     }
     writer.uint32(26).fork();
@@ -2433,13 +2433,13 @@ function createBaseListAdminOverridesRequest(): ListAdminOverridesRequest {
 export const ListAdminOverridesRequest = {
   typeUrl: "/google.api.serviceusage.v1beta1.ListAdminOverridesRequest",
   encode(message: ListAdminOverridesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(10).string(message.parent);
     }
-    if (message.pageSize !== 0) {
+    if (message.pageSize !== undefined) {
       writer.uint32(16).int32(message.pageSize);
     }
-    if (message.pageToken !== "") {
+    if (message.pageToken !== undefined) {
       writer.uint32(26).string(message.pageToken);
     }
     return writer;
@@ -2551,7 +2551,7 @@ export const ListAdminOverridesResponse = {
     for (const v of message.overrides) {
       QuotaOverride.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.nextPageToken !== "") {
+    if (message.nextPageToken !== undefined) {
       writer.uint32(18).string(message.nextPageToken);
     }
     return writer;
@@ -2761,13 +2761,13 @@ function createBaseImportAdminOverridesRequest(): ImportAdminOverridesRequest {
 export const ImportAdminOverridesRequest = {
   typeUrl: "/google.api.serviceusage.v1beta1.ImportAdminOverridesRequest",
   encode(message: ImportAdminOverridesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(10).string(message.parent);
     }
     if (message.inlineSource !== undefined) {
       OverrideInlineSource.encode(message.inlineSource, writer.uint32(18).fork()).ldelim();
     }
-    if (message.force === true) {
+    if (message.force !== undefined) {
       writer.uint32(24).bool(message.force);
     }
     writer.uint32(34).fork();
@@ -3080,13 +3080,13 @@ function createBaseCreateConsumerOverrideRequest(): CreateConsumerOverrideReques
 export const CreateConsumerOverrideRequest = {
   typeUrl: "/google.api.serviceusage.v1beta1.CreateConsumerOverrideRequest",
   encode(message: CreateConsumerOverrideRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(10).string(message.parent);
     }
     if (message.override !== undefined) {
       QuotaOverride.encode(message.override, writer.uint32(18).fork()).ldelim();
     }
-    if (message.force === true) {
+    if (message.force !== undefined) {
       writer.uint32(24).bool(message.force);
     }
     writer.uint32(34).fork();
@@ -3235,13 +3235,13 @@ function createBaseUpdateConsumerOverrideRequest(): UpdateConsumerOverrideReques
 export const UpdateConsumerOverrideRequest = {
   typeUrl: "/google.api.serviceusage.v1beta1.UpdateConsumerOverrideRequest",
   encode(message: UpdateConsumerOverrideRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     if (message.override !== undefined) {
       QuotaOverride.encode(message.override, writer.uint32(18).fork()).ldelim();
     }
-    if (message.force === true) {
+    if (message.force !== undefined) {
       writer.uint32(24).bool(message.force);
     }
     if (message.updateMask !== undefined) {
@@ -3404,10 +3404,10 @@ function createBaseDeleteConsumerOverrideRequest(): DeleteConsumerOverrideReques
 export const DeleteConsumerOverrideRequest = {
   typeUrl: "/google.api.serviceusage.v1beta1.DeleteConsumerOverrideRequest",
   encode(message: DeleteConsumerOverrideRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.force === true) {
+    if (message.force !== undefined) {
       writer.uint32(16).bool(message.force);
     }
     writer.uint32(26).fork();
@@ -3541,13 +3541,13 @@ function createBaseListConsumerOverridesRequest(): ListConsumerOverridesRequest 
 export const ListConsumerOverridesRequest = {
   typeUrl: "/google.api.serviceusage.v1beta1.ListConsumerOverridesRequest",
   encode(message: ListConsumerOverridesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(10).string(message.parent);
     }
-    if (message.pageSize !== 0) {
+    if (message.pageSize !== undefined) {
       writer.uint32(16).int32(message.pageSize);
     }
-    if (message.pageToken !== "") {
+    if (message.pageToken !== undefined) {
       writer.uint32(26).string(message.pageToken);
     }
     return writer;
@@ -3659,7 +3659,7 @@ export const ListConsumerOverridesResponse = {
     for (const v of message.overrides) {
       QuotaOverride.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.nextPageToken !== "") {
+    if (message.nextPageToken !== undefined) {
       writer.uint32(18).string(message.nextPageToken);
     }
     return writer;
@@ -3869,13 +3869,13 @@ function createBaseImportConsumerOverridesRequest(): ImportConsumerOverridesRequ
 export const ImportConsumerOverridesRequest = {
   typeUrl: "/google.api.serviceusage.v1beta1.ImportConsumerOverridesRequest",
   encode(message: ImportConsumerOverridesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(10).string(message.parent);
     }
     if (message.inlineSource !== undefined) {
       OverrideInlineSource.encode(message.inlineSource, writer.uint32(18).fork()).ldelim();
     }
-    if (message.force === true) {
+    if (message.force !== undefined) {
       writer.uint32(24).bool(message.force);
     }
     writer.uint32(34).fork();
@@ -4551,7 +4551,7 @@ function createBaseGenerateServiceIdentityRequest(): GenerateServiceIdentityRequ
 export const GenerateServiceIdentityRequest = {
   typeUrl: "/google.api.serviceusage.v1beta1.GenerateServiceIdentityRequest",
   encode(message: GenerateServiceIdentityRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(10).string(message.parent);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/system_parameter.ts
+++ b/__fixtures__/v-next/outputv4/google/api/system_parameter.ts
@@ -231,7 +231,7 @@ function createBaseSystemParameterRule(): SystemParameterRule {
 export const SystemParameterRule = {
   typeUrl: "/google.api.SystemParameterRule",
   encode(message: SystemParameterRule, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.selector !== "") {
+    if (message.selector !== undefined) {
       writer.uint32(10).string(message.selector);
     }
     for (const v of message.parameters) {
@@ -345,13 +345,13 @@ function createBaseSystemParameter(): SystemParameter {
 export const SystemParameter = {
   typeUrl: "/google.api.SystemParameter",
   encode(message: SystemParameter, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.httpHeader !== "") {
+    if (message.httpHeader !== undefined) {
       writer.uint32(18).string(message.httpHeader);
     }
-    if (message.urlQueryParameter !== "") {
+    if (message.urlQueryParameter !== undefined) {
       writer.uint32(26).string(message.urlQueryParameter);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/usage.ts
+++ b/__fixtures__/v-next/outputv4/google/api/usage.ts
@@ -143,7 +143,7 @@ export const Usage = {
     for (const v of message.rules) {
       UsageRule.encode(v!, writer.uint32(50).fork()).ldelim();
     }
-    if (message.producerNotificationChannel !== "") {
+    if (message.producerNotificationChannel !== undefined) {
       writer.uint32(58).string(message.producerNotificationChannel);
     }
     return writer;
@@ -277,13 +277,13 @@ function createBaseUsageRule(): UsageRule {
 export const UsageRule = {
   typeUrl: "/google.api.UsageRule",
   encode(message: UsageRule, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.selector !== "") {
+    if (message.selector !== undefined) {
       writer.uint32(10).string(message.selector);
     }
-    if (message.allowUnregisteredCalls === true) {
+    if (message.allowUnregisteredCalls !== undefined) {
       writer.uint32(16).bool(message.allowUnregisteredCalls);
     }
-    if (message.skipServiceControl === true) {
+    if (message.skipServiceControl !== undefined) {
       writer.uint32(24).bool(message.skipServiceControl);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/api/visibility.ts
+++ b/__fixtures__/v-next/outputv4/google/api/visibility.ts
@@ -213,10 +213,10 @@ function createBaseVisibilityRule(): VisibilityRule {
 export const VisibilityRule = {
   typeUrl: "/google.api.VisibilityRule",
   encode(message: VisibilityRule, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.selector !== "") {
+    if (message.selector !== undefined) {
       writer.uint32(10).string(message.selector);
     }
-    if (message.restriction !== "") {
+    if (message.restriction !== undefined) {
       writer.uint32(18).string(message.restriction);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/logging/type/http_request.ts
+++ b/__fixtures__/v-next/outputv4/google/logging/type/http_request.ts
@@ -129,49 +129,49 @@ function createBaseHttpRequest(): HttpRequest {
 export const HttpRequest = {
   typeUrl: "/google.logging.type.HttpRequest",
   encode(message: HttpRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.requestMethod !== "") {
+    if (message.requestMethod !== undefined) {
       writer.uint32(10).string(message.requestMethod);
     }
-    if (message.requestUrl !== "") {
+    if (message.requestUrl !== undefined) {
       writer.uint32(18).string(message.requestUrl);
     }
-    if (message.requestSize !== BigInt(0)) {
+    if (message.requestSize !== undefined) {
       writer.uint32(24).int64(message.requestSize);
     }
-    if (message.status !== 0) {
+    if (message.status !== undefined) {
       writer.uint32(32).int32(message.status);
     }
-    if (message.responseSize !== BigInt(0)) {
+    if (message.responseSize !== undefined) {
       writer.uint32(40).int64(message.responseSize);
     }
-    if (message.userAgent !== "") {
+    if (message.userAgent !== undefined) {
       writer.uint32(50).string(message.userAgent);
     }
-    if (message.remoteIp !== "") {
+    if (message.remoteIp !== undefined) {
       writer.uint32(58).string(message.remoteIp);
     }
-    if (message.serverIp !== "") {
+    if (message.serverIp !== undefined) {
       writer.uint32(106).string(message.serverIp);
     }
-    if (message.referer !== "") {
+    if (message.referer !== undefined) {
       writer.uint32(66).string(message.referer);
     }
     if (message.latency !== undefined) {
       Duration.encode(message.latency, writer.uint32(114).fork()).ldelim();
     }
-    if (message.cacheLookup === true) {
+    if (message.cacheLookup !== undefined) {
       writer.uint32(88).bool(message.cacheLookup);
     }
-    if (message.cacheHit === true) {
+    if (message.cacheHit !== undefined) {
       writer.uint32(72).bool(message.cacheHit);
     }
-    if (message.cacheValidatedWithOriginServer === true) {
+    if (message.cacheValidatedWithOriginServer !== undefined) {
       writer.uint32(80).bool(message.cacheValidatedWithOriginServer);
     }
-    if (message.cacheFillBytes !== BigInt(0)) {
+    if (message.cacheFillBytes !== undefined) {
       writer.uint32(96).int64(message.cacheFillBytes);
     }
-    if (message.protocol !== "") {
+    if (message.protocol !== undefined) {
       writer.uint32(122).string(message.protocol);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/logging/v2/log_entry.ts
+++ b/__fixtures__/v-next/outputv4/google/logging/v2/log_entry.ts
@@ -309,10 +309,10 @@ function createBaseLogEntry_LabelsEntry(): LogEntry_LabelsEntry {
 }
 export const LogEntry_LabelsEntry = {
   encode(message: LogEntry_LabelsEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(18).string(message.value);
     }
     return writer;
@@ -419,7 +419,7 @@ function createBaseLogEntry(): LogEntry {
 export const LogEntry = {
   typeUrl: "/google.logging.v2.LogEntry",
   encode(message: LogEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.logName !== "") {
+    if (message.logName !== undefined) {
       writer.uint32(98).string(message.logName);
     }
     if (message.resource !== undefined) {
@@ -443,7 +443,7 @@ export const LogEntry = {
     if (message.severity !== 0) {
       writer.uint32(80).int32(message.severity);
     }
-    if (message.insertId !== "") {
+    if (message.insertId !== undefined) {
       writer.uint32(34).string(message.insertId);
     }
     if (message.httpRequest !== undefined) {
@@ -458,13 +458,13 @@ export const LogEntry = {
     if (message.operation !== undefined) {
       LogEntryOperation.encode(message.operation, writer.uint32(122).fork()).ldelim();
     }
-    if (message.trace !== "") {
+    if (message.trace !== undefined) {
       writer.uint32(178).string(message.trace);
     }
-    if (message.spanId !== "") {
+    if (message.spanId !== undefined) {
       writer.uint32(218).string(message.spanId);
     }
-    if (message.traceSampled === true) {
+    if (message.traceSampled !== undefined) {
       writer.uint32(240).bool(message.traceSampled);
     }
     if (message.sourceLocation !== undefined) {
@@ -794,16 +794,16 @@ function createBaseLogEntryOperation(): LogEntryOperation {
 export const LogEntryOperation = {
   typeUrl: "/google.logging.v2.LogEntryOperation",
   encode(message: LogEntryOperation, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.id !== "") {
+    if (message.id !== undefined) {
       writer.uint32(10).string(message.id);
     }
-    if (message.producer !== "") {
+    if (message.producer !== undefined) {
       writer.uint32(18).string(message.producer);
     }
-    if (message.first === true) {
+    if (message.first !== undefined) {
       writer.uint32(24).bool(message.first);
     }
-    if (message.last === true) {
+    if (message.last !== undefined) {
       writer.uint32(32).bool(message.last);
     }
     return writer;
@@ -924,13 +924,13 @@ function createBaseLogEntrySourceLocation(): LogEntrySourceLocation {
 export const LogEntrySourceLocation = {
   typeUrl: "/google.logging.v2.LogEntrySourceLocation",
   encode(message: LogEntrySourceLocation, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.file !== "") {
+    if (message.file !== undefined) {
       writer.uint32(10).string(message.file);
     }
-    if (message.line !== BigInt(0)) {
+    if (message.line !== undefined) {
       writer.uint32(16).int64(message.line);
     }
-    if (message.function !== "") {
+    if (message.function !== undefined) {
       writer.uint32(26).string(message.function);
     }
     return writer;
@@ -1042,13 +1042,13 @@ function createBaseLogSplit(): LogSplit {
 export const LogSplit = {
   typeUrl: "/google.logging.v2.LogSplit",
   encode(message: LogSplit, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.uid !== "") {
+    if (message.uid !== undefined) {
       writer.uint32(10).string(message.uid);
     }
-    if (message.index !== 0) {
+    if (message.index !== undefined) {
       writer.uint32(16).int32(message.index);
     }
-    if (message.totalSplits !== 0) {
+    if (message.totalSplits !== undefined) {
       writer.uint32(24).int32(message.totalSplits);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/logging/v2/logging.ts
+++ b/__fixtures__/v-next/outputv4/google/logging/v2/logging.ts
@@ -551,7 +551,7 @@ function createBaseDeleteLogRequest(): DeleteLogRequest {
 export const DeleteLogRequest = {
   typeUrl: "/google.logging.v2.DeleteLogRequest",
   encode(message: DeleteLogRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.logName !== "") {
+    if (message.logName !== undefined) {
       writer.uint32(10).string(message.logName);
     }
     return writer;
@@ -637,10 +637,10 @@ function createBaseWriteLogEntriesRequest_LabelsEntry(): WriteLogEntriesRequest_
 }
 export const WriteLogEntriesRequest_LabelsEntry = {
   encode(message: WriteLogEntriesRequest_LabelsEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(18).string(message.value);
     }
     return writer;
@@ -736,7 +736,7 @@ function createBaseWriteLogEntriesRequest(): WriteLogEntriesRequest {
 export const WriteLogEntriesRequest = {
   typeUrl: "/google.logging.v2.WriteLogEntriesRequest",
   encode(message: WriteLogEntriesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.logName !== "") {
+    if (message.logName !== undefined) {
       writer.uint32(10).string(message.logName);
     }
     if (message.resource !== undefined) {
@@ -751,10 +751,10 @@ export const WriteLogEntriesRequest = {
     for (const v of message.entries) {
       LogEntry.encode(v!, writer.uint32(34).fork()).ldelim();
     }
-    if (message.partialSuccess === true) {
+    if (message.partialSuccess !== undefined) {
       writer.uint32(40).bool(message.partialSuccess);
     }
-    if (message.dryRun === true) {
+    if (message.dryRun !== undefined) {
       writer.uint32(48).bool(message.dryRun);
     }
     return writer;
@@ -1021,7 +1021,7 @@ function createBaseWriteLogEntriesPartialErrors_LogEntryErrorsEntry(): WriteLogE
 }
 export const WriteLogEntriesPartialErrors_LogEntryErrorsEntry = {
   encode(message: WriteLogEntriesPartialErrors_LogEntryErrorsEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== 0) {
+    if (message.key !== undefined) {
       writer.uint32(8).int32(message.key);
     }
     if (message.value !== undefined) {
@@ -1258,16 +1258,16 @@ export const ListLogEntriesRequest = {
     for (const v of message.resourceNames) {
       writer.uint32(66).string(v!);
     }
-    if (message.filter !== "") {
+    if (message.filter !== undefined) {
       writer.uint32(18).string(message.filter);
     }
-    if (message.orderBy !== "") {
+    if (message.orderBy !== undefined) {
       writer.uint32(26).string(message.orderBy);
     }
-    if (message.pageSize !== 0) {
+    if (message.pageSize !== undefined) {
       writer.uint32(32).int32(message.pageSize);
     }
-    if (message.pageToken !== "") {
+    if (message.pageToken !== undefined) {
       writer.uint32(42).string(message.pageToken);
     }
     return writer;
@@ -1413,7 +1413,7 @@ export const ListLogEntriesResponse = {
     for (const v of message.entries) {
       LogEntry.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.nextPageToken !== "") {
+    if (message.nextPageToken !== undefined) {
       writer.uint32(18).string(message.nextPageToken);
     }
     return writer;
@@ -1523,10 +1523,10 @@ function createBaseListMonitoredResourceDescriptorsRequest(): ListMonitoredResou
 export const ListMonitoredResourceDescriptorsRequest = {
   typeUrl: "/google.logging.v2.ListMonitoredResourceDescriptorsRequest",
   encode(message: ListMonitoredResourceDescriptorsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.pageSize !== 0) {
+    if (message.pageSize !== undefined) {
       writer.uint32(8).int32(message.pageSize);
     }
-    if (message.pageToken !== "") {
+    if (message.pageToken !== undefined) {
       writer.uint32(18).string(message.pageToken);
     }
     return writer;
@@ -1627,7 +1627,7 @@ export const ListMonitoredResourceDescriptorsResponse = {
     for (const v of message.resourceDescriptors) {
       MonitoredResourceDescriptor.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.nextPageToken !== "") {
+    if (message.nextPageToken !== undefined) {
       writer.uint32(18).string(message.nextPageToken);
     }
     return writer;
@@ -1739,13 +1739,13 @@ function createBaseListLogsRequest(): ListLogsRequest {
 export const ListLogsRequest = {
   typeUrl: "/google.logging.v2.ListLogsRequest",
   encode(message: ListLogsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(10).string(message.parent);
     }
-    if (message.pageSize !== 0) {
+    if (message.pageSize !== undefined) {
       writer.uint32(16).int32(message.pageSize);
     }
-    if (message.pageToken !== "") {
+    if (message.pageToken !== undefined) {
       writer.uint32(26).string(message.pageToken);
     }
     for (const v of message.resourceNames) {
@@ -1883,7 +1883,7 @@ export const ListLogsResponse = {
     for (const v of message.logNames) {
       writer.uint32(26).string(v!);
     }
-    if (message.nextPageToken !== "") {
+    if (message.nextPageToken !== undefined) {
       writer.uint32(18).string(message.nextPageToken);
     }
     return writer;
@@ -1997,7 +1997,7 @@ export const TailLogEntriesRequest = {
     for (const v of message.resourceNames) {
       writer.uint32(10).string(v!);
     }
-    if (message.filter !== "") {
+    if (message.filter !== undefined) {
       writer.uint32(18).string(message.filter);
     }
     if (message.bufferWindow !== undefined) {
@@ -2251,7 +2251,7 @@ export const TailLogEntriesResponse_SuppressionInfo = {
     if (message.reason !== 0) {
       writer.uint32(8).int32(message.reason);
     }
-    if (message.suppressedCount !== 0) {
+    if (message.suppressedCount !== undefined) {
       writer.uint32(16).int32(message.suppressedCount);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/logging/v2/logging_config.ts
+++ b/__fixtures__/v-next/outputv4/google/logging/v2/logging_config.ts
@@ -1757,10 +1757,10 @@ function createBaseLogBucket(): LogBucket {
 export const LogBucket = {
   typeUrl: "/google.logging.v2.LogBucket",
   encode(message: LogBucket, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(26).string(message.description);
     }
     if (message.createTime !== undefined) {
@@ -1769,10 +1769,10 @@ export const LogBucket = {
     if (message.updateTime !== undefined) {
       Timestamp.encode(toTimestamp(message.updateTime), writer.uint32(42).fork()).ldelim();
     }
-    if (message.retentionDays !== 0) {
+    if (message.retentionDays !== undefined) {
       writer.uint32(88).int32(message.retentionDays);
     }
-    if (message.locked === true) {
+    if (message.locked !== undefined) {
       writer.uint32(72).bool(message.locked);
     }
     if (message.lifecycleState !== 0) {
@@ -1973,10 +1973,10 @@ function createBaseLogView(): LogView {
 export const LogView = {
   typeUrl: "/google.logging.v2.LogView",
   encode(message: LogView, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(26).string(message.description);
     }
     if (message.createTime !== undefined) {
@@ -1985,7 +1985,7 @@ export const LogView = {
     if (message.updateTime !== undefined) {
       Timestamp.encode(toTimestamp(message.updateTime), writer.uint32(42).fork()).ldelim();
     }
-    if (message.filter !== "") {
+    if (message.filter !== undefined) {
       writer.uint32(58).string(message.filter);
     }
     return writer;
@@ -2126,19 +2126,19 @@ function createBaseLogSink(): LogSink {
 export const LogSink = {
   typeUrl: "/google.logging.v2.LogSink",
   encode(message: LogSink, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.destination !== "") {
+    if (message.destination !== undefined) {
       writer.uint32(26).string(message.destination);
     }
-    if (message.filter !== "") {
+    if (message.filter !== undefined) {
       writer.uint32(42).string(message.filter);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(146).string(message.description);
     }
-    if (message.disabled === true) {
+    if (message.disabled !== undefined) {
       writer.uint32(152).bool(message.disabled);
     }
     for (const v of message.exclusions) {
@@ -2147,10 +2147,10 @@ export const LogSink = {
     if (message.outputVersionFormat !== 0) {
       writer.uint32(48).int32(message.outputVersionFormat);
     }
-    if (message.writerIdentity !== "") {
+    if (message.writerIdentity !== undefined) {
       writer.uint32(66).string(message.writerIdentity);
     }
-    if (message.includeChildren === true) {
+    if (message.includeChildren !== undefined) {
       writer.uint32(72).bool(message.includeChildren);
     }
     if (message.bigqueryOptions !== undefined) {
@@ -2381,10 +2381,10 @@ function createBaseBigQueryOptions(): BigQueryOptions {
 export const BigQueryOptions = {
   typeUrl: "/google.logging.v2.BigQueryOptions",
   encode(message: BigQueryOptions, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.usePartitionedTables === true) {
+    if (message.usePartitionedTables !== undefined) {
       writer.uint32(8).bool(message.usePartitionedTables);
     }
-    if (message.usesTimestampColumnPartitioning === true) {
+    if (message.usesTimestampColumnPartitioning !== undefined) {
       writer.uint32(24).bool(message.usesTimestampColumnPartitioning);
     }
     return writer;
@@ -2483,13 +2483,13 @@ function createBaseListBucketsRequest(): ListBucketsRequest {
 export const ListBucketsRequest = {
   typeUrl: "/google.logging.v2.ListBucketsRequest",
   encode(message: ListBucketsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(10).string(message.parent);
     }
-    if (message.pageToken !== "") {
+    if (message.pageToken !== undefined) {
       writer.uint32(18).string(message.pageToken);
     }
-    if (message.pageSize !== 0) {
+    if (message.pageSize !== undefined) {
       writer.uint32(24).int32(message.pageSize);
     }
     return writer;
@@ -2601,7 +2601,7 @@ export const ListBucketsResponse = {
     for (const v of message.buckets) {
       LogBucket.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.nextPageToken !== "") {
+    if (message.nextPageToken !== undefined) {
       writer.uint32(18).string(message.nextPageToken);
     }
     return writer;
@@ -2712,10 +2712,10 @@ function createBaseCreateBucketRequest(): CreateBucketRequest {
 export const CreateBucketRequest = {
   typeUrl: "/google.logging.v2.CreateBucketRequest",
   encode(message: CreateBucketRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(10).string(message.parent);
     }
-    if (message.bucketId !== "") {
+    if (message.bucketId !== undefined) {
       writer.uint32(18).string(message.bucketId);
     }
     if (message.bucket !== undefined) {
@@ -2830,7 +2830,7 @@ function createBaseUpdateBucketRequest(): UpdateBucketRequest {
 export const UpdateBucketRequest = {
   typeUrl: "/google.logging.v2.UpdateBucketRequest",
   encode(message: UpdateBucketRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     if (message.bucket !== undefined) {
@@ -2948,7 +2948,7 @@ function createBaseGetBucketRequest(): GetBucketRequest {
 export const GetBucketRequest = {
   typeUrl: "/google.logging.v2.GetBucketRequest",
   encode(message: GetBucketRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     return writer;
@@ -3034,7 +3034,7 @@ function createBaseDeleteBucketRequest(): DeleteBucketRequest {
 export const DeleteBucketRequest = {
   typeUrl: "/google.logging.v2.DeleteBucketRequest",
   encode(message: DeleteBucketRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     return writer;
@@ -3120,7 +3120,7 @@ function createBaseUndeleteBucketRequest(): UndeleteBucketRequest {
 export const UndeleteBucketRequest = {
   typeUrl: "/google.logging.v2.UndeleteBucketRequest",
   encode(message: UndeleteBucketRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     return writer;
@@ -3208,13 +3208,13 @@ function createBaseListViewsRequest(): ListViewsRequest {
 export const ListViewsRequest = {
   typeUrl: "/google.logging.v2.ListViewsRequest",
   encode(message: ListViewsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(10).string(message.parent);
     }
-    if (message.pageToken !== "") {
+    if (message.pageToken !== undefined) {
       writer.uint32(18).string(message.pageToken);
     }
-    if (message.pageSize !== 0) {
+    if (message.pageSize !== undefined) {
       writer.uint32(24).int32(message.pageSize);
     }
     return writer;
@@ -3326,7 +3326,7 @@ export const ListViewsResponse = {
     for (const v of message.views) {
       LogView.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.nextPageToken !== "") {
+    if (message.nextPageToken !== undefined) {
       writer.uint32(18).string(message.nextPageToken);
     }
     return writer;
@@ -3437,10 +3437,10 @@ function createBaseCreateViewRequest(): CreateViewRequest {
 export const CreateViewRequest = {
   typeUrl: "/google.logging.v2.CreateViewRequest",
   encode(message: CreateViewRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(10).string(message.parent);
     }
-    if (message.viewId !== "") {
+    if (message.viewId !== undefined) {
       writer.uint32(18).string(message.viewId);
     }
     if (message.view !== undefined) {
@@ -3555,7 +3555,7 @@ function createBaseUpdateViewRequest(): UpdateViewRequest {
 export const UpdateViewRequest = {
   typeUrl: "/google.logging.v2.UpdateViewRequest",
   encode(message: UpdateViewRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     if (message.view !== undefined) {
@@ -3673,7 +3673,7 @@ function createBaseGetViewRequest(): GetViewRequest {
 export const GetViewRequest = {
   typeUrl: "/google.logging.v2.GetViewRequest",
   encode(message: GetViewRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     return writer;
@@ -3759,7 +3759,7 @@ function createBaseDeleteViewRequest(): DeleteViewRequest {
 export const DeleteViewRequest = {
   typeUrl: "/google.logging.v2.DeleteViewRequest",
   encode(message: DeleteViewRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     return writer;
@@ -3847,13 +3847,13 @@ function createBaseListSinksRequest(): ListSinksRequest {
 export const ListSinksRequest = {
   typeUrl: "/google.logging.v2.ListSinksRequest",
   encode(message: ListSinksRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(10).string(message.parent);
     }
-    if (message.pageToken !== "") {
+    if (message.pageToken !== undefined) {
       writer.uint32(18).string(message.pageToken);
     }
-    if (message.pageSize !== 0) {
+    if (message.pageSize !== undefined) {
       writer.uint32(24).int32(message.pageSize);
     }
     return writer;
@@ -3965,7 +3965,7 @@ export const ListSinksResponse = {
     for (const v of message.sinks) {
       LogSink.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.nextPageToken !== "") {
+    if (message.nextPageToken !== undefined) {
       writer.uint32(18).string(message.nextPageToken);
     }
     return writer;
@@ -4074,7 +4074,7 @@ function createBaseGetSinkRequest(): GetSinkRequest {
 export const GetSinkRequest = {
   typeUrl: "/google.logging.v2.GetSinkRequest",
   encode(message: GetSinkRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sinkName !== "") {
+    if (message.sinkName !== undefined) {
       writer.uint32(10).string(message.sinkName);
     }
     return writer;
@@ -4162,13 +4162,13 @@ function createBaseCreateSinkRequest(): CreateSinkRequest {
 export const CreateSinkRequest = {
   typeUrl: "/google.logging.v2.CreateSinkRequest",
   encode(message: CreateSinkRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(10).string(message.parent);
     }
     if (message.sink !== undefined) {
       LogSink.encode(message.sink, writer.uint32(18).fork()).ldelim();
     }
-    if (message.uniqueWriterIdentity === true) {
+    if (message.uniqueWriterIdentity !== undefined) {
       writer.uint32(24).bool(message.uniqueWriterIdentity);
     }
     return writer;
@@ -4281,13 +4281,13 @@ function createBaseUpdateSinkRequest(): UpdateSinkRequest {
 export const UpdateSinkRequest = {
   typeUrl: "/google.logging.v2.UpdateSinkRequest",
   encode(message: UpdateSinkRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sinkName !== "") {
+    if (message.sinkName !== undefined) {
       writer.uint32(10).string(message.sinkName);
     }
     if (message.sink !== undefined) {
       LogSink.encode(message.sink, writer.uint32(18).fork()).ldelim();
     }
-    if (message.uniqueWriterIdentity === true) {
+    if (message.uniqueWriterIdentity !== undefined) {
       writer.uint32(24).bool(message.uniqueWriterIdentity);
     }
     if (message.updateMask !== undefined) {
@@ -4413,7 +4413,7 @@ function createBaseDeleteSinkRequest(): DeleteSinkRequest {
 export const DeleteSinkRequest = {
   typeUrl: "/google.logging.v2.DeleteSinkRequest",
   encode(message: DeleteSinkRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sinkName !== "") {
+    if (message.sinkName !== undefined) {
       writer.uint32(10).string(message.sinkName);
     }
     return writer;
@@ -4504,16 +4504,16 @@ function createBaseLogExclusion(): LogExclusion {
 export const LogExclusion = {
   typeUrl: "/google.logging.v2.LogExclusion",
   encode(message: LogExclusion, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
-    if (message.filter !== "") {
+    if (message.filter !== undefined) {
       writer.uint32(26).string(message.filter);
     }
-    if (message.disabled === true) {
+    if (message.disabled !== undefined) {
       writer.uint32(32).bool(message.disabled);
     }
     if (message.createTime !== undefined) {
@@ -4662,13 +4662,13 @@ function createBaseListExclusionsRequest(): ListExclusionsRequest {
 export const ListExclusionsRequest = {
   typeUrl: "/google.logging.v2.ListExclusionsRequest",
   encode(message: ListExclusionsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(10).string(message.parent);
     }
-    if (message.pageToken !== "") {
+    if (message.pageToken !== undefined) {
       writer.uint32(18).string(message.pageToken);
     }
-    if (message.pageSize !== 0) {
+    if (message.pageSize !== undefined) {
       writer.uint32(24).int32(message.pageSize);
     }
     return writer;
@@ -4780,7 +4780,7 @@ export const ListExclusionsResponse = {
     for (const v of message.exclusions) {
       LogExclusion.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.nextPageToken !== "") {
+    if (message.nextPageToken !== undefined) {
       writer.uint32(18).string(message.nextPageToken);
     }
     return writer;
@@ -4889,7 +4889,7 @@ function createBaseGetExclusionRequest(): GetExclusionRequest {
 export const GetExclusionRequest = {
   typeUrl: "/google.logging.v2.GetExclusionRequest",
   encode(message: GetExclusionRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     return writer;
@@ -4976,7 +4976,7 @@ function createBaseCreateExclusionRequest(): CreateExclusionRequest {
 export const CreateExclusionRequest = {
   typeUrl: "/google.logging.v2.CreateExclusionRequest",
   encode(message: CreateExclusionRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(10).string(message.parent);
     }
     if (message.exclusion !== undefined) {
@@ -5080,7 +5080,7 @@ function createBaseUpdateExclusionRequest(): UpdateExclusionRequest {
 export const UpdateExclusionRequest = {
   typeUrl: "/google.logging.v2.UpdateExclusionRequest",
   encode(message: UpdateExclusionRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     if (message.exclusion !== undefined) {
@@ -5198,7 +5198,7 @@ function createBaseDeleteExclusionRequest(): DeleteExclusionRequest {
 export const DeleteExclusionRequest = {
   typeUrl: "/google.logging.v2.DeleteExclusionRequest",
   encode(message: DeleteExclusionRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     return writer;
@@ -5284,7 +5284,7 @@ function createBaseGetCmekSettingsRequest(): GetCmekSettingsRequest {
 export const GetCmekSettingsRequest = {
   typeUrl: "/google.logging.v2.GetCmekSettingsRequest",
   encode(message: GetCmekSettingsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     return writer;
@@ -5372,7 +5372,7 @@ function createBaseUpdateCmekSettingsRequest(): UpdateCmekSettingsRequest {
 export const UpdateCmekSettingsRequest = {
   typeUrl: "/google.logging.v2.UpdateCmekSettingsRequest",
   encode(message: UpdateCmekSettingsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     if (message.cmekSettings !== undefined) {
@@ -5492,13 +5492,13 @@ function createBaseCmekSettings(): CmekSettings {
 export const CmekSettings = {
   typeUrl: "/google.logging.v2.CmekSettings",
   encode(message: CmekSettings, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.kmsKeyName !== "") {
+    if (message.kmsKeyName !== undefined) {
       writer.uint32(18).string(message.kmsKeyName);
     }
-    if (message.serviceAccountId !== "") {
+    if (message.serviceAccountId !== undefined) {
       writer.uint32(26).string(message.serviceAccountId);
     }
     return writer;
@@ -5606,7 +5606,7 @@ function createBaseGetSettingsRequest(): GetSettingsRequest {
 export const GetSettingsRequest = {
   typeUrl: "/google.logging.v2.GetSettingsRequest",
   encode(message: GetSettingsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     return writer;
@@ -5694,7 +5694,7 @@ function createBaseUpdateSettingsRequest(): UpdateSettingsRequest {
 export const UpdateSettingsRequest = {
   typeUrl: "/google.logging.v2.UpdateSettingsRequest",
   encode(message: UpdateSettingsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     if (message.settings !== undefined) {
@@ -5816,19 +5816,19 @@ function createBaseSettings(): Settings {
 export const Settings = {
   typeUrl: "/google.logging.v2.Settings",
   encode(message: Settings, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.kmsKeyName !== "") {
+    if (message.kmsKeyName !== undefined) {
       writer.uint32(18).string(message.kmsKeyName);
     }
-    if (message.kmsServiceAccountId !== "") {
+    if (message.kmsServiceAccountId !== undefined) {
       writer.uint32(26).string(message.kmsServiceAccountId);
     }
-    if (message.storageLocation !== "") {
+    if (message.storageLocation !== undefined) {
       writer.uint32(34).string(message.storageLocation);
     }
-    if (message.disableDefaultSink === true) {
+    if (message.disableDefaultSink !== undefined) {
       writer.uint32(40).bool(message.disableDefaultSink);
     }
     return writer;
@@ -5960,13 +5960,13 @@ function createBaseCopyLogEntriesRequest(): CopyLogEntriesRequest {
 export const CopyLogEntriesRequest = {
   typeUrl: "/google.logging.v2.CopyLogEntriesRequest",
   encode(message: CopyLogEntriesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.filter !== "") {
+    if (message.filter !== undefined) {
       writer.uint32(26).string(message.filter);
     }
-    if (message.destination !== "") {
+    if (message.destination !== undefined) {
       writer.uint32(34).string(message.destination);
     }
     return writer;
@@ -6089,16 +6089,16 @@ export const CopyLogEntriesMetadata = {
     if (message.state !== 0) {
       writer.uint32(24).int32(message.state);
     }
-    if (message.cancellationRequested === true) {
+    if (message.cancellationRequested !== undefined) {
       writer.uint32(32).bool(message.cancellationRequested);
     }
     if (message.request !== undefined) {
       CopyLogEntriesRequest.encode(message.request, writer.uint32(42).fork()).ldelim();
     }
-    if (message.progress !== 0) {
+    if (message.progress !== undefined) {
       writer.uint32(48).int32(message.progress);
     }
-    if (message.writerIdentity !== "") {
+    if (message.writerIdentity !== undefined) {
       writer.uint32(58).string(message.writerIdentity);
     }
     return writer;
@@ -6252,7 +6252,7 @@ function createBaseCopyLogEntriesResponse(): CopyLogEntriesResponse {
 export const CopyLogEntriesResponse = {
   typeUrl: "/google.logging.v2.CopyLogEntriesResponse",
   encode(message: CopyLogEntriesResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.logEntriesCopiedCount !== BigInt(0)) {
+    if (message.logEntriesCopiedCount !== undefined) {
       writer.uint32(8).int64(message.logEntriesCopiedCount);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/logging/v2/logging_metrics.ts
+++ b/__fixtures__/v-next/outputv4/google/logging/v2/logging_metrics.ts
@@ -358,10 +358,10 @@ function createBaseLogMetric_LabelExtractorsEntry(): LogMetric_LabelExtractorsEn
 }
 export const LogMetric_LabelExtractorsEntry = {
   encode(message: LogMetric_LabelExtractorsEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(18).string(message.value);
     }
     return writer;
@@ -462,22 +462,22 @@ function createBaseLogMetric(): LogMetric {
 export const LogMetric = {
   typeUrl: "/google.logging.v2.LogMetric",
   encode(message: LogMetric, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
-    if (message.filter !== "") {
+    if (message.filter !== undefined) {
       writer.uint32(26).string(message.filter);
     }
-    if (message.disabled === true) {
+    if (message.disabled !== undefined) {
       writer.uint32(96).bool(message.disabled);
     }
     if (message.metricDescriptor !== undefined) {
       MetricDescriptor.encode(message.metricDescriptor, writer.uint32(42).fork()).ldelim();
     }
-    if (message.valueExtractor !== "") {
+    if (message.valueExtractor !== undefined) {
       writer.uint32(50).string(message.valueExtractor);
     }
     Object.entries(message.labelExtractors).forEach(([key, value]) => {
@@ -742,13 +742,13 @@ function createBaseListLogMetricsRequest(): ListLogMetricsRequest {
 export const ListLogMetricsRequest = {
   typeUrl: "/google.logging.v2.ListLogMetricsRequest",
   encode(message: ListLogMetricsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(10).string(message.parent);
     }
-    if (message.pageToken !== "") {
+    if (message.pageToken !== undefined) {
       writer.uint32(18).string(message.pageToken);
     }
-    if (message.pageSize !== 0) {
+    if (message.pageSize !== undefined) {
       writer.uint32(24).int32(message.pageSize);
     }
     return writer;
@@ -860,7 +860,7 @@ export const ListLogMetricsResponse = {
     for (const v of message.metrics) {
       LogMetric.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.nextPageToken !== "") {
+    if (message.nextPageToken !== undefined) {
       writer.uint32(18).string(message.nextPageToken);
     }
     return writer;
@@ -969,7 +969,7 @@ function createBaseGetLogMetricRequest(): GetLogMetricRequest {
 export const GetLogMetricRequest = {
   typeUrl: "/google.logging.v2.GetLogMetricRequest",
   encode(message: GetLogMetricRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.metricName !== "") {
+    if (message.metricName !== undefined) {
       writer.uint32(10).string(message.metricName);
     }
     return writer;
@@ -1056,7 +1056,7 @@ function createBaseCreateLogMetricRequest(): CreateLogMetricRequest {
 export const CreateLogMetricRequest = {
   typeUrl: "/google.logging.v2.CreateLogMetricRequest",
   encode(message: CreateLogMetricRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.parent !== "") {
+    if (message.parent !== undefined) {
       writer.uint32(10).string(message.parent);
     }
     if (message.metric !== undefined) {
@@ -1159,7 +1159,7 @@ function createBaseUpdateLogMetricRequest(): UpdateLogMetricRequest {
 export const UpdateLogMetricRequest = {
   typeUrl: "/google.logging.v2.UpdateLogMetricRequest",
   encode(message: UpdateLogMetricRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.metricName !== "") {
+    if (message.metricName !== undefined) {
       writer.uint32(10).string(message.metricName);
     }
     if (message.metric !== undefined) {
@@ -1261,7 +1261,7 @@ function createBaseDeleteLogMetricRequest(): DeleteLogMetricRequest {
 export const DeleteLogMetricRequest = {
   typeUrl: "/google.logging.v2.DeleteLogMetricRequest",
   encode(message: DeleteLogMetricRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.metricName !== "") {
+    if (message.metricName !== undefined) {
       writer.uint32(10).string(message.metricName);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/longrunning/operations.ts
+++ b/__fixtures__/v-next/outputv4/google/longrunning/operations.ts
@@ -223,13 +223,13 @@ function createBaseOperation(): Operation {
 export const Operation = {
   typeUrl: "/google.longrunning.Operation",
   encode(message: Operation, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     if (message.metadata !== undefined) {
       Any.encode(message.metadata, writer.uint32(18).fork()).ldelim();
     }
-    if (message.done === true) {
+    if (message.done !== undefined) {
       writer.uint32(24).bool(message.done);
     }
     if (message.error !== undefined) {
@@ -371,7 +371,7 @@ function createBaseGetOperationRequest(): GetOperationRequest {
 export const GetOperationRequest = {
   typeUrl: "/google.longrunning.GetOperationRequest",
   encode(message: GetOperationRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     return writer;
@@ -460,16 +460,16 @@ function createBaseListOperationsRequest(): ListOperationsRequest {
 export const ListOperationsRequest = {
   typeUrl: "/google.longrunning.ListOperationsRequest",
   encode(message: ListOperationsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(34).string(message.name);
     }
-    if (message.filter !== "") {
+    if (message.filter !== undefined) {
       writer.uint32(10).string(message.filter);
     }
-    if (message.pageSize !== 0) {
+    if (message.pageSize !== undefined) {
       writer.uint32(16).int32(message.pageSize);
     }
-    if (message.pageToken !== "") {
+    if (message.pageToken !== undefined) {
       writer.uint32(26).string(message.pageToken);
     }
     return writer;
@@ -592,7 +592,7 @@ export const ListOperationsResponse = {
     for (const v of message.operations) {
       Operation.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.nextPageToken !== "") {
+    if (message.nextPageToken !== undefined) {
       writer.uint32(18).string(message.nextPageToken);
     }
     return writer;
@@ -701,7 +701,7 @@ function createBaseCancelOperationRequest(): CancelOperationRequest {
 export const CancelOperationRequest = {
   typeUrl: "/google.longrunning.CancelOperationRequest",
   encode(message: CancelOperationRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     return writer;
@@ -787,7 +787,7 @@ function createBaseDeleteOperationRequest(): DeleteOperationRequest {
 export const DeleteOperationRequest = {
   typeUrl: "/google.longrunning.DeleteOperationRequest",
   encode(message: DeleteOperationRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     return writer;
@@ -874,7 +874,7 @@ function createBaseWaitOperationRequest(): WaitOperationRequest {
 export const WaitOperationRequest = {
   typeUrl: "/google.longrunning.WaitOperationRequest",
   encode(message: WaitOperationRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     if (message.timeout !== undefined) {
@@ -977,10 +977,10 @@ function createBaseOperationInfo(): OperationInfo {
 export const OperationInfo = {
   typeUrl: "/google.longrunning.OperationInfo",
   encode(message: OperationInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.responseType !== "") {
+    if (message.responseType !== undefined) {
       writer.uint32(10).string(message.responseType);
     }
-    if (message.metadataType !== "") {
+    if (message.metadataType !== undefined) {
       writer.uint32(18).string(message.metadataType);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/protobuf/any.ts
+++ b/__fixtures__/v-next/outputv4/google/protobuf/any.ts
@@ -217,7 +217,7 @@ function createBaseAny(): Any {
 export const Any = {
   typeUrl: "/google.protobuf.Any",
   encode(message: Any, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.typeUrl !== "") {
+    if (message.typeUrl !== undefined) {
       writer.uint32(10).string(message.typeUrl);
     }
     if (message.value.length !== 0) {

--- a/__fixtures__/v-next/outputv4/google/protobuf/api.ts
+++ b/__fixtures__/v-next/outputv4/google/protobuf/api.ts
@@ -302,7 +302,7 @@ function createBaseApi(): Api {
 export const Api = {
   typeUrl: "/google.protobuf.Api",
   encode(message: Api, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     for (const v of message.methods) {
@@ -311,7 +311,7 @@ export const Api = {
     for (const v of message.options) {
       Option.encode(v!, writer.uint32(26).fork()).ldelim();
     }
-    if (message.version !== "") {
+    if (message.version !== undefined) {
       writer.uint32(34).string(message.version);
     }
     if (message.sourceContext !== undefined) {
@@ -516,19 +516,19 @@ function createBaseMethod(): Method {
 export const Method = {
   typeUrl: "/google.protobuf.Method",
   encode(message: Method, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.requestTypeUrl !== "") {
+    if (message.requestTypeUrl !== undefined) {
       writer.uint32(18).string(message.requestTypeUrl);
     }
-    if (message.requestStreaming === true) {
+    if (message.requestStreaming !== undefined) {
       writer.uint32(24).bool(message.requestStreaming);
     }
-    if (message.responseTypeUrl !== "") {
+    if (message.responseTypeUrl !== undefined) {
       writer.uint32(34).string(message.responseTypeUrl);
     }
-    if (message.responseStreaming === true) {
+    if (message.responseStreaming !== undefined) {
       writer.uint32(40).bool(message.responseStreaming);
     }
     for (const v of message.options) {
@@ -699,10 +699,10 @@ function createBaseMixin(): Mixin {
 export const Mixin = {
   typeUrl: "/google.protobuf.Mixin",
   encode(message: Mixin, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.root !== "") {
+    if (message.root !== undefined) {
       writer.uint32(18).string(message.root);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/protobuf/compiler/plugin.ts
+++ b/__fixtures__/v-next/outputv4/google/protobuf/compiler/plugin.ts
@@ -169,16 +169,16 @@ function createBaseVersion(): Version {
 export const Version = {
   typeUrl: "/google.protobuf.compiler.Version",
   encode(message: Version, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.major !== 0) {
+    if (message.major !== undefined) {
       writer.uint32(8).int32(message.major);
     }
-    if (message.minor !== 0) {
+    if (message.minor !== undefined) {
       writer.uint32(16).int32(message.minor);
     }
-    if (message.patch !== 0) {
+    if (message.patch !== undefined) {
       writer.uint32(24).int32(message.patch);
     }
-    if (message.suffix !== "") {
+    if (message.suffix !== undefined) {
       writer.uint32(34).string(message.suffix);
     }
     return writer;
@@ -303,7 +303,7 @@ export const CodeGeneratorRequest = {
     for (const v of message.fileToGenerate) {
       writer.uint32(10).string(v!);
     }
-    if (message.parameter !== "") {
+    if (message.parameter !== undefined) {
       writer.uint32(18).string(message.parameter);
     }
     for (const v of message.protoFile) {
@@ -455,7 +455,7 @@ function createBaseCodeGeneratorResponse(): CodeGeneratorResponse {
 export const CodeGeneratorResponse = {
   typeUrl: "/google.protobuf.compiler.CodeGeneratorResponse",
   encode(message: CodeGeneratorResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.error !== "") {
+    if (message.error !== undefined) {
       writer.uint32(10).string(message.error);
     }
     for (const v of message.file) {
@@ -569,13 +569,13 @@ function createBaseCodeGeneratorResponse_File(): CodeGeneratorResponse_File {
 export const CodeGeneratorResponse_File = {
   typeUrl: "/google.protobuf.compiler.File",
   encode(message: CodeGeneratorResponse_File, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.insertionPoint !== "") {
+    if (message.insertionPoint !== undefined) {
       writer.uint32(18).string(message.insertionPoint);
     }
-    if (message.content !== "") {
+    if (message.content !== undefined) {
       writer.uint32(122).string(message.content);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/protobuf/descriptor.ts
+++ b/__fixtures__/v-next/outputv4/google/protobuf/descriptor.ts
@@ -1503,10 +1503,10 @@ function createBaseFileDescriptorProto(): FileDescriptorProto {
 export const FileDescriptorProto = {
   typeUrl: "/google.protobuf.FileDescriptorProto",
   encode(message: FileDescriptorProto, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.package !== "") {
+    if (message.package !== undefined) {
       writer.uint32(18).string(message.package);
     }
     for (const v of message.dependency) {
@@ -1540,7 +1540,7 @@ export const FileDescriptorProto = {
     if (message.sourceCodeInfo !== undefined) {
       SourceCodeInfo.encode(message.sourceCodeInfo, writer.uint32(74).fork()).ldelim();
     }
-    if (message.syntax !== "") {
+    if (message.syntax !== undefined) {
       writer.uint32(98).string(message.syntax);
     }
     return writer;
@@ -1858,7 +1858,7 @@ function createBaseDescriptorProto(): DescriptorProto {
 export const DescriptorProto = {
   typeUrl: "/google.protobuf.DescriptorProto",
   encode(message: DescriptorProto, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     for (const v of message.field) {
@@ -2170,10 +2170,10 @@ function createBaseDescriptorProto_ExtensionRange(): DescriptorProto_ExtensionRa
 export const DescriptorProto_ExtensionRange = {
   typeUrl: "/google.protobuf.ExtensionRange",
   encode(message: DescriptorProto_ExtensionRange, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.start !== 0) {
+    if (message.start !== undefined) {
       writer.uint32(8).int32(message.start);
     }
-    if (message.end !== 0) {
+    if (message.end !== undefined) {
       writer.uint32(16).int32(message.end);
     }
     if (message.options !== undefined) {
@@ -2287,10 +2287,10 @@ function createBaseDescriptorProto_ReservedRange(): DescriptorProto_ReservedRang
 export const DescriptorProto_ReservedRange = {
   typeUrl: "/google.protobuf.ReservedRange",
   encode(message: DescriptorProto_ReservedRange, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.start !== 0) {
+    if (message.start !== undefined) {
       writer.uint32(8).int32(message.start);
     }
-    if (message.end !== 0) {
+    if (message.end !== undefined) {
       writer.uint32(16).int32(message.end);
     }
     return writer;
@@ -2494,10 +2494,10 @@ function createBaseFieldDescriptorProto(): FieldDescriptorProto {
 export const FieldDescriptorProto = {
   typeUrl: "/google.protobuf.FieldDescriptorProto",
   encode(message: FieldDescriptorProto, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.number !== 0) {
+    if (message.number !== undefined) {
       writer.uint32(24).int32(message.number);
     }
     if (message.label !== 1) {
@@ -2506,19 +2506,19 @@ export const FieldDescriptorProto = {
     if (message.type !== 1) {
       writer.uint32(40).int32(message.type);
     }
-    if (message.typeName !== "") {
+    if (message.typeName !== undefined) {
       writer.uint32(50).string(message.typeName);
     }
-    if (message.extendee !== "") {
+    if (message.extendee !== undefined) {
       writer.uint32(18).string(message.extendee);
     }
-    if (message.defaultValue !== "") {
+    if (message.defaultValue !== undefined) {
       writer.uint32(58).string(message.defaultValue);
     }
-    if (message.oneofIndex !== 0) {
+    if (message.oneofIndex !== undefined) {
       writer.uint32(72).int32(message.oneofIndex);
     }
-    if (message.jsonName !== "") {
+    if (message.jsonName !== undefined) {
       writer.uint32(82).string(message.jsonName);
     }
     if (message.options !== undefined) {
@@ -2709,7 +2709,7 @@ function createBaseOneofDescriptorProto(): OneofDescriptorProto {
 export const OneofDescriptorProto = {
   typeUrl: "/google.protobuf.OneofDescriptorProto",
   encode(message: OneofDescriptorProto, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     if (message.options !== undefined) {
@@ -2815,7 +2815,7 @@ function createBaseEnumDescriptorProto(): EnumDescriptorProto {
 export const EnumDescriptorProto = {
   typeUrl: "/google.protobuf.EnumDescriptorProto",
   encode(message: EnumDescriptorProto, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     for (const v of message.value) {
@@ -2996,10 +2996,10 @@ function createBaseEnumDescriptorProto_EnumReservedRange(): EnumDescriptorProto_
 export const EnumDescriptorProto_EnumReservedRange = {
   typeUrl: "/google.protobuf.EnumReservedRange",
   encode(message: EnumDescriptorProto_EnumReservedRange, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.start !== 0) {
+    if (message.start !== undefined) {
       writer.uint32(8).int32(message.start);
     }
-    if (message.end !== 0) {
+    if (message.end !== undefined) {
       writer.uint32(16).int32(message.end);
     }
     return writer;
@@ -3098,10 +3098,10 @@ function createBaseEnumValueDescriptorProto(): EnumValueDescriptorProto {
 export const EnumValueDescriptorProto = {
   typeUrl: "/google.protobuf.EnumValueDescriptorProto",
   encode(message: EnumValueDescriptorProto, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.number !== 0) {
+    if (message.number !== undefined) {
       writer.uint32(16).int32(message.number);
     }
     if (message.options !== undefined) {
@@ -3216,7 +3216,7 @@ function createBaseServiceDescriptorProto(): ServiceDescriptorProto {
 export const ServiceDescriptorProto = {
   typeUrl: "/google.protobuf.ServiceDescriptorProto",
   encode(message: ServiceDescriptorProto, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     for (const v of message.method) {
@@ -3349,22 +3349,22 @@ function createBaseMethodDescriptorProto(): MethodDescriptorProto {
 export const MethodDescriptorProto = {
   typeUrl: "/google.protobuf.MethodDescriptorProto",
   encode(message: MethodDescriptorProto, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.inputType !== "") {
+    if (message.inputType !== undefined) {
       writer.uint32(18).string(message.inputType);
     }
-    if (message.outputType !== "") {
+    if (message.outputType !== undefined) {
       writer.uint32(26).string(message.outputType);
     }
     if (message.options !== undefined) {
       MethodOptions.encode(message.options, writer.uint32(34).fork()).ldelim();
     }
-    if (message.clientStreaming === true) {
+    if (message.clientStreaming !== undefined) {
       writer.uint32(40).bool(message.clientStreaming);
     }
-    if (message.serverStreaming === true) {
+    if (message.serverStreaming !== undefined) {
       writer.uint32(48).bool(message.serverStreaming);
     }
     return writer;
@@ -3527,64 +3527,64 @@ function createBaseFileOptions(): FileOptions {
 export const FileOptions = {
   typeUrl: "/google.protobuf.FileOptions",
   encode(message: FileOptions, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.javaPackage !== "") {
+    if (message.javaPackage !== undefined) {
       writer.uint32(10).string(message.javaPackage);
     }
-    if (message.javaOuterClassname !== "") {
+    if (message.javaOuterClassname !== undefined) {
       writer.uint32(66).string(message.javaOuterClassname);
     }
-    if (message.javaMultipleFiles === true) {
+    if (message.javaMultipleFiles !== undefined) {
       writer.uint32(80).bool(message.javaMultipleFiles);
     }
-    if (message.javaGenerateEqualsAndHash === true) {
+    if (message.javaGenerateEqualsAndHash !== undefined) {
       writer.uint32(160).bool(message.javaGenerateEqualsAndHash);
     }
-    if (message.javaStringCheckUtf8 === true) {
+    if (message.javaStringCheckUtf8 !== undefined) {
       writer.uint32(216).bool(message.javaStringCheckUtf8);
     }
     if (message.optimizeFor !== 1) {
       writer.uint32(72).int32(message.optimizeFor);
     }
-    if (message.goPackage !== "") {
+    if (message.goPackage !== undefined) {
       writer.uint32(90).string(message.goPackage);
     }
-    if (message.ccGenericServices === true) {
+    if (message.ccGenericServices !== undefined) {
       writer.uint32(128).bool(message.ccGenericServices);
     }
-    if (message.javaGenericServices === true) {
+    if (message.javaGenericServices !== undefined) {
       writer.uint32(136).bool(message.javaGenericServices);
     }
-    if (message.pyGenericServices === true) {
+    if (message.pyGenericServices !== undefined) {
       writer.uint32(144).bool(message.pyGenericServices);
     }
-    if (message.phpGenericServices === true) {
+    if (message.phpGenericServices !== undefined) {
       writer.uint32(336).bool(message.phpGenericServices);
     }
-    if (message.deprecated === true) {
+    if (message.deprecated !== undefined) {
       writer.uint32(184).bool(message.deprecated);
     }
-    if (message.ccEnableArenas === true) {
+    if (message.ccEnableArenas !== undefined) {
       writer.uint32(248).bool(message.ccEnableArenas);
     }
-    if (message.objcClassPrefix !== "") {
+    if (message.objcClassPrefix !== undefined) {
       writer.uint32(290).string(message.objcClassPrefix);
     }
-    if (message.csharpNamespace !== "") {
+    if (message.csharpNamespace !== undefined) {
       writer.uint32(298).string(message.csharpNamespace);
     }
-    if (message.swiftPrefix !== "") {
+    if (message.swiftPrefix !== undefined) {
       writer.uint32(314).string(message.swiftPrefix);
     }
-    if (message.phpClassPrefix !== "") {
+    if (message.phpClassPrefix !== undefined) {
       writer.uint32(322).string(message.phpClassPrefix);
     }
-    if (message.phpNamespace !== "") {
+    if (message.phpNamespace !== undefined) {
       writer.uint32(330).string(message.phpNamespace);
     }
-    if (message.phpMetadataNamespace !== "") {
+    if (message.phpMetadataNamespace !== undefined) {
       writer.uint32(354).string(message.phpMetadataNamespace);
     }
-    if (message.rubyPackage !== "") {
+    if (message.rubyPackage !== undefined) {
       writer.uint32(362).string(message.rubyPackage);
     }
     for (const v of message.uninterpretedOption) {
@@ -3909,16 +3909,16 @@ function createBaseMessageOptions(): MessageOptions {
 export const MessageOptions = {
   typeUrl: "/google.protobuf.MessageOptions",
   encode(message: MessageOptions, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.messageSetWireFormat === true) {
+    if (message.messageSetWireFormat !== undefined) {
       writer.uint32(8).bool(message.messageSetWireFormat);
     }
-    if (message.noStandardDescriptorAccessor === true) {
+    if (message.noStandardDescriptorAccessor !== undefined) {
       writer.uint32(16).bool(message.noStandardDescriptorAccessor);
     }
-    if (message.deprecated === true) {
+    if (message.deprecated !== undefined) {
       writer.uint32(24).bool(message.deprecated);
     }
-    if (message.mapEntry === true) {
+    if (message.mapEntry !== undefined) {
       writer.uint32(56).bool(message.mapEntry);
     }
     for (const v of message.uninterpretedOption) {
@@ -4072,19 +4072,19 @@ export const FieldOptions = {
     if (message.ctype !== 1) {
       writer.uint32(8).int32(message.ctype);
     }
-    if (message.packed === true) {
+    if (message.packed !== undefined) {
       writer.uint32(16).bool(message.packed);
     }
     if (message.jstype !== 1) {
       writer.uint32(48).int32(message.jstype);
     }
-    if (message.lazy === true) {
+    if (message.lazy !== undefined) {
       writer.uint32(40).bool(message.lazy);
     }
-    if (message.deprecated === true) {
+    if (message.deprecated !== undefined) {
       writer.uint32(24).bool(message.deprecated);
     }
-    if (message.weak === true) {
+    if (message.weak !== undefined) {
       writer.uint32(80).bool(message.weak);
     }
     for (const v of message.uninterpretedOption) {
@@ -4351,10 +4351,10 @@ function createBaseEnumOptions(): EnumOptions {
 export const EnumOptions = {
   typeUrl: "/google.protobuf.EnumOptions",
   encode(message: EnumOptions, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.allowAlias === true) {
+    if (message.allowAlias !== undefined) {
       writer.uint32(16).bool(message.allowAlias);
     }
-    if (message.deprecated === true) {
+    if (message.deprecated !== undefined) {
       writer.uint32(24).bool(message.deprecated);
     }
     for (const v of message.uninterpretedOption) {
@@ -4478,7 +4478,7 @@ function createBaseEnumValueOptions(): EnumValueOptions {
 export const EnumValueOptions = {
   typeUrl: "/google.protobuf.EnumValueOptions",
   encode(message: EnumValueOptions, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.deprecated === true) {
+    if (message.deprecated !== undefined) {
       writer.uint32(8).bool(message.deprecated);
     }
     for (const v of message.uninterpretedOption) {
@@ -4591,7 +4591,7 @@ function createBaseServiceOptions(): ServiceOptions {
 export const ServiceOptions = {
   typeUrl: "/google.protobuf.ServiceOptions",
   encode(message: ServiceOptions, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.deprecated === true) {
+    if (message.deprecated !== undefined) {
       writer.uint32(264).bool(message.deprecated);
     }
     for (const v of message.uninterpretedOption) {
@@ -4705,7 +4705,7 @@ function createBaseMethodOptions(): MethodOptions {
 export const MethodOptions = {
   typeUrl: "/google.protobuf.MethodOptions",
   encode(message: MethodOptions, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.deprecated === true) {
+    if (message.deprecated !== undefined) {
       writer.uint32(264).bool(message.deprecated);
     }
     if (message.idempotencyLevel !== 1) {
@@ -4840,22 +4840,22 @@ export const UninterpretedOption = {
     for (const v of message.name) {
       UninterpretedOption_NamePart.encode(v!, writer.uint32(18).fork()).ldelim();
     }
-    if (message.identifierValue !== "") {
+    if (message.identifierValue !== undefined) {
       writer.uint32(26).string(message.identifierValue);
     }
-    if (message.positiveIntValue !== BigInt(0)) {
+    if (message.positiveIntValue !== undefined) {
       writer.uint32(32).uint64(message.positiveIntValue);
     }
-    if (message.negativeIntValue !== BigInt(0)) {
+    if (message.negativeIntValue !== undefined) {
       writer.uint32(40).int64(message.negativeIntValue);
     }
-    if (message.doubleValue !== 0) {
+    if (message.doubleValue !== undefined) {
       writer.uint32(49).double(message.doubleValue);
     }
     if (message.stringValue.length !== 0) {
       writer.uint32(58).bytes(message.stringValue);
     }
-    if (message.aggregateValue !== "") {
+    if (message.aggregateValue !== undefined) {
       writer.uint32(66).string(message.aggregateValue);
     }
     return writer;
@@ -5024,10 +5024,10 @@ function createBaseUninterpretedOption_NamePart(): UninterpretedOption_NamePart 
 export const UninterpretedOption_NamePart = {
   typeUrl: "/google.protobuf.NamePart",
   encode(message: UninterpretedOption_NamePart, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.namePart !== "") {
+    if (message.namePart !== undefined) {
       writer.uint32(10).string(message.namePart);
     }
-    if (message.isExtension === true) {
+    if (message.isExtension !== undefined) {
       writer.uint32(16).bool(message.isExtension);
     }
     return writer;
@@ -5236,10 +5236,10 @@ export const SourceCodeInfo_Location = {
       writer.int32(v);
     }
     writer.ldelim();
-    if (message.leadingComments !== "") {
+    if (message.leadingComments !== undefined) {
       writer.uint32(26).string(message.leadingComments);
     }
-    if (message.trailingComments !== "") {
+    if (message.trailingComments !== undefined) {
       writer.uint32(34).string(message.trailingComments);
     }
     for (const v of message.leadingDetachedComments) {
@@ -5528,13 +5528,13 @@ export const GeneratedCodeInfo_Annotation = {
       writer.int32(v);
     }
     writer.ldelim();
-    if (message.sourceFile !== "") {
+    if (message.sourceFile !== undefined) {
       writer.uint32(18).string(message.sourceFile);
     }
-    if (message.begin !== 0) {
+    if (message.begin !== undefined) {
       writer.uint32(24).int32(message.begin);
     }
-    if (message.end !== 0) {
+    if (message.end !== undefined) {
       writer.uint32(32).int32(message.end);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/protobuf/duration.ts
+++ b/__fixtures__/v-next/outputv4/google/protobuf/duration.ts
@@ -155,10 +155,10 @@ function createBaseDuration(): Duration {
 export const Duration = {
   typeUrl: "/google.protobuf.Duration",
   encode(message: Duration, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.seconds !== BigInt(0)) {
+    if (message.seconds !== undefined) {
       writer.uint32(8).int64(message.seconds);
     }
-    if (message.nanos !== 0) {
+    if (message.nanos !== undefined) {
       writer.uint32(16).int32(message.nanos);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/protobuf/source_context.ts
+++ b/__fixtures__/v-next/outputv4/google/protobuf/source_context.ts
@@ -31,7 +31,7 @@ function createBaseSourceContext(): SourceContext {
 export const SourceContext = {
   typeUrl: "/google.protobuf.SourceContext",
   encode(message: SourceContext, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.fileName !== "") {
+    if (message.fileName !== undefined) {
       writer.uint32(10).string(message.fileName);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/protobuf/struct.ts
+++ b/__fixtures__/v-next/outputv4/google/protobuf/struct.ts
@@ -151,7 +151,7 @@ function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
 }
 export const Struct_FieldsEntry = {
   encode(message: Struct_FieldsEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
     if (message.value !== undefined) {

--- a/__fixtures__/v-next/outputv4/google/protobuf/timestamp.ts
+++ b/__fixtures__/v-next/outputv4/google/protobuf/timestamp.ts
@@ -201,10 +201,10 @@ function createBaseTimestamp(): Timestamp {
 export const Timestamp = {
   typeUrl: "/google.protobuf.Timestamp",
   encode(message: Timestamp, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.seconds !== BigInt(0)) {
+    if (message.seconds !== undefined) {
       writer.uint32(8).int64(message.seconds);
     }
-    if (message.nanos !== 0) {
+    if (message.nanos !== undefined) {
       writer.uint32(16).int32(message.nanos);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/protobuf/type.ts
+++ b/__fixtures__/v-next/outputv4/google/protobuf/type.ts
@@ -401,7 +401,7 @@ function createBaseType(): Type {
 export const Type = {
   typeUrl: "/google.protobuf.Type",
   encode(message: Type, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     for (const v of message.fields) {
@@ -610,28 +610,28 @@ export const Field = {
     if (message.cardinality !== 0) {
       writer.uint32(16).int32(message.cardinality);
     }
-    if (message.number !== 0) {
+    if (message.number !== undefined) {
       writer.uint32(24).int32(message.number);
     }
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(34).string(message.name);
     }
-    if (message.typeUrl !== "") {
+    if (message.typeUrl !== undefined) {
       writer.uint32(50).string(message.typeUrl);
     }
-    if (message.oneofIndex !== 0) {
+    if (message.oneofIndex !== undefined) {
       writer.uint32(56).int32(message.oneofIndex);
     }
-    if (message.packed === true) {
+    if (message.packed !== undefined) {
       writer.uint32(64).bool(message.packed);
     }
     for (const v of message.options) {
       Option.encode(v!, writer.uint32(74).fork()).ldelim();
     }
-    if (message.jsonName !== "") {
+    if (message.jsonName !== undefined) {
       writer.uint32(82).string(message.jsonName);
     }
-    if (message.defaultValue !== "") {
+    if (message.defaultValue !== undefined) {
       writer.uint32(90).string(message.defaultValue);
     }
     return writer;
@@ -832,7 +832,7 @@ function createBaseEnum(): Enum {
 export const Enum = {
   typeUrl: "/google.protobuf.Enum",
   encode(message: Enum, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     for (const v of message.enumvalue) {
@@ -1002,10 +1002,10 @@ function createBaseEnumValue(): EnumValue {
 export const EnumValue = {
   typeUrl: "/google.protobuf.EnumValue",
   encode(message: EnumValue, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
-    if (message.number !== 0) {
+    if (message.number !== undefined) {
       writer.uint32(16).int32(message.number);
     }
     for (const v of message.options) {
@@ -1129,7 +1129,7 @@ function createBaseOption(): Option {
 export const Option = {
   typeUrl: "/google.protobuf.Option",
   encode(message: Option, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
     }
     if (message.value !== undefined) {

--- a/__fixtures__/v-next/outputv4/google/protobuf/wrappers.ts
+++ b/__fixtures__/v-next/outputv4/google/protobuf/wrappers.ts
@@ -198,7 +198,7 @@ function createBaseDoubleValue(): DoubleValue {
 export const DoubleValue = {
   typeUrl: "/google.protobuf.DoubleValue",
   encode(message: DoubleValue, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.value !== 0) {
+    if (message.value !== undefined) {
       writer.uint32(9).double(message.value);
     }
     return writer;
@@ -284,7 +284,7 @@ function createBaseFloatValue(): FloatValue {
 export const FloatValue = {
   typeUrl: "/google.protobuf.FloatValue",
   encode(message: FloatValue, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.value !== 0) {
+    if (message.value !== undefined) {
       writer.uint32(13).float(message.value);
     }
     return writer;
@@ -370,7 +370,7 @@ function createBaseInt64Value(): Int64Value {
 export const Int64Value = {
   typeUrl: "/google.protobuf.Int64Value",
   encode(message: Int64Value, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.value !== BigInt(0)) {
+    if (message.value !== undefined) {
       writer.uint32(8).int64(message.value);
     }
     return writer;
@@ -458,7 +458,7 @@ function createBaseUInt64Value(): UInt64Value {
 export const UInt64Value = {
   typeUrl: "/google.protobuf.UInt64Value",
   encode(message: UInt64Value, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.value !== BigInt(0)) {
+    if (message.value !== undefined) {
       writer.uint32(8).uint64(message.value);
     }
     return writer;
@@ -546,7 +546,7 @@ function createBaseInt32Value(): Int32Value {
 export const Int32Value = {
   typeUrl: "/google.protobuf.Int32Value",
   encode(message: Int32Value, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.value !== 0) {
+    if (message.value !== undefined) {
       writer.uint32(8).int32(message.value);
     }
     return writer;
@@ -632,7 +632,7 @@ function createBaseUInt32Value(): UInt32Value {
 export const UInt32Value = {
   typeUrl: "/google.protobuf.UInt32Value",
   encode(message: UInt32Value, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.value !== 0) {
+    if (message.value !== undefined) {
       writer.uint32(8).uint32(message.value);
     }
     return writer;
@@ -718,7 +718,7 @@ function createBaseBoolValue(): BoolValue {
 export const BoolValue = {
   typeUrl: "/google.protobuf.BoolValue",
   encode(message: BoolValue, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.value === true) {
+    if (message.value !== undefined) {
       writer.uint32(8).bool(message.value);
     }
     return writer;
@@ -804,7 +804,7 @@ function createBaseStringValue(): StringValue {
 export const StringValue = {
   typeUrl: "/google.protobuf.StringValue",
   encode(message: StringValue, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(10).string(message.value);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/rpc/context/attribute_context.ts
+++ b/__fixtures__/v-next/outputv4/google/rpc/context/attribute_context.ts
@@ -802,10 +802,10 @@ function createBaseAttributeContext_Peer_LabelsEntry(): AttributeContext_Peer_La
 }
 export const AttributeContext_Peer_LabelsEntry = {
   encode(message: AttributeContext_Peer_LabelsEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(18).string(message.value);
     }
     return writer;
@@ -900,10 +900,10 @@ function createBaseAttributeContext_Peer(): AttributeContext_Peer {
 export const AttributeContext_Peer = {
   typeUrl: "/google.rpc.context.Peer",
   encode(message: AttributeContext_Peer, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.ip !== "") {
+    if (message.ip !== undefined) {
       writer.uint32(10).string(message.ip);
     }
-    if (message.port !== BigInt(0)) {
+    if (message.port !== undefined) {
       writer.uint32(16).int64(message.port);
     }
     Object.entries(message.labels).forEach(([key, value]) => {
@@ -912,10 +912,10 @@ export const AttributeContext_Peer = {
         value
       }, writer.uint32(50).fork()).ldelim();
     });
-    if (message.principal !== "") {
+    if (message.principal !== undefined) {
       writer.uint32(58).string(message.principal);
     }
-    if (message.regionCode !== "") {
+    if (message.regionCode !== undefined) {
       writer.uint32(66).string(message.regionCode);
     }
     return writer;
@@ -1095,16 +1095,16 @@ function createBaseAttributeContext_Api(): AttributeContext_Api {
 export const AttributeContext_Api = {
   typeUrl: "/google.rpc.context.Api",
   encode(message: AttributeContext_Api, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.service !== "") {
+    if (message.service !== undefined) {
       writer.uint32(10).string(message.service);
     }
-    if (message.operation !== "") {
+    if (message.operation !== undefined) {
       writer.uint32(18).string(message.operation);
     }
-    if (message.protocol !== "") {
+    if (message.protocol !== undefined) {
       writer.uint32(26).string(message.protocol);
     }
-    if (message.version !== "") {
+    if (message.version !== undefined) {
       writer.uint32(34).string(message.version);
     }
     return writer;
@@ -1227,13 +1227,13 @@ function createBaseAttributeContext_Auth(): AttributeContext_Auth {
 export const AttributeContext_Auth = {
   typeUrl: "/google.rpc.context.Auth",
   encode(message: AttributeContext_Auth, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.principal !== "") {
+    if (message.principal !== undefined) {
       writer.uint32(10).string(message.principal);
     }
     for (const v of message.audiences) {
       writer.uint32(18).string(v!);
     }
-    if (message.presenter !== "") {
+    if (message.presenter !== undefined) {
       writer.uint32(26).string(message.presenter);
     }
     if (message.claims !== undefined) {
@@ -1395,10 +1395,10 @@ function createBaseAttributeContext_Request_HeadersEntry(): AttributeContext_Req
 }
 export const AttributeContext_Request_HeadersEntry = {
   encode(message: AttributeContext_Request_HeadersEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(18).string(message.value);
     }
     return writer;
@@ -1500,10 +1500,10 @@ function createBaseAttributeContext_Request(): AttributeContext_Request {
 export const AttributeContext_Request = {
   typeUrl: "/google.rpc.context.Request",
   encode(message: AttributeContext_Request, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.id !== "") {
+    if (message.id !== undefined) {
       writer.uint32(10).string(message.id);
     }
-    if (message.method !== "") {
+    if (message.method !== undefined) {
       writer.uint32(18).string(message.method);
     }
     Object.entries(message.headers).forEach(([key, value]) => {
@@ -1512,28 +1512,28 @@ export const AttributeContext_Request = {
         value
       }, writer.uint32(26).fork()).ldelim();
     });
-    if (message.path !== "") {
+    if (message.path !== undefined) {
       writer.uint32(34).string(message.path);
     }
-    if (message.host !== "") {
+    if (message.host !== undefined) {
       writer.uint32(42).string(message.host);
     }
-    if (message.scheme !== "") {
+    if (message.scheme !== undefined) {
       writer.uint32(50).string(message.scheme);
     }
-    if (message.query !== "") {
+    if (message.query !== undefined) {
       writer.uint32(58).string(message.query);
     }
     if (message.time !== undefined) {
       Timestamp.encode(toTimestamp(message.time), writer.uint32(74).fork()).ldelim();
     }
-    if (message.size !== BigInt(0)) {
+    if (message.size !== undefined) {
       writer.uint32(80).int64(message.size);
     }
-    if (message.protocol !== "") {
+    if (message.protocol !== undefined) {
       writer.uint32(90).string(message.protocol);
     }
-    if (message.reason !== "") {
+    if (message.reason !== undefined) {
       writer.uint32(98).string(message.reason);
     }
     if (message.auth !== undefined) {
@@ -1792,10 +1792,10 @@ function createBaseAttributeContext_Response_HeadersEntry(): AttributeContext_Re
 }
 export const AttributeContext_Response_HeadersEntry = {
   encode(message: AttributeContext_Response_HeadersEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(18).string(message.value);
     }
     return writer;
@@ -1890,10 +1890,10 @@ function createBaseAttributeContext_Response(): AttributeContext_Response {
 export const AttributeContext_Response = {
   typeUrl: "/google.rpc.context.Response",
   encode(message: AttributeContext_Response, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.code !== BigInt(0)) {
+    if (message.code !== undefined) {
       writer.uint32(8).int64(message.code);
     }
-    if (message.size !== BigInt(0)) {
+    if (message.size !== undefined) {
       writer.uint32(16).int64(message.size);
     }
     Object.entries(message.headers).forEach(([key, value]) => {
@@ -2086,10 +2086,10 @@ function createBaseAttributeContext_Resource_LabelsEntry(): AttributeContext_Res
 }
 export const AttributeContext_Resource_LabelsEntry = {
   encode(message: AttributeContext_Resource_LabelsEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(18).string(message.value);
     }
     return writer;
@@ -2180,10 +2180,10 @@ function createBaseAttributeContext_Resource_AnnotationsEntry(): AttributeContex
 }
 export const AttributeContext_Resource_AnnotationsEntry = {
   encode(message: AttributeContext_Resource_AnnotationsEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(18).string(message.value);
     }
     return writer;
@@ -2285,13 +2285,13 @@ function createBaseAttributeContext_Resource(): AttributeContext_Resource {
 export const AttributeContext_Resource = {
   typeUrl: "/google.rpc.context.Resource",
   encode(message: AttributeContext_Resource, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.service !== "") {
+    if (message.service !== undefined) {
       writer.uint32(10).string(message.service);
     }
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(18).string(message.name);
     }
-    if (message.type !== "") {
+    if (message.type !== undefined) {
       writer.uint32(26).string(message.type);
     }
     Object.entries(message.labels).forEach(([key, value]) => {
@@ -2300,7 +2300,7 @@ export const AttributeContext_Resource = {
         value
       }, writer.uint32(34).fork()).ldelim();
     });
-    if (message.uid !== "") {
+    if (message.uid !== undefined) {
       writer.uint32(42).string(message.uid);
     }
     Object.entries(message.annotations).forEach(([key, value]) => {
@@ -2309,7 +2309,7 @@ export const AttributeContext_Resource = {
         value
       }, writer.uint32(50).fork()).ldelim();
     });
-    if (message.displayName !== "") {
+    if (message.displayName !== undefined) {
       writer.uint32(58).string(message.displayName);
     }
     if (message.createTime !== undefined) {
@@ -2321,10 +2321,10 @@ export const AttributeContext_Resource = {
     if (message.deleteTime !== undefined) {
       Timestamp.encode(toTimestamp(message.deleteTime), writer.uint32(82).fork()).ldelim();
     }
-    if (message.etag !== "") {
+    if (message.etag !== undefined) {
       writer.uint32(90).string(message.etag);
     }
-    if (message.location !== "") {
+    if (message.location !== undefined) {
       writer.uint32(98).string(message.location);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/rpc/error_details.ts
+++ b/__fixtures__/v-next/outputv4/google/rpc/error_details.ts
@@ -565,7 +565,7 @@ export const DebugInfo = {
     for (const v of message.stackEntries) {
       writer.uint32(10).string(v!);
     }
-    if (message.detail !== "") {
+    if (message.detail !== undefined) {
       writer.uint32(18).string(message.detail);
     }
     return writer;
@@ -773,10 +773,10 @@ function createBaseQuotaFailure_Violation(): QuotaFailure_Violation {
 export const QuotaFailure_Violation = {
   typeUrl: "/google.rpc.Violation",
   encode(message: QuotaFailure_Violation, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.subject !== "") {
+    if (message.subject !== undefined) {
       writer.uint32(10).string(message.subject);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
     return writer;
@@ -873,10 +873,10 @@ function createBaseErrorInfo_MetadataEntry(): ErrorInfo_MetadataEntry {
 }
 export const ErrorInfo_MetadataEntry = {
   encode(message: ErrorInfo_MetadataEntry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(18).string(message.value);
     }
     return writer;
@@ -969,10 +969,10 @@ function createBaseErrorInfo(): ErrorInfo {
 export const ErrorInfo = {
   typeUrl: "/google.rpc.ErrorInfo",
   encode(message: ErrorInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.reason !== "") {
+    if (message.reason !== undefined) {
       writer.uint32(10).string(message.reason);
     }
-    if (message.domain !== "") {
+    if (message.domain !== undefined) {
       writer.uint32(18).string(message.domain);
     }
     Object.entries(message.metadata).forEach(([key, value]) => {
@@ -1231,13 +1231,13 @@ function createBasePreconditionFailure_Violation(): PreconditionFailure_Violatio
 export const PreconditionFailure_Violation = {
   typeUrl: "/google.rpc.Violation",
   encode(message: PreconditionFailure_Violation, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.type !== "") {
+    if (message.type !== undefined) {
       writer.uint32(10).string(message.type);
     }
-    if (message.subject !== "") {
+    if (message.subject !== undefined) {
       writer.uint32(18).string(message.subject);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(26).string(message.description);
     }
     return writer;
@@ -1444,10 +1444,10 @@ function createBaseBadRequest_FieldViolation(): BadRequest_FieldViolation {
 export const BadRequest_FieldViolation = {
   typeUrl: "/google.rpc.FieldViolation",
   encode(message: BadRequest_FieldViolation, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.field !== "") {
+    if (message.field !== undefined) {
       writer.uint32(10).string(message.field);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
     return writer;
@@ -1545,10 +1545,10 @@ function createBaseRequestInfo(): RequestInfo {
 export const RequestInfo = {
   typeUrl: "/google.rpc.RequestInfo",
   encode(message: RequestInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.requestId !== "") {
+    if (message.requestId !== undefined) {
       writer.uint32(10).string(message.requestId);
     }
-    if (message.servingData !== "") {
+    if (message.servingData !== undefined) {
       writer.uint32(18).string(message.servingData);
     }
     return writer;
@@ -1648,16 +1648,16 @@ function createBaseResourceInfo(): ResourceInfo {
 export const ResourceInfo = {
   typeUrl: "/google.rpc.ResourceInfo",
   encode(message: ResourceInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.resourceType !== "") {
+    if (message.resourceType !== undefined) {
       writer.uint32(10).string(message.resourceType);
     }
-    if (message.resourceName !== "") {
+    if (message.resourceName !== undefined) {
       writer.uint32(18).string(message.resourceName);
     }
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(26).string(message.owner);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(34).string(message.description);
     }
     return writer;
@@ -1875,10 +1875,10 @@ function createBaseHelp_Link(): Help_Link {
 export const Help_Link = {
   typeUrl: "/google.rpc.Link",
   encode(message: Help_Link, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(10).string(message.description);
     }
-    if (message.url !== "") {
+    if (message.url !== undefined) {
       writer.uint32(18).string(message.url);
     }
     return writer;
@@ -1976,10 +1976,10 @@ function createBaseLocalizedMessage(): LocalizedMessage {
 export const LocalizedMessage = {
   typeUrl: "/google.rpc.LocalizedMessage",
   encode(message: LocalizedMessage, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.locale !== "") {
+    if (message.locale !== undefined) {
       writer.uint32(10).string(message.locale);
     }
-    if (message.message !== "") {
+    if (message.message !== undefined) {
       writer.uint32(18).string(message.message);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/google/rpc/status.ts
+++ b/__fixtures__/v-next/outputv4/google/rpc/status.ts
@@ -54,10 +54,10 @@ function createBaseStatus(): Status {
 export const Status = {
   typeUrl: "/google.rpc.Status",
   encode(message: Status, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.code !== 0) {
+    if (message.code !== undefined) {
       writer.uint32(8).int32(message.code);
     }
-    if (message.message !== "") {
+    if (message.message !== undefined) {
       writer.uint32(18).string(message.message);
     }
     for (const v of message.details) {

--- a/__fixtures__/v-next/outputv4/ibc/applications/transfer/v1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/ibc/applications/transfer/v1/genesis.ts
@@ -28,7 +28,7 @@ function createBaseGenesisState(): GenesisState {
 export const GenesisState = {
   typeUrl: "/ibc.applications.transfer.v1.GenesisState",
   encode(message: GenesisState, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.portId !== "") {
+    if (message.portId !== undefined) {
       writer.uint32(10).string(message.portId);
     }
     for (const v of message.denomTraces) {

--- a/__fixtures__/v-next/outputv4/ibc/applications/transfer/v1/query.ts
+++ b/__fixtures__/v-next/outputv4/ibc/applications/transfer/v1/query.ts
@@ -111,7 +111,7 @@ function createBaseQueryDenomTraceRequest(): QueryDenomTraceRequest {
 export const QueryDenomTraceRequest = {
   typeUrl: "/ibc.applications.transfer.v1.QueryDenomTraceRequest",
   encode(message: QueryDenomTraceRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.hash !== "") {
+    if (message.hash !== undefined) {
       writer.uint32(10).string(message.hash);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/ibc/applications/transfer/v1/transfer.ts
+++ b/__fixtures__/v-next/outputv4/ibc/applications/transfer/v1/transfer.ts
@@ -67,10 +67,10 @@ function createBaseDenomTrace(): DenomTrace {
 export const DenomTrace = {
   typeUrl: "/ibc.applications.transfer.v1.DenomTrace",
   encode(message: DenomTrace, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.path !== "") {
+    if (message.path !== undefined) {
       writer.uint32(10).string(message.path);
     }
-    if (message.baseDenom !== "") {
+    if (message.baseDenom !== undefined) {
       writer.uint32(18).string(message.baseDenom);
     }
     return writer;
@@ -174,10 +174,10 @@ function createBaseParams(): Params {
 export const Params = {
   typeUrl: "/ibc.applications.transfer.v1.Params",
   encode(message: Params, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sendEnabled === true) {
+    if (message.sendEnabled !== undefined) {
       writer.uint32(8).bool(message.sendEnabled);
     }
-    if (message.receiveEnabled === true) {
+    if (message.receiveEnabled !== undefined) {
       writer.uint32(16).bool(message.receiveEnabled);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/ibc/applications/transfer/v1/tx.ts
+++ b/__fixtures__/v-next/outputv4/ibc/applications/transfer/v1/tx.ts
@@ -70,25 +70,25 @@ function createBaseMsgTransfer(): MsgTransfer {
 export const MsgTransfer = {
   typeUrl: "/ibc.applications.transfer.v1.MsgTransfer",
   encode(message: MsgTransfer, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sourcePort !== "") {
+    if (message.sourcePort !== undefined) {
       writer.uint32(10).string(message.sourcePort);
     }
-    if (message.sourceChannel !== "") {
+    if (message.sourceChannel !== undefined) {
       writer.uint32(18).string(message.sourceChannel);
     }
     if (message.token !== undefined) {
       Coin.encode(message.token, writer.uint32(26).fork()).ldelim();
     }
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(34).string(message.sender);
     }
-    if (message.receiver !== "") {
+    if (message.receiver !== undefined) {
       writer.uint32(42).string(message.receiver);
     }
     if (message.timeoutHeight !== undefined) {
       Height.encode(message.timeoutHeight, writer.uint32(50).fork()).ldelim();
     }
-    if (message.timeoutTimestamp !== BigInt(0)) {
+    if (message.timeoutTimestamp !== undefined) {
       writer.uint32(56).uint64(message.timeoutTimestamp);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/ibc/applications/transfer/v2/packet.ts
+++ b/__fixtures__/v-next/outputv4/ibc/applications/transfer/v2/packet.ts
@@ -42,16 +42,16 @@ function createBaseFungibleTokenPacketData(): FungibleTokenPacketData {
 export const FungibleTokenPacketData = {
   typeUrl: "/ibc.applications.transfer.v2.FungibleTokenPacketData",
   encode(message: FungibleTokenPacketData, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(10).string(message.denom);
     }
-    if (message.amount !== "") {
+    if (message.amount !== undefined) {
       writer.uint32(18).string(message.amount);
     }
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(26).string(message.sender);
     }
-    if (message.receiver !== "") {
+    if (message.receiver !== undefined) {
       writer.uint32(34).string(message.receiver);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/ibc/core/channel/v1/channel.ts
+++ b/__fixtures__/v-next/outputv4/ibc/core/channel/v1/channel.ts
@@ -326,7 +326,7 @@ export const Channel = {
     for (const v of message.connectionHops) {
       writer.uint32(34).string(v!);
     }
-    if (message.version !== "") {
+    if (message.version !== undefined) {
       writer.uint32(42).string(message.version);
     }
     return writer;
@@ -494,13 +494,13 @@ export const IdentifiedChannel = {
     for (const v of message.connectionHops) {
       writer.uint32(34).string(v!);
     }
-    if (message.version !== "") {
+    if (message.version !== undefined) {
       writer.uint32(42).string(message.version);
     }
-    if (message.portId !== "") {
+    if (message.portId !== undefined) {
       writer.uint32(50).string(message.portId);
     }
-    if (message.channelId !== "") {
+    if (message.channelId !== undefined) {
       writer.uint32(58).string(message.channelId);
     }
     return writer;
@@ -673,10 +673,10 @@ function createBaseCounterparty(): Counterparty {
 export const Counterparty = {
   typeUrl: "/ibc.core.channel.v1.Counterparty",
   encode(message: Counterparty, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.portId !== "") {
+    if (message.portId !== undefined) {
       writer.uint32(10).string(message.portId);
     }
-    if (message.channelId !== "") {
+    if (message.channelId !== undefined) {
       writer.uint32(18).string(message.channelId);
     }
     return writer;
@@ -786,19 +786,19 @@ function createBasePacket(): Packet {
 export const Packet = {
   typeUrl: "/ibc.core.channel.v1.Packet",
   encode(message: Packet, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sequence !== BigInt(0)) {
+    if (message.sequence !== undefined) {
       writer.uint32(8).uint64(message.sequence);
     }
-    if (message.sourcePort !== "") {
+    if (message.sourcePort !== undefined) {
       writer.uint32(18).string(message.sourcePort);
     }
-    if (message.sourceChannel !== "") {
+    if (message.sourceChannel !== undefined) {
       writer.uint32(26).string(message.sourceChannel);
     }
-    if (message.destinationPort !== "") {
+    if (message.destinationPort !== undefined) {
       writer.uint32(34).string(message.destinationPort);
     }
-    if (message.destinationChannel !== "") {
+    if (message.destinationChannel !== undefined) {
       writer.uint32(42).string(message.destinationChannel);
     }
     if (message.data.length !== 0) {
@@ -807,7 +807,7 @@ export const Packet = {
     if (message.timeoutHeight !== undefined) {
       Height.encode(message.timeoutHeight, writer.uint32(58).fork()).ldelim();
     }
-    if (message.timeoutTimestamp !== BigInt(0)) {
+    if (message.timeoutTimestamp !== undefined) {
       writer.uint32(64).uint64(message.timeoutTimestamp);
     }
     return writer;
@@ -985,13 +985,13 @@ function createBasePacketState(): PacketState {
 export const PacketState = {
   typeUrl: "/ibc.core.channel.v1.PacketState",
   encode(message: PacketState, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.portId !== "") {
+    if (message.portId !== undefined) {
       writer.uint32(10).string(message.portId);
     }
-    if (message.channelId !== "") {
+    if (message.channelId !== undefined) {
       writer.uint32(18).string(message.channelId);
     }
-    if (message.sequence !== BigInt(0)) {
+    if (message.sequence !== undefined) {
       writer.uint32(24).uint64(message.sequence);
     }
     if (message.data.length !== 0) {

--- a/__fixtures__/v-next/outputv4/ibc/core/channel/v1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/ibc/core/channel/v1/genesis.ts
@@ -87,7 +87,7 @@ export const GenesisState = {
     for (const v of message.ackSequences) {
       PacketSequence.encode(v!, writer.uint32(58).fork()).ldelim();
     }
-    if (message.nextChannelSequence !== BigInt(0)) {
+    if (message.nextChannelSequence !== undefined) {
       writer.uint32(64).uint64(message.nextChannelSequence);
     }
     return writer;
@@ -344,13 +344,13 @@ function createBasePacketSequence(): PacketSequence {
 export const PacketSequence = {
   typeUrl: "/ibc.core.channel.v1.PacketSequence",
   encode(message: PacketSequence, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.portId !== "") {
+    if (message.portId !== undefined) {
       writer.uint32(10).string(message.portId);
     }
-    if (message.channelId !== "") {
+    if (message.channelId !== undefined) {
       writer.uint32(18).string(message.channelId);
     }
-    if (message.sequence !== BigInt(0)) {
+    if (message.sequence !== undefined) {
       writer.uint32(24).uint64(message.sequence);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/ibc/core/channel/v1/query.ts
+++ b/__fixtures__/v-next/outputv4/ibc/core/channel/v1/query.ts
@@ -637,10 +637,10 @@ function createBaseQueryChannelRequest(): QueryChannelRequest {
 export const QueryChannelRequest = {
   typeUrl: "/ibc.core.channel.v1.QueryChannelRequest",
   encode(message: QueryChannelRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.portId !== "") {
+    if (message.portId !== undefined) {
       writer.uint32(10).string(message.portId);
     }
-    if (message.channelId !== "") {
+    if (message.channelId !== undefined) {
       writer.uint32(18).string(message.channelId);
     }
     return writer;
@@ -1102,7 +1102,7 @@ function createBaseQueryConnectionChannelsRequest(): QueryConnectionChannelsRequ
 export const QueryConnectionChannelsRequest = {
   typeUrl: "/ibc.core.channel.v1.QueryConnectionChannelsRequest",
   encode(message: QueryConnectionChannelsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.connection !== "") {
+    if (message.connection !== undefined) {
       writer.uint32(10).string(message.connection);
     }
     if (message.pagination !== undefined) {
@@ -1349,10 +1349,10 @@ function createBaseQueryChannelClientStateRequest(): QueryChannelClientStateRequ
 export const QueryChannelClientStateRequest = {
   typeUrl: "/ibc.core.channel.v1.QueryChannelClientStateRequest",
   encode(message: QueryChannelClientStateRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.portId !== "") {
+    if (message.portId !== undefined) {
       writer.uint32(10).string(message.portId);
     }
-    if (message.channelId !== "") {
+    if (message.channelId !== undefined) {
       writer.uint32(18).string(message.channelId);
     }
     return writer;
@@ -1584,16 +1584,16 @@ function createBaseQueryChannelConsensusStateRequest(): QueryChannelConsensusSta
 export const QueryChannelConsensusStateRequest = {
   typeUrl: "/ibc.core.channel.v1.QueryChannelConsensusStateRequest",
   encode(message: QueryChannelConsensusStateRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.portId !== "") {
+    if (message.portId !== undefined) {
       writer.uint32(10).string(message.portId);
     }
-    if (message.channelId !== "") {
+    if (message.channelId !== undefined) {
       writer.uint32(18).string(message.channelId);
     }
-    if (message.revisionNumber !== BigInt(0)) {
+    if (message.revisionNumber !== undefined) {
       writer.uint32(24).uint64(message.revisionNumber);
     }
-    if (message.revisionHeight !== BigInt(0)) {
+    if (message.revisionHeight !== undefined) {
       writer.uint32(32).uint64(message.revisionHeight);
     }
     return writer;
@@ -1728,7 +1728,7 @@ export const QueryChannelConsensusStateResponse = {
     if (message.consensusState !== undefined) {
       Any.encode(message.consensusState, writer.uint32(10).fork()).ldelim();
     }
-    if (message.clientId !== "") {
+    if (message.clientId !== undefined) {
       writer.uint32(18).string(message.clientId);
     }
     if (message.proof.length !== 0) {
@@ -1865,13 +1865,13 @@ function createBaseQueryPacketCommitmentRequest(): QueryPacketCommitmentRequest 
 export const QueryPacketCommitmentRequest = {
   typeUrl: "/ibc.core.channel.v1.QueryPacketCommitmentRequest",
   encode(message: QueryPacketCommitmentRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.portId !== "") {
+    if (message.portId !== undefined) {
       writer.uint32(10).string(message.portId);
     }
-    if (message.channelId !== "") {
+    if (message.channelId !== undefined) {
       writer.uint32(18).string(message.channelId);
     }
-    if (message.sequence !== BigInt(0)) {
+    if (message.sequence !== undefined) {
       writer.uint32(24).uint64(message.sequence);
     }
     return writer;
@@ -2113,10 +2113,10 @@ function createBaseQueryPacketCommitmentsRequest(): QueryPacketCommitmentsReques
 export const QueryPacketCommitmentsRequest = {
   typeUrl: "/ibc.core.channel.v1.QueryPacketCommitmentsRequest",
   encode(message: QueryPacketCommitmentsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.portId !== "") {
+    if (message.portId !== undefined) {
       writer.uint32(10).string(message.portId);
     }
-    if (message.channelId !== "") {
+    if (message.channelId !== undefined) {
       writer.uint32(18).string(message.channelId);
     }
     if (message.pagination !== undefined) {
@@ -2375,13 +2375,13 @@ function createBaseQueryPacketReceiptRequest(): QueryPacketReceiptRequest {
 export const QueryPacketReceiptRequest = {
   typeUrl: "/ibc.core.channel.v1.QueryPacketReceiptRequest",
   encode(message: QueryPacketReceiptRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.portId !== "") {
+    if (message.portId !== undefined) {
       writer.uint32(10).string(message.portId);
     }
-    if (message.channelId !== "") {
+    if (message.channelId !== undefined) {
       writer.uint32(18).string(message.channelId);
     }
-    if (message.sequence !== BigInt(0)) {
+    if (message.sequence !== undefined) {
       writer.uint32(24).uint64(message.sequence);
     }
     return writer;
@@ -2499,7 +2499,7 @@ function createBaseQueryPacketReceiptResponse(): QueryPacketReceiptResponse {
 export const QueryPacketReceiptResponse = {
   typeUrl: "/ibc.core.channel.v1.QueryPacketReceiptResponse",
   encode(message: QueryPacketReceiptResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.received === true) {
+    if (message.received !== undefined) {
       writer.uint32(16).bool(message.received);
     }
     if (message.proof.length !== 0) {
@@ -2623,13 +2623,13 @@ function createBaseQueryPacketAcknowledgementRequest(): QueryPacketAcknowledgeme
 export const QueryPacketAcknowledgementRequest = {
   typeUrl: "/ibc.core.channel.v1.QueryPacketAcknowledgementRequest",
   encode(message: QueryPacketAcknowledgementRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.portId !== "") {
+    if (message.portId !== undefined) {
       writer.uint32(10).string(message.portId);
     }
-    if (message.channelId !== "") {
+    if (message.channelId !== undefined) {
       writer.uint32(18).string(message.channelId);
     }
-    if (message.sequence !== BigInt(0)) {
+    if (message.sequence !== undefined) {
       writer.uint32(24).uint64(message.sequence);
     }
     return writer;
@@ -2872,10 +2872,10 @@ function createBaseQueryPacketAcknowledgementsRequest(): QueryPacketAcknowledgem
 export const QueryPacketAcknowledgementsRequest = {
   typeUrl: "/ibc.core.channel.v1.QueryPacketAcknowledgementsRequest",
   encode(message: QueryPacketAcknowledgementsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.portId !== "") {
+    if (message.portId !== undefined) {
       writer.uint32(10).string(message.portId);
     }
-    if (message.channelId !== "") {
+    if (message.channelId !== undefined) {
       writer.uint32(18).string(message.channelId);
     }
     if (message.pagination !== undefined) {
@@ -3169,10 +3169,10 @@ function createBaseQueryUnreceivedPacketsRequest(): QueryUnreceivedPacketsReques
 export const QueryUnreceivedPacketsRequest = {
   typeUrl: "/ibc.core.channel.v1.QueryUnreceivedPacketsRequest",
   encode(message: QueryUnreceivedPacketsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.portId !== "") {
+    if (message.portId !== undefined) {
       writer.uint32(10).string(message.portId);
     }
-    if (message.channelId !== "") {
+    if (message.channelId !== undefined) {
       writer.uint32(18).string(message.channelId);
     }
     writer.uint32(26).fork();
@@ -3442,10 +3442,10 @@ function createBaseQueryUnreceivedAcksRequest(): QueryUnreceivedAcksRequest {
 export const QueryUnreceivedAcksRequest = {
   typeUrl: "/ibc.core.channel.v1.QueryUnreceivedAcksRequest",
   encode(message: QueryUnreceivedAcksRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.portId !== "") {
+    if (message.portId !== undefined) {
       writer.uint32(10).string(message.portId);
     }
-    if (message.channelId !== "") {
+    if (message.channelId !== undefined) {
       writer.uint32(18).string(message.channelId);
     }
     writer.uint32(26).fork();
@@ -3714,10 +3714,10 @@ function createBaseQueryNextSequenceReceiveRequest(): QueryNextSequenceReceiveRe
 export const QueryNextSequenceReceiveRequest = {
   typeUrl: "/ibc.core.channel.v1.QueryNextSequenceReceiveRequest",
   encode(message: QueryNextSequenceReceiveRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.portId !== "") {
+    if (message.portId !== undefined) {
       writer.uint32(10).string(message.portId);
     }
-    if (message.channelId !== "") {
+    if (message.channelId !== undefined) {
       writer.uint32(18).string(message.channelId);
     }
     return writer;
@@ -3822,7 +3822,7 @@ function createBaseQueryNextSequenceReceiveResponse(): QueryNextSequenceReceiveR
 export const QueryNextSequenceReceiveResponse = {
   typeUrl: "/ibc.core.channel.v1.QueryNextSequenceReceiveResponse",
   encode(message: QueryNextSequenceReceiveResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.nextSequenceReceive !== BigInt(0)) {
+    if (message.nextSequenceReceive !== undefined) {
       writer.uint32(8).uint64(message.nextSequenceReceive);
     }
     if (message.proof.length !== 0) {

--- a/__fixtures__/v-next/outputv4/ibc/core/channel/v1/tx.ts
+++ b/__fixtures__/v-next/outputv4/ibc/core/channel/v1/tx.ts
@@ -345,13 +345,13 @@ function createBaseMsgChannelOpenInit(): MsgChannelOpenInit {
 export const MsgChannelOpenInit = {
   typeUrl: "/ibc.core.channel.v1.MsgChannelOpenInit",
   encode(message: MsgChannelOpenInit, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.portId !== "") {
+    if (message.portId !== undefined) {
       writer.uint32(10).string(message.portId);
     }
     if (message.channel !== undefined) {
       Channel.encode(message.channel, writer.uint32(18).fork()).ldelim();
     }
-    if (message.signer !== "") {
+    if (message.signer !== undefined) {
       writer.uint32(26).string(message.signer);
     }
     return writer;
@@ -546,16 +546,16 @@ function createBaseMsgChannelOpenTry(): MsgChannelOpenTry {
 export const MsgChannelOpenTry = {
   typeUrl: "/ibc.core.channel.v1.MsgChannelOpenTry",
   encode(message: MsgChannelOpenTry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.portId !== "") {
+    if (message.portId !== undefined) {
       writer.uint32(10).string(message.portId);
     }
-    if (message.previousChannelId !== "") {
+    if (message.previousChannelId !== undefined) {
       writer.uint32(18).string(message.previousChannelId);
     }
     if (message.channel !== undefined) {
       Channel.encode(message.channel, writer.uint32(26).fork()).ldelim();
     }
-    if (message.counterpartyVersion !== "") {
+    if (message.counterpartyVersion !== undefined) {
       writer.uint32(34).string(message.counterpartyVersion);
     }
     if (message.proofInit.length !== 0) {
@@ -564,7 +564,7 @@ export const MsgChannelOpenTry = {
     if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(50).fork()).ldelim();
     }
-    if (message.signer !== "") {
+    if (message.signer !== undefined) {
       writer.uint32(58).string(message.signer);
     }
     return writer;
@@ -805,16 +805,16 @@ function createBaseMsgChannelOpenAck(): MsgChannelOpenAck {
 export const MsgChannelOpenAck = {
   typeUrl: "/ibc.core.channel.v1.MsgChannelOpenAck",
   encode(message: MsgChannelOpenAck, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.portId !== "") {
+    if (message.portId !== undefined) {
       writer.uint32(10).string(message.portId);
     }
-    if (message.channelId !== "") {
+    if (message.channelId !== undefined) {
       writer.uint32(18).string(message.channelId);
     }
-    if (message.counterpartyChannelId !== "") {
+    if (message.counterpartyChannelId !== undefined) {
       writer.uint32(26).string(message.counterpartyChannelId);
     }
-    if (message.counterpartyVersion !== "") {
+    if (message.counterpartyVersion !== undefined) {
       writer.uint32(34).string(message.counterpartyVersion);
     }
     if (message.proofTry.length !== 0) {
@@ -823,7 +823,7 @@ export const MsgChannelOpenAck = {
     if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(50).fork()).ldelim();
     }
-    if (message.signer !== "") {
+    if (message.signer !== undefined) {
       writer.uint32(58).string(message.signer);
     }
     return writer;
@@ -1060,10 +1060,10 @@ function createBaseMsgChannelOpenConfirm(): MsgChannelOpenConfirm {
 export const MsgChannelOpenConfirm = {
   typeUrl: "/ibc.core.channel.v1.MsgChannelOpenConfirm",
   encode(message: MsgChannelOpenConfirm, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.portId !== "") {
+    if (message.portId !== undefined) {
       writer.uint32(10).string(message.portId);
     }
-    if (message.channelId !== "") {
+    if (message.channelId !== undefined) {
       writer.uint32(18).string(message.channelId);
     }
     if (message.proofAck.length !== 0) {
@@ -1072,7 +1072,7 @@ export const MsgChannelOpenConfirm = {
     if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(34).fork()).ldelim();
     }
-    if (message.signer !== "") {
+    if (message.signer !== undefined) {
       writer.uint32(42).string(message.signer);
     }
     return writer;
@@ -1285,13 +1285,13 @@ function createBaseMsgChannelCloseInit(): MsgChannelCloseInit {
 export const MsgChannelCloseInit = {
   typeUrl: "/ibc.core.channel.v1.MsgChannelCloseInit",
   encode(message: MsgChannelCloseInit, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.portId !== "") {
+    if (message.portId !== undefined) {
       writer.uint32(10).string(message.portId);
     }
-    if (message.channelId !== "") {
+    if (message.channelId !== undefined) {
       writer.uint32(18).string(message.channelId);
     }
-    if (message.signer !== "") {
+    if (message.signer !== undefined) {
       writer.uint32(26).string(message.signer);
     }
     return writer;
@@ -1482,10 +1482,10 @@ function createBaseMsgChannelCloseConfirm(): MsgChannelCloseConfirm {
 export const MsgChannelCloseConfirm = {
   typeUrl: "/ibc.core.channel.v1.MsgChannelCloseConfirm",
   encode(message: MsgChannelCloseConfirm, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.portId !== "") {
+    if (message.portId !== undefined) {
       writer.uint32(10).string(message.portId);
     }
-    if (message.channelId !== "") {
+    if (message.channelId !== undefined) {
       writer.uint32(18).string(message.channelId);
     }
     if (message.proofInit.length !== 0) {
@@ -1494,7 +1494,7 @@ export const MsgChannelCloseConfirm = {
     if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(34).fork()).ldelim();
     }
-    if (message.signer !== "") {
+    if (message.signer !== undefined) {
       writer.uint32(42).string(message.signer);
     }
     return writer;
@@ -1717,7 +1717,7 @@ export const MsgRecvPacket = {
     if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(26).fork()).ldelim();
     }
-    if (message.signer !== "") {
+    if (message.signer !== undefined) {
       writer.uint32(34).string(message.signer);
     }
     return writer;
@@ -1932,10 +1932,10 @@ export const MsgTimeout = {
     if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(26).fork()).ldelim();
     }
-    if (message.nextSequenceRecv !== BigInt(0)) {
+    if (message.nextSequenceRecv !== undefined) {
       writer.uint32(32).uint64(message.nextSequenceRecv);
     }
-    if (message.signer !== "") {
+    if (message.signer !== undefined) {
       writer.uint32(42).string(message.signer);
     }
     return writer;
@@ -2167,10 +2167,10 @@ export const MsgTimeoutOnClose = {
     if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(34).fork()).ldelim();
     }
-    if (message.nextSequenceRecv !== BigInt(0)) {
+    if (message.nextSequenceRecv !== undefined) {
       writer.uint32(40).uint64(message.nextSequenceRecv);
     }
-    if (message.signer !== "") {
+    if (message.signer !== undefined) {
       writer.uint32(50).string(message.signer);
     }
     return writer;
@@ -2412,7 +2412,7 @@ export const MsgAcknowledgement = {
     if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(34).fork()).ldelim();
     }
-    if (message.signer !== "") {
+    if (message.signer !== undefined) {
       writer.uint32(42).string(message.signer);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/ibc/core/client/v1/client.ts
+++ b/__fixtures__/v-next/outputv4/ibc/core/client/v1/client.ts
@@ -196,7 +196,7 @@ function createBaseIdentifiedClientState(): IdentifiedClientState {
 export const IdentifiedClientState = {
   typeUrl: "/ibc.core.client.v1.IdentifiedClientState",
   encode(message: IdentifiedClientState, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.clientId !== "") {
+    if (message.clientId !== undefined) {
       writer.uint32(10).string(message.clientId);
     }
     if (message.clientState !== undefined) {
@@ -416,7 +416,7 @@ function createBaseClientConsensusStates(): ClientConsensusStates {
 export const ClientConsensusStates = {
   typeUrl: "/ibc.core.client.v1.ClientConsensusStates",
   encode(message: ClientConsensusStates, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.clientId !== "") {
+    if (message.clientId !== undefined) {
       writer.uint32(10).string(message.clientId);
     }
     for (const v of message.consensusStates) {
@@ -537,16 +537,16 @@ function createBaseClientUpdateProposal(): ClientUpdateProposal {
 export const ClientUpdateProposal = {
   typeUrl: "/ibc.core.client.v1.ClientUpdateProposal",
   encode(message: ClientUpdateProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
-    if (message.subjectClientId !== "") {
+    if (message.subjectClientId !== undefined) {
       writer.uint32(26).string(message.subjectClientId);
     }
-    if (message.substituteClientId !== "") {
+    if (message.substituteClientId !== undefined) {
       writer.uint32(34).string(message.substituteClientId);
     }
     return writer;
@@ -674,10 +674,10 @@ function createBaseUpgradeProposal(): UpgradeProposal {
 export const UpgradeProposal = {
   typeUrl: "/ibc.core.client.v1.UpgradeProposal",
   encode(message: UpgradeProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
     if (message.plan !== undefined) {
@@ -813,10 +813,10 @@ function createBaseHeight(): Height {
 export const Height = {
   typeUrl: "/ibc.core.client.v1.Height",
   encode(message: Height, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.revisionNumber !== BigInt(0)) {
+    if (message.revisionNumber !== undefined) {
       writer.uint32(8).uint64(message.revisionNumber);
     }
-    if (message.revisionHeight !== BigInt(0)) {
+    if (message.revisionHeight !== undefined) {
       writer.uint32(16).uint64(message.revisionHeight);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/ibc/core/client/v1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/ibc/core/client/v1/genesis.ts
@@ -96,10 +96,10 @@ export const GenesisState = {
     if (message.params !== undefined) {
       Params.encode(message.params, writer.uint32(34).fork()).ldelim();
     }
-    if (message.createLocalhost === true) {
+    if (message.createLocalhost !== undefined) {
       writer.uint32(40).bool(message.createLocalhost);
     }
-    if (message.nextClientSequence !== BigInt(0)) {
+    if (message.nextClientSequence !== undefined) {
       writer.uint32(48).uint64(message.nextClientSequence);
     }
     return writer;
@@ -394,7 +394,7 @@ function createBaseIdentifiedGenesisMetadata(): IdentifiedGenesisMetadata {
 export const IdentifiedGenesisMetadata = {
   typeUrl: "/ibc.core.client.v1.IdentifiedGenesisMetadata",
   encode(message: IdentifiedGenesisMetadata, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.clientId !== "") {
+    if (message.clientId !== undefined) {
       writer.uint32(10).string(message.clientId);
     }
     for (const v of message.clientMetadata) {

--- a/__fixtures__/v-next/outputv4/ibc/core/client/v1/query.ts
+++ b/__fixtures__/v-next/outputv4/ibc/core/client/v1/query.ts
@@ -337,7 +337,7 @@ function createBaseQueryClientStateRequest(): QueryClientStateRequest {
 export const QueryClientStateRequest = {
   typeUrl: "/ibc.core.client.v1.QueryClientStateRequest",
   encode(message: QueryClientStateRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.clientId !== "") {
+    if (message.clientId !== undefined) {
       writer.uint32(10).string(message.clientId);
     }
     return writer;
@@ -773,16 +773,16 @@ function createBaseQueryConsensusStateRequest(): QueryConsensusStateRequest {
 export const QueryConsensusStateRequest = {
   typeUrl: "/ibc.core.client.v1.QueryConsensusStateRequest",
   encode(message: QueryConsensusStateRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.clientId !== "") {
+    if (message.clientId !== undefined) {
       writer.uint32(10).string(message.clientId);
     }
-    if (message.revisionNumber !== BigInt(0)) {
+    if (message.revisionNumber !== undefined) {
       writer.uint32(16).uint64(message.revisionNumber);
     }
-    if (message.revisionHeight !== BigInt(0)) {
+    if (message.revisionHeight !== undefined) {
       writer.uint32(24).uint64(message.revisionHeight);
     }
-    if (message.latestHeight === true) {
+    if (message.latestHeight !== undefined) {
       writer.uint32(32).bool(message.latestHeight);
     }
     return writer;
@@ -1038,7 +1038,7 @@ function createBaseQueryConsensusStatesRequest(): QueryConsensusStatesRequest {
 export const QueryConsensusStatesRequest = {
   typeUrl: "/ibc.core.client.v1.QueryConsensusStatesRequest",
   encode(message: QueryConsensusStatesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.clientId !== "") {
+    if (message.clientId !== undefined) {
       writer.uint32(10).string(message.clientId);
     }
     if (message.pagination !== undefined) {
@@ -1267,7 +1267,7 @@ function createBaseQueryClientStatusRequest(): QueryClientStatusRequest {
 export const QueryClientStatusRequest = {
   typeUrl: "/ibc.core.client.v1.QueryClientStatusRequest",
   encode(message: QueryClientStatusRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.clientId !== "") {
+    if (message.clientId !== undefined) {
       writer.uint32(10).string(message.clientId);
     }
     return writer;
@@ -1359,7 +1359,7 @@ function createBaseQueryClientStatusResponse(): QueryClientStatusResponse {
 export const QueryClientStatusResponse = {
   typeUrl: "/ibc.core.client.v1.QueryClientStatusResponse",
   encode(message: QueryClientStatusResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.status !== "") {
+    if (message.status !== undefined) {
       writer.uint32(10).string(message.status);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/ibc/core/client/v1/tx.ts
+++ b/__fixtures__/v-next/outputv4/ibc/core/client/v1/tx.ts
@@ -165,7 +165,7 @@ export const MsgCreateClient = {
     if (message.consensusState !== undefined) {
       Any.encode(message.consensusState, writer.uint32(18).fork()).ldelim();
     }
-    if (message.signer !== "") {
+    if (message.signer !== undefined) {
       writer.uint32(26).string(message.signer);
     }
     return writer;
@@ -358,13 +358,13 @@ function createBaseMsgUpdateClient(): MsgUpdateClient {
 export const MsgUpdateClient = {
   typeUrl: "/ibc.core.client.v1.MsgUpdateClient",
   encode(message: MsgUpdateClient, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.clientId !== "") {
+    if (message.clientId !== undefined) {
       writer.uint32(10).string(message.clientId);
     }
     if (message.header !== undefined) {
       Any.encode(message.header, writer.uint32(18).fork()).ldelim();
     }
-    if (message.signer !== "") {
+    if (message.signer !== undefined) {
       writer.uint32(26).string(message.signer);
     }
     return writer;
@@ -558,7 +558,7 @@ function createBaseMsgUpgradeClient(): MsgUpgradeClient {
 export const MsgUpgradeClient = {
   typeUrl: "/ibc.core.client.v1.MsgUpgradeClient",
   encode(message: MsgUpgradeClient, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.clientId !== "") {
+    if (message.clientId !== undefined) {
       writer.uint32(10).string(message.clientId);
     }
     if (message.clientState !== undefined) {
@@ -573,7 +573,7 @@ export const MsgUpgradeClient = {
     if (message.proofUpgradeConsensusState.length !== 0) {
       writer.uint32(42).bytes(message.proofUpgradeConsensusState);
     }
-    if (message.signer !== "") {
+    if (message.signer !== undefined) {
       writer.uint32(50).string(message.signer);
     }
     return writer;
@@ -799,13 +799,13 @@ function createBaseMsgSubmitMisbehaviour(): MsgSubmitMisbehaviour {
 export const MsgSubmitMisbehaviour = {
   typeUrl: "/ibc.core.client.v1.MsgSubmitMisbehaviour",
   encode(message: MsgSubmitMisbehaviour, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.clientId !== "") {
+    if (message.clientId !== undefined) {
       writer.uint32(10).string(message.clientId);
     }
     if (message.misbehaviour !== undefined) {
       Any.encode(message.misbehaviour, writer.uint32(18).fork()).ldelim();
     }
-    if (message.signer !== "") {
+    if (message.signer !== undefined) {
       writer.uint32(26).string(message.signer);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/ibc/core/connection/v1/connection.ts
+++ b/__fixtures__/v-next/outputv4/ibc/core/connection/v1/connection.ts
@@ -240,7 +240,7 @@ function createBaseConnectionEnd(): ConnectionEnd {
 export const ConnectionEnd = {
   typeUrl: "/ibc.core.connection.v1.ConnectionEnd",
   encode(message: ConnectionEnd, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.clientId !== "") {
+    if (message.clientId !== undefined) {
       writer.uint32(10).string(message.clientId);
     }
     for (const v of message.versions) {
@@ -252,7 +252,7 @@ export const ConnectionEnd = {
     if (message.counterparty !== undefined) {
       Counterparty.encode(message.counterparty, writer.uint32(34).fork()).ldelim();
     }
-    if (message.delayPeriod !== BigInt(0)) {
+    if (message.delayPeriod !== undefined) {
       writer.uint32(40).uint64(message.delayPeriod);
     }
     return writer;
@@ -409,10 +409,10 @@ function createBaseIdentifiedConnection(): IdentifiedConnection {
 export const IdentifiedConnection = {
   typeUrl: "/ibc.core.connection.v1.IdentifiedConnection",
   encode(message: IdentifiedConnection, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.id !== "") {
+    if (message.id !== undefined) {
       writer.uint32(10).string(message.id);
     }
-    if (message.clientId !== "") {
+    if (message.clientId !== undefined) {
       writer.uint32(18).string(message.clientId);
     }
     for (const v of message.versions) {
@@ -424,7 +424,7 @@ export const IdentifiedConnection = {
     if (message.counterparty !== undefined) {
       Counterparty.encode(message.counterparty, writer.uint32(42).fork()).ldelim();
     }
-    if (message.delayPeriod !== BigInt(0)) {
+    if (message.delayPeriod !== undefined) {
       writer.uint32(48).uint64(message.delayPeriod);
     }
     return writer;
@@ -589,10 +589,10 @@ function createBaseCounterparty(): Counterparty {
 export const Counterparty = {
   typeUrl: "/ibc.core.connection.v1.Counterparty",
   encode(message: Counterparty, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.clientId !== "") {
+    if (message.clientId !== undefined) {
       writer.uint32(10).string(message.clientId);
     }
-    if (message.connectionId !== "") {
+    if (message.connectionId !== undefined) {
       writer.uint32(18).string(message.connectionId);
     }
     if (message.prefix !== undefined) {
@@ -816,7 +816,7 @@ function createBaseConnectionPaths(): ConnectionPaths {
 export const ConnectionPaths = {
   typeUrl: "/ibc.core.connection.v1.ConnectionPaths",
   encode(message: ConnectionPaths, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.clientId !== "") {
+    if (message.clientId !== undefined) {
       writer.uint32(10).string(message.clientId);
     }
     for (const v of message.paths) {
@@ -935,7 +935,7 @@ function createBaseVersion(): Version {
 export const Version = {
   typeUrl: "/ibc.core.connection.v1.Version",
   encode(message: Version, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.identifier !== "") {
+    if (message.identifier !== undefined) {
       writer.uint32(10).string(message.identifier);
     }
     for (const v of message.features) {
@@ -1053,7 +1053,7 @@ function createBaseParams(): Params {
 export const Params = {
   typeUrl: "/ibc.core.connection.v1.Params",
   encode(message: Params, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.maxExpectedTimePerBlock !== BigInt(0)) {
+    if (message.maxExpectedTimePerBlock !== undefined) {
       writer.uint32(8).uint64(message.maxExpectedTimePerBlock);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/ibc/core/connection/v1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/ibc/core/connection/v1/genesis.ts
@@ -38,7 +38,7 @@ export const GenesisState = {
     for (const v of message.clientConnectionPaths) {
       ConnectionPaths.encode(v!, writer.uint32(18).fork()).ldelim();
     }
-    if (message.nextConnectionSequence !== BigInt(0)) {
+    if (message.nextConnectionSequence !== undefined) {
       writer.uint32(24).uint64(message.nextConnectionSequence);
     }
     if (message.params !== undefined) {

--- a/__fixtures__/v-next/outputv4/ibc/core/connection/v1/query.ts
+++ b/__fixtures__/v-next/outputv4/ibc/core/connection/v1/query.ts
@@ -241,7 +241,7 @@ function createBaseQueryConnectionRequest(): QueryConnectionRequest {
 export const QueryConnectionRequest = {
   typeUrl: "/ibc.core.connection.v1.QueryConnectionRequest",
   encode(message: QueryConnectionRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.connectionId !== "") {
+    if (message.connectionId !== undefined) {
       writer.uint32(10).string(message.connectionId);
     }
     return writer;
@@ -691,7 +691,7 @@ function createBaseQueryClientConnectionsRequest(): QueryClientConnectionsReques
 export const QueryClientConnectionsRequest = {
   typeUrl: "/ibc.core.connection.v1.QueryClientConnectionsRequest",
   encode(message: QueryClientConnectionsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.clientId !== "") {
+    if (message.clientId !== undefined) {
       writer.uint32(10).string(message.clientId);
     }
     return writer;
@@ -919,7 +919,7 @@ function createBaseQueryConnectionClientStateRequest(): QueryConnectionClientSta
 export const QueryConnectionClientStateRequest = {
   typeUrl: "/ibc.core.connection.v1.QueryConnectionClientStateRequest",
   encode(message: QueryConnectionClientStateRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.connectionId !== "") {
+    if (message.connectionId !== undefined) {
       writer.uint32(10).string(message.connectionId);
     }
     return writer;
@@ -1139,13 +1139,13 @@ function createBaseQueryConnectionConsensusStateRequest(): QueryConnectionConsen
 export const QueryConnectionConsensusStateRequest = {
   typeUrl: "/ibc.core.connection.v1.QueryConnectionConsensusStateRequest",
   encode(message: QueryConnectionConsensusStateRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.connectionId !== "") {
+    if (message.connectionId !== undefined) {
       writer.uint32(10).string(message.connectionId);
     }
-    if (message.revisionNumber !== BigInt(0)) {
+    if (message.revisionNumber !== undefined) {
       writer.uint32(16).uint64(message.revisionNumber);
     }
-    if (message.revisionHeight !== BigInt(0)) {
+    if (message.revisionHeight !== undefined) {
       writer.uint32(24).uint64(message.revisionHeight);
     }
     return writer;
@@ -1269,7 +1269,7 @@ export const QueryConnectionConsensusStateResponse = {
     if (message.consensusState !== undefined) {
       Any.encode(message.consensusState, writer.uint32(10).fork()).ldelim();
     }
-    if (message.clientId !== "") {
+    if (message.clientId !== undefined) {
       writer.uint32(18).string(message.clientId);
     }
     if (message.proof.length !== 0) {

--- a/__fixtures__/v-next/outputv4/ibc/core/connection/v1/tx.ts
+++ b/__fixtures__/v-next/outputv4/ibc/core/connection/v1/tx.ts
@@ -203,7 +203,7 @@ function createBaseMsgConnectionOpenInit(): MsgConnectionOpenInit {
 export const MsgConnectionOpenInit = {
   typeUrl: "/ibc.core.connection.v1.MsgConnectionOpenInit",
   encode(message: MsgConnectionOpenInit, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.clientId !== "") {
+    if (message.clientId !== undefined) {
       writer.uint32(10).string(message.clientId);
     }
     if (message.counterparty !== undefined) {
@@ -212,10 +212,10 @@ export const MsgConnectionOpenInit = {
     if (message.version !== undefined) {
       Version.encode(message.version, writer.uint32(26).fork()).ldelim();
     }
-    if (message.delayPeriod !== BigInt(0)) {
+    if (message.delayPeriod !== undefined) {
       writer.uint32(32).uint64(message.delayPeriod);
     }
-    if (message.signer !== "") {
+    if (message.signer !== undefined) {
       writer.uint32(42).string(message.signer);
     }
     return writer;
@@ -441,10 +441,10 @@ function createBaseMsgConnectionOpenTry(): MsgConnectionOpenTry {
 export const MsgConnectionOpenTry = {
   typeUrl: "/ibc.core.connection.v1.MsgConnectionOpenTry",
   encode(message: MsgConnectionOpenTry, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.clientId !== "") {
+    if (message.clientId !== undefined) {
       writer.uint32(10).string(message.clientId);
     }
-    if (message.previousConnectionId !== "") {
+    if (message.previousConnectionId !== undefined) {
       writer.uint32(18).string(message.previousConnectionId);
     }
     if (message.clientState !== undefined) {
@@ -453,7 +453,7 @@ export const MsgConnectionOpenTry = {
     if (message.counterparty !== undefined) {
       Counterparty.encode(message.counterparty, writer.uint32(34).fork()).ldelim();
     }
-    if (message.delayPeriod !== BigInt(0)) {
+    if (message.delayPeriod !== undefined) {
       writer.uint32(40).uint64(message.delayPeriod);
     }
     for (const v of message.counterpartyVersions) {
@@ -474,7 +474,7 @@ export const MsgConnectionOpenTry = {
     if (message.consensusHeight !== undefined) {
       Height.encode(message.consensusHeight, writer.uint32(90).fork()).ldelim();
     }
-    if (message.signer !== "") {
+    if (message.signer !== undefined) {
       writer.uint32(98).string(message.signer);
     }
     return writer;
@@ -791,10 +791,10 @@ function createBaseMsgConnectionOpenAck(): MsgConnectionOpenAck {
 export const MsgConnectionOpenAck = {
   typeUrl: "/ibc.core.connection.v1.MsgConnectionOpenAck",
   encode(message: MsgConnectionOpenAck, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.connectionId !== "") {
+    if (message.connectionId !== undefined) {
       writer.uint32(10).string(message.connectionId);
     }
-    if (message.counterpartyConnectionId !== "") {
+    if (message.counterpartyConnectionId !== undefined) {
       writer.uint32(18).string(message.counterpartyConnectionId);
     }
     if (message.version !== undefined) {
@@ -818,7 +818,7 @@ export const MsgConnectionOpenAck = {
     if (message.consensusHeight !== undefined) {
       Height.encode(message.consensusHeight, writer.uint32(74).fork()).ldelim();
     }
-    if (message.signer !== "") {
+    if (message.signer !== undefined) {
       writer.uint32(82).string(message.signer);
     }
     return writer;
@@ -1093,7 +1093,7 @@ function createBaseMsgConnectionOpenConfirm(): MsgConnectionOpenConfirm {
 export const MsgConnectionOpenConfirm = {
   typeUrl: "/ibc.core.connection.v1.MsgConnectionOpenConfirm",
   encode(message: MsgConnectionOpenConfirm, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.connectionId !== "") {
+    if (message.connectionId !== undefined) {
       writer.uint32(10).string(message.connectionId);
     }
     if (message.proofAck.length !== 0) {
@@ -1102,7 +1102,7 @@ export const MsgConnectionOpenConfirm = {
     if (message.proofHeight !== undefined) {
       Height.encode(message.proofHeight, writer.uint32(26).fork()).ldelim();
     }
-    if (message.signer !== "") {
+    if (message.signer !== undefined) {
       writer.uint32(34).string(message.signer);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/ibc/core/port/v1/query.ts
+++ b/__fixtures__/v-next/outputv4/ibc/core/port/v1/query.ts
@@ -55,10 +55,10 @@ function createBaseQueryAppVersionRequest(): QueryAppVersionRequest {
 export const QueryAppVersionRequest = {
   typeUrl: "/ibc.core.port.v1.QueryAppVersionRequest",
   encode(message: QueryAppVersionRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.portId !== "") {
+    if (message.portId !== undefined) {
       writer.uint32(10).string(message.portId);
     }
-    if (message.connectionId !== "") {
+    if (message.connectionId !== undefined) {
       writer.uint32(18).string(message.connectionId);
     }
     if (message.ordering !== 0) {
@@ -67,7 +67,7 @@ export const QueryAppVersionRequest = {
     if (message.counterparty !== undefined) {
       Counterparty.encode(message.counterparty, writer.uint32(34).fork()).ldelim();
     }
-    if (message.proposedVersion !== "") {
+    if (message.proposedVersion !== undefined) {
       writer.uint32(42).string(message.proposedVersion);
     }
     return writer;
@@ -206,10 +206,10 @@ function createBaseQueryAppVersionResponse(): QueryAppVersionResponse {
 export const QueryAppVersionResponse = {
   typeUrl: "/ibc.core.port.v1.QueryAppVersionResponse",
   encode(message: QueryAppVersionResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.portId !== "") {
+    if (message.portId !== undefined) {
       writer.uint32(10).string(message.portId);
     }
-    if (message.version !== "") {
+    if (message.version !== undefined) {
       writer.uint32(18).string(message.version);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/ibc/lightclients/localhost/v1/localhost.ts
+++ b/__fixtures__/v-next/outputv4/ibc/lightclients/localhost/v1/localhost.ts
@@ -33,7 +33,7 @@ function createBaseClientState(): ClientState {
 export const ClientState = {
   typeUrl: "/ibc.lightclients.localhost.v1.ClientState",
   encode(message: ClientState, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.chainId !== "") {
+    if (message.chainId !== undefined) {
       writer.uint32(10).string(message.chainId);
     }
     if (message.height !== undefined) {

--- a/__fixtures__/v-next/outputv4/ibc/lightclients/solomachine/v1/solomachine.ts
+++ b/__fixtures__/v-next/outputv4/ibc/lightclients/solomachine/v1/solomachine.ts
@@ -447,16 +447,16 @@ function createBaseClientState(): ClientState {
 export const ClientState = {
   typeUrl: "/ibc.lightclients.solomachine.v1.ClientState",
   encode(message: ClientState, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sequence !== BigInt(0)) {
+    if (message.sequence !== undefined) {
       writer.uint32(8).uint64(message.sequence);
     }
-    if (message.frozenSequence !== BigInt(0)) {
+    if (message.frozenSequence !== undefined) {
       writer.uint32(16).uint64(message.frozenSequence);
     }
     if (message.consensusState !== undefined) {
       ConsensusState.encode(message.consensusState, writer.uint32(26).fork()).ldelim();
     }
-    if (message.allowUpdateAfterProposal === true) {
+    if (message.allowUpdateAfterProposal !== undefined) {
       writer.uint32(32).bool(message.allowUpdateAfterProposal);
     }
     return writer;
@@ -592,10 +592,10 @@ export const ConsensusState = {
     if (message.publicKey !== undefined) {
       Any.encode(message.publicKey, writer.uint32(10).fork()).ldelim();
     }
-    if (message.diversifier !== "") {
+    if (message.diversifier !== undefined) {
       writer.uint32(18).string(message.diversifier);
     }
-    if (message.timestamp !== BigInt(0)) {
+    if (message.timestamp !== undefined) {
       writer.uint32(24).uint64(message.timestamp);
     }
     return writer;
@@ -717,10 +717,10 @@ function createBaseHeader(): Header {
 export const Header = {
   typeUrl: "/ibc.lightclients.solomachine.v1.Header",
   encode(message: Header, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sequence !== BigInt(0)) {
+    if (message.sequence !== undefined) {
       writer.uint32(8).uint64(message.sequence);
     }
-    if (message.timestamp !== BigInt(0)) {
+    if (message.timestamp !== undefined) {
       writer.uint32(16).uint64(message.timestamp);
     }
     if (message.signature.length !== 0) {
@@ -729,7 +729,7 @@ export const Header = {
     if (message.newPublicKey !== undefined) {
       Any.encode(message.newPublicKey, writer.uint32(34).fork()).ldelim();
     }
-    if (message.newDiversifier !== "") {
+    if (message.newDiversifier !== undefined) {
       writer.uint32(42).string(message.newDiversifier);
     }
     return writer;
@@ -874,10 +874,10 @@ function createBaseMisbehaviour(): Misbehaviour {
 export const Misbehaviour = {
   typeUrl: "/ibc.lightclients.solomachine.v1.Misbehaviour",
   encode(message: Misbehaviour, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.clientId !== "") {
+    if (message.clientId !== undefined) {
       writer.uint32(10).string(message.clientId);
     }
-    if (message.sequence !== BigInt(0)) {
+    if (message.sequence !== undefined) {
       writer.uint32(16).uint64(message.sequence);
     }
     if (message.signatureOne !== undefined) {
@@ -1026,7 +1026,7 @@ export const SignatureAndData = {
     if (message.data.length !== 0) {
       writer.uint32(26).bytes(message.data);
     }
-    if (message.timestamp !== BigInt(0)) {
+    if (message.timestamp !== undefined) {
       writer.uint32(32).uint64(message.timestamp);
     }
     return writer;
@@ -1157,7 +1157,7 @@ export const TimestampedSignatureData = {
     if (message.signatureData.length !== 0) {
       writer.uint32(10).bytes(message.signatureData);
     }
-    if (message.timestamp !== BigInt(0)) {
+    if (message.timestamp !== undefined) {
       writer.uint32(16).uint64(message.timestamp);
     }
     return writer;
@@ -1266,13 +1266,13 @@ function createBaseSignBytes(): SignBytes {
 export const SignBytes = {
   typeUrl: "/ibc.lightclients.solomachine.v1.SignBytes",
   encode(message: SignBytes, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sequence !== BigInt(0)) {
+    if (message.sequence !== undefined) {
       writer.uint32(8).uint64(message.sequence);
     }
-    if (message.timestamp !== BigInt(0)) {
+    if (message.timestamp !== undefined) {
       writer.uint32(16).uint64(message.timestamp);
     }
-    if (message.diversifier !== "") {
+    if (message.diversifier !== undefined) {
       writer.uint32(26).string(message.diversifier);
     }
     if (message.dataType !== 0) {
@@ -1422,7 +1422,7 @@ export const HeaderData = {
     if (message.newPubKey !== undefined) {
       Any.encode(message.newPubKey, writer.uint32(10).fork()).ldelim();
     }
-    if (message.newDiversifier !== "") {
+    if (message.newDiversifier !== undefined) {
       writer.uint32(18).string(message.newDiversifier);
     }
     return writer;
@@ -2273,7 +2273,7 @@ export const NextSequenceRecvData = {
     if (message.path.length !== 0) {
       writer.uint32(10).bytes(message.path);
     }
-    if (message.nextSeqRecv !== BigInt(0)) {
+    if (message.nextSeqRecv !== undefined) {
       writer.uint32(16).uint64(message.nextSeqRecv);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/ibc/lightclients/solomachine/v2/solomachine.ts
+++ b/__fixtures__/v-next/outputv4/ibc/lightclients/solomachine/v2/solomachine.ts
@@ -447,16 +447,16 @@ function createBaseClientState(): ClientState {
 export const ClientState = {
   typeUrl: "/ibc.lightclients.solomachine.v2.ClientState",
   encode(message: ClientState, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sequence !== BigInt(0)) {
+    if (message.sequence !== undefined) {
       writer.uint32(8).uint64(message.sequence);
     }
-    if (message.isFrozen === true) {
+    if (message.isFrozen !== undefined) {
       writer.uint32(16).bool(message.isFrozen);
     }
     if (message.consensusState !== undefined) {
       ConsensusState.encode(message.consensusState, writer.uint32(26).fork()).ldelim();
     }
-    if (message.allowUpdateAfterProposal === true) {
+    if (message.allowUpdateAfterProposal !== undefined) {
       writer.uint32(32).bool(message.allowUpdateAfterProposal);
     }
     return writer;
@@ -590,10 +590,10 @@ export const ConsensusState = {
     if (message.publicKey !== undefined) {
       Any.encode(message.publicKey, writer.uint32(10).fork()).ldelim();
     }
-    if (message.diversifier !== "") {
+    if (message.diversifier !== undefined) {
       writer.uint32(18).string(message.diversifier);
     }
-    if (message.timestamp !== BigInt(0)) {
+    if (message.timestamp !== undefined) {
       writer.uint32(24).uint64(message.timestamp);
     }
     return writer;
@@ -715,10 +715,10 @@ function createBaseHeader(): Header {
 export const Header = {
   typeUrl: "/ibc.lightclients.solomachine.v2.Header",
   encode(message: Header, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sequence !== BigInt(0)) {
+    if (message.sequence !== undefined) {
       writer.uint32(8).uint64(message.sequence);
     }
-    if (message.timestamp !== BigInt(0)) {
+    if (message.timestamp !== undefined) {
       writer.uint32(16).uint64(message.timestamp);
     }
     if (message.signature.length !== 0) {
@@ -727,7 +727,7 @@ export const Header = {
     if (message.newPublicKey !== undefined) {
       Any.encode(message.newPublicKey, writer.uint32(34).fork()).ldelim();
     }
-    if (message.newDiversifier !== "") {
+    if (message.newDiversifier !== undefined) {
       writer.uint32(42).string(message.newDiversifier);
     }
     return writer;
@@ -872,10 +872,10 @@ function createBaseMisbehaviour(): Misbehaviour {
 export const Misbehaviour = {
   typeUrl: "/ibc.lightclients.solomachine.v2.Misbehaviour",
   encode(message: Misbehaviour, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.clientId !== "") {
+    if (message.clientId !== undefined) {
       writer.uint32(10).string(message.clientId);
     }
-    if (message.sequence !== BigInt(0)) {
+    if (message.sequence !== undefined) {
       writer.uint32(16).uint64(message.sequence);
     }
     if (message.signatureOne !== undefined) {
@@ -1024,7 +1024,7 @@ export const SignatureAndData = {
     if (message.data.length !== 0) {
       writer.uint32(26).bytes(message.data);
     }
-    if (message.timestamp !== BigInt(0)) {
+    if (message.timestamp !== undefined) {
       writer.uint32(32).uint64(message.timestamp);
     }
     return writer;
@@ -1155,7 +1155,7 @@ export const TimestampedSignatureData = {
     if (message.signatureData.length !== 0) {
       writer.uint32(10).bytes(message.signatureData);
     }
-    if (message.timestamp !== BigInt(0)) {
+    if (message.timestamp !== undefined) {
       writer.uint32(16).uint64(message.timestamp);
     }
     return writer;
@@ -1264,13 +1264,13 @@ function createBaseSignBytes(): SignBytes {
 export const SignBytes = {
   typeUrl: "/ibc.lightclients.solomachine.v2.SignBytes",
   encode(message: SignBytes, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sequence !== BigInt(0)) {
+    if (message.sequence !== undefined) {
       writer.uint32(8).uint64(message.sequence);
     }
-    if (message.timestamp !== BigInt(0)) {
+    if (message.timestamp !== undefined) {
       writer.uint32(16).uint64(message.timestamp);
     }
-    if (message.diversifier !== "") {
+    if (message.diversifier !== undefined) {
       writer.uint32(26).string(message.diversifier);
     }
     if (message.dataType !== 0) {
@@ -1420,7 +1420,7 @@ export const HeaderData = {
     if (message.newPubKey !== undefined) {
       Any.encode(message.newPubKey, writer.uint32(10).fork()).ldelim();
     }
-    if (message.newDiversifier !== "") {
+    if (message.newDiversifier !== undefined) {
       writer.uint32(18).string(message.newDiversifier);
     }
     return writer;
@@ -2271,7 +2271,7 @@ export const NextSequenceRecvData = {
     if (message.path.length !== 0) {
       writer.uint32(10).bytes(message.path);
     }
-    if (message.nextSeqRecv !== BigInt(0)) {
+    if (message.nextSeqRecv !== undefined) {
       writer.uint32(16).uint64(message.nextSeqRecv);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/ibc/lightclients/tendermint/v1/tendermint.ts
+++ b/__fixtures__/v-next/outputv4/ibc/lightclients/tendermint/v1/tendermint.ts
@@ -197,7 +197,7 @@ function createBaseClientState(): ClientState {
 export const ClientState = {
   typeUrl: "/ibc.lightclients.tendermint.v1.ClientState",
   encode(message: ClientState, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.chainId !== "") {
+    if (message.chainId !== undefined) {
       writer.uint32(10).string(message.chainId);
     }
     if (message.trustLevel !== undefined) {
@@ -224,10 +224,10 @@ export const ClientState = {
     for (const v of message.upgradePath) {
       writer.uint32(74).string(v!);
     }
-    if (message.allowUpdateAfterExpiry === true) {
+    if (message.allowUpdateAfterExpiry !== undefined) {
       writer.uint32(80).bool(message.allowUpdateAfterExpiry);
     }
-    if (message.allowUpdateAfterMisbehaviour === true) {
+    if (message.allowUpdateAfterMisbehaviour !== undefined) {
       writer.uint32(88).bool(message.allowUpdateAfterMisbehaviour);
     }
     return writer;
@@ -591,7 +591,7 @@ function createBaseMisbehaviour(): Misbehaviour {
 export const Misbehaviour = {
   typeUrl: "/ibc.lightclients.tendermint.v1.Misbehaviour",
   encode(message: Misbehaviour, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.clientId !== "") {
+    if (message.clientId !== undefined) {
       writer.uint32(10).string(message.clientId);
     }
     if (message.header1 !== undefined) {
@@ -861,10 +861,10 @@ function createBaseFraction(): Fraction {
 export const Fraction = {
   typeUrl: "/ibc.lightclients.tendermint.v1.Fraction",
   encode(message: Fraction, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.numerator !== BigInt(0)) {
+    if (message.numerator !== undefined) {
       writer.uint32(8).uint64(message.numerator);
     }
-    if (message.denominator !== BigInt(0)) {
+    if (message.denominator !== undefined) {
       writer.uint32(16).uint64(message.denominator);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/claim/v1beta1/claim.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/claim/v1beta1/claim.ts
@@ -77,7 +77,7 @@ function createBaseClaimRecord(): ClaimRecord {
 export const ClaimRecord = {
   typeUrl: "/osmosis.claim.v1beta1.ClaimRecord",
   encode(message: ClaimRecord, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     for (const v of message.initialClaimableAmount) {

--- a/__fixtures__/v-next/outputv4/osmosis/claim/v1beta1/params.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/claim/v1beta1/params.ts
@@ -42,7 +42,7 @@ export const Params = {
     if (message.durationOfDecay !== undefined) {
       Duration.encode(message.durationOfDecay, writer.uint32(26).fork()).ldelim();
     }
-    if (message.claimDenom !== "") {
+    if (message.claimDenom !== undefined) {
       writer.uint32(34).string(message.claimDenom);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/claim/v1beta1/query.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/claim/v1beta1/query.ts
@@ -460,7 +460,7 @@ function createBaseQueryClaimRecordRequest(): QueryClaimRecordRequest {
 export const QueryClaimRecordRequest = {
   typeUrl: "/osmosis.claim.v1beta1.QueryClaimRecordRequest",
   encode(message: QueryClaimRecordRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     return writer;
@@ -647,7 +647,7 @@ function createBaseQueryClaimableForActionRequest(): QueryClaimableForActionRequ
 export const QueryClaimableForActionRequest = {
   typeUrl: "/osmosis.claim.v1beta1.QueryClaimableForActionRequest",
   encode(message: QueryClaimableForActionRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     if (message.action !== 0) {
@@ -857,7 +857,7 @@ function createBaseQueryTotalClaimableRequest(): QueryTotalClaimableRequest {
 export const QueryTotalClaimableRequest = {
   typeUrl: "/osmosis.claim.v1beta1.QueryTotalClaimableRequest",
   encode(message: QueryTotalClaimableRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/epochs/genesis.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/epochs/genesis.ts
@@ -104,7 +104,7 @@ function createBaseEpochInfo(): EpochInfo {
 export const EpochInfo = {
   typeUrl: "/osmosis.epochs.v1beta1.EpochInfo",
   encode(message: EpochInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.identifier !== "") {
+    if (message.identifier !== undefined) {
       writer.uint32(10).string(message.identifier);
     }
     if (message.startTime !== undefined) {
@@ -113,16 +113,16 @@ export const EpochInfo = {
     if (message.duration !== undefined) {
       Duration.encode(message.duration, writer.uint32(26).fork()).ldelim();
     }
-    if (message.currentEpoch !== BigInt(0)) {
+    if (message.currentEpoch !== undefined) {
       writer.uint32(32).int64(message.currentEpoch);
     }
     if (message.currentEpochStartTime !== undefined) {
       Timestamp.encode(toTimestamp(message.currentEpochStartTime), writer.uint32(42).fork()).ldelim();
     }
-    if (message.epochCountingStarted === true) {
+    if (message.epochCountingStarted !== undefined) {
       writer.uint32(48).bool(message.epochCountingStarted);
     }
-    if (message.currentEpochStartHeight !== BigInt(0)) {
+    if (message.currentEpochStartHeight !== undefined) {
       writer.uint32(64).int64(message.currentEpochStartHeight);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/epochs/query.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/epochs/query.ts
@@ -223,7 +223,7 @@ function createBaseQueryCurrentEpochRequest(): QueryCurrentEpochRequest {
 export const QueryCurrentEpochRequest = {
   typeUrl: "/osmosis.epochs.v1beta1.QueryCurrentEpochRequest",
   encode(message: QueryCurrentEpochRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.identifier !== "") {
+    if (message.identifier !== undefined) {
       writer.uint32(10).string(message.identifier);
     }
     return writer;
@@ -315,7 +315,7 @@ function createBaseQueryCurrentEpochResponse(): QueryCurrentEpochResponse {
 export const QueryCurrentEpochResponse = {
   typeUrl: "/osmosis.epochs.v1beta1.QueryCurrentEpochResponse",
   encode(message: QueryCurrentEpochResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.currentEpoch !== BigInt(0)) {
+    if (message.currentEpoch !== undefined) {
       writer.uint32(8).int64(message.currentEpoch);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/gamm/pool-models/balancer/balancerPool.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/gamm/pool-models/balancer/balancerPool.ts
@@ -333,10 +333,10 @@ function createBasePoolParams(): PoolParams {
 export const PoolParams = {
   typeUrl: "/osmosis.gamm.v1beta1.PoolParams",
   encode(message: PoolParams, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.swapFee !== "") {
+    if (message.swapFee !== undefined) {
       writer.uint32(10).string(Decimal.fromUserInput(message.swapFee, 18).atomics);
     }
-    if (message.exitFee !== "") {
+    if (message.exitFee !== undefined) {
       writer.uint32(18).string(Decimal.fromUserInput(message.exitFee, 18).atomics);
     }
     if (message.smoothWeightChangeParams !== undefined) {
@@ -459,7 +459,7 @@ export const PoolAsset = {
     if (message.token !== undefined) {
       Coin.encode(message.token, writer.uint32(10).fork()).ldelim();
     }
-    if (message.weight !== "") {
+    if (message.weight !== undefined) {
       writer.uint32(18).string(message.weight);
     }
     return writer;
@@ -570,16 +570,16 @@ function createBasePool(): Pool {
 export const Pool = {
   typeUrl: "/osmosis.gamm.v1beta1.Pool",
   encode(message: Pool, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
-    if (message.id !== BigInt(0)) {
+    if (message.id !== undefined) {
       writer.uint32(16).uint64(message.id);
     }
     if (message.poolParams !== undefined) {
       PoolParams.encode(message.poolParams, writer.uint32(26).fork()).ldelim();
     }
-    if (message.futurePoolGovernor !== "") {
+    if (message.futurePoolGovernor !== undefined) {
       writer.uint32(34).string(message.futurePoolGovernor);
     }
     if (message.totalShares !== undefined) {
@@ -588,7 +588,7 @@ export const Pool = {
     for (const v of message.poolAssets) {
       PoolAsset.encode(v!, writer.uint32(50).fork()).ldelim();
     }
-    if (message.totalWeight !== "") {
+    if (message.totalWeight !== undefined) {
       writer.uint32(58).string(message.totalWeight);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/gamm/pool-models/balancer/tx/tx.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/gamm/pool-models/balancer/tx/tx.ts
@@ -43,7 +43,7 @@ function createBaseMsgCreateBalancerPool(): MsgCreateBalancerPool {
 export const MsgCreateBalancerPool = {
   typeUrl: "/osmosis.gamm.poolmodels.balancer.v1beta1.MsgCreateBalancerPool",
   encode(message: MsgCreateBalancerPool, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
     if (message.poolParams !== undefined) {
@@ -52,7 +52,7 @@ export const MsgCreateBalancerPool = {
     for (const v of message.poolAssets) {
       PoolAsset.encode(v!, writer.uint32(26).fork()).ldelim();
     }
-    if (message.futurePoolGovernor !== "") {
+    if (message.futurePoolGovernor !== undefined) {
       writer.uint32(34).string(message.futurePoolGovernor);
     }
     return writer;
@@ -191,7 +191,7 @@ function createBaseMsgCreateBalancerPoolResponse(): MsgCreateBalancerPoolRespons
 export const MsgCreateBalancerPoolResponse = {
   typeUrl: "/osmosis.gamm.poolmodels.balancer.v1beta1.MsgCreateBalancerPoolResponse",
   encode(message: MsgCreateBalancerPoolResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(8).uint64(message.poolId);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/gamm/pool-models/stableswap/stableswap_pool.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/gamm/pool-models/stableswap/stableswap_pool.ts
@@ -76,10 +76,10 @@ function createBasePoolParams(): PoolParams {
 export const PoolParams = {
   typeUrl: "/osmosis.gamm.poolmodels.stableswap.v1beta1.PoolParams",
   encode(message: PoolParams, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.swapFee !== "") {
+    if (message.swapFee !== undefined) {
       writer.uint32(10).string(Decimal.fromUserInput(message.swapFee, 18).atomics);
     }
-    if (message.exitFee !== "") {
+    if (message.exitFee !== undefined) {
       writer.uint32(18).string(Decimal.fromUserInput(message.exitFee, 18).atomics);
     }
     return writer;
@@ -189,16 +189,16 @@ function createBasePool(): Pool {
 export const Pool = {
   typeUrl: "/osmosis.gamm.poolmodels.stableswap.v1beta1.Pool",
   encode(message: Pool, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
-    if (message.id !== BigInt(0)) {
+    if (message.id !== undefined) {
       writer.uint32(16).uint64(message.id);
     }
     if (message.poolParams !== undefined) {
       PoolParams.encode(message.poolParams, writer.uint32(26).fork()).ldelim();
     }
-    if (message.futurePoolGovernor !== "") {
+    if (message.futurePoolGovernor !== undefined) {
       writer.uint32(34).string(message.futurePoolGovernor);
     }
     if (message.totalShares !== undefined) {
@@ -212,7 +212,7 @@ export const Pool = {
       writer.uint64(v);
     }
     writer.ldelim();
-    if (message.scalingFactorController !== "") {
+    if (message.scalingFactorController !== undefined) {
       writer.uint32(66).string(message.scalingFactorController);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/gamm/pool-models/stableswap/tx.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/gamm/pool-models/stableswap/tx.ts
@@ -78,7 +78,7 @@ function createBaseMsgCreateStableswapPool(): MsgCreateStableswapPool {
 export const MsgCreateStableswapPool = {
   typeUrl: "/osmosis.gamm.poolmodels.stableswap.v1beta1.MsgCreateStableswapPool",
   encode(message: MsgCreateStableswapPool, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
     if (message.poolParams !== undefined) {
@@ -92,10 +92,10 @@ export const MsgCreateStableswapPool = {
       writer.uint64(v);
     }
     writer.ldelim();
-    if (message.futurePoolGovernor !== "") {
+    if (message.futurePoolGovernor !== undefined) {
       writer.uint32(42).string(message.futurePoolGovernor);
     }
-    if (message.scalingFactorController !== "") {
+    if (message.scalingFactorController !== undefined) {
       writer.uint32(50).string(message.scalingFactorController);
     }
     return writer;
@@ -275,7 +275,7 @@ function createBaseMsgCreateStableswapPoolResponse(): MsgCreateStableswapPoolRes
 export const MsgCreateStableswapPoolResponse = {
   typeUrl: "/osmosis.gamm.poolmodels.stableswap.v1beta1.MsgCreateStableswapPoolResponse",
   encode(message: MsgCreateStableswapPoolResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(8).uint64(message.poolId);
     }
     return writer;
@@ -371,10 +371,10 @@ function createBaseMsgStableSwapAdjustScalingFactors(): MsgStableSwapAdjustScali
 export const MsgStableSwapAdjustScalingFactors = {
   typeUrl: "/osmosis.gamm.poolmodels.stableswap.v1beta1.MsgStableSwapAdjustScalingFactors",
   encode(message: MsgStableSwapAdjustScalingFactors, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(16).uint64(message.poolId);
     }
     writer.uint32(26).fork();

--- a/__fixtures__/v-next/outputv4/osmosis/gamm/v1beta1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/gamm/v1beta1/genesis.ts
@@ -149,7 +149,7 @@ export const GenesisState = {
     for (const v of message.pools) {
       Any.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.nextPoolNumber !== BigInt(0)) {
+    if (message.nextPoolNumber !== undefined) {
       writer.uint32(16).uint64(message.nextPoolNumber);
     }
     if (message.params !== undefined) {

--- a/__fixtures__/v-next/outputv4/osmosis/gamm/v1beta1/query.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/gamm/v1beta1/query.ts
@@ -389,7 +389,7 @@ function createBaseQueryPoolRequest(): QueryPoolRequest {
 export const QueryPoolRequest = {
   typeUrl: "/osmosis.gamm.v1beta1.QueryPoolRequest",
   encode(message: QueryPoolRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(8).uint64(message.poolId);
     }
     return writer;
@@ -865,7 +865,7 @@ function createBaseQueryNumPoolsResponse(): QueryNumPoolsResponse {
 export const QueryNumPoolsResponse = {
   typeUrl: "/osmosis.gamm.v1beta1.QueryNumPoolsResponse",
   encode(message: QueryNumPoolsResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.numPools !== BigInt(0)) {
+    if (message.numPools !== undefined) {
       writer.uint32(8).uint64(message.numPools);
     }
     return writer;
@@ -959,7 +959,7 @@ function createBaseQueryPoolTypeRequest(): QueryPoolTypeRequest {
 export const QueryPoolTypeRequest = {
   typeUrl: "/osmosis.gamm.v1beta1.QueryPoolTypeRequest",
   encode(message: QueryPoolTypeRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(8).uint64(message.poolId);
     }
     return writer;
@@ -1053,7 +1053,7 @@ function createBaseQueryPoolTypeResponse(): QueryPoolTypeResponse {
 export const QueryPoolTypeResponse = {
   typeUrl: "/osmosis.gamm.v1beta1.QueryPoolTypeResponse",
   encode(message: QueryPoolTypeResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.poolType !== "") {
+    if (message.poolType !== undefined) {
       writer.uint32(10).string(message.poolType);
     }
     return writer;
@@ -1146,7 +1146,7 @@ function createBaseQueryCalcJoinPoolSharesRequest(): QueryCalcJoinPoolSharesRequ
 export const QueryCalcJoinPoolSharesRequest = {
   typeUrl: "/osmosis.gamm.v1beta1.QueryCalcJoinPoolSharesRequest",
   encode(message: QueryCalcJoinPoolSharesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(8).uint64(message.poolId);
     }
     for (const v of message.tokensIn) {
@@ -1267,7 +1267,7 @@ function createBaseQueryCalcJoinPoolSharesResponse(): QueryCalcJoinPoolSharesRes
 export const QueryCalcJoinPoolSharesResponse = {
   typeUrl: "/osmosis.gamm.v1beta1.QueryCalcJoinPoolSharesResponse",
   encode(message: QueryCalcJoinPoolSharesResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.shareOutAmount !== "") {
+    if (message.shareOutAmount !== undefined) {
       writer.uint32(10).string(message.shareOutAmount);
     }
     for (const v of message.tokensOut) {
@@ -1386,10 +1386,10 @@ function createBaseQueryCalcExitPoolCoinsFromSharesRequest(): QueryCalcExitPoolC
 export const QueryCalcExitPoolCoinsFromSharesRequest = {
   typeUrl: "/osmosis.gamm.v1beta1.QueryCalcExitPoolCoinsFromSharesRequest",
   encode(message: QueryCalcExitPoolCoinsFromSharesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(8).uint64(message.poolId);
     }
-    if (message.shareInAmount !== "") {
+    if (message.shareInAmount !== undefined) {
       writer.uint32(18).string(message.shareInAmount);
     }
     return writer;
@@ -1598,7 +1598,7 @@ function createBaseQueryPoolParamsRequest(): QueryPoolParamsRequest {
 export const QueryPoolParamsRequest = {
   typeUrl: "/osmosis.gamm.v1beta1.QueryPoolParamsRequest",
   encode(message: QueryPoolParamsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(8).uint64(message.poolId);
     }
     return writer;
@@ -1786,7 +1786,7 @@ function createBaseQueryTotalPoolLiquidityRequest(): QueryTotalPoolLiquidityRequ
 export const QueryTotalPoolLiquidityRequest = {
   typeUrl: "/osmosis.gamm.v1beta1.QueryTotalPoolLiquidityRequest",
   encode(message: QueryTotalPoolLiquidityRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(8).uint64(message.poolId);
     }
     return writer;
@@ -1984,7 +1984,7 @@ function createBaseQueryTotalSharesRequest(): QueryTotalSharesRequest {
 export const QueryTotalSharesRequest = {
   typeUrl: "/osmosis.gamm.v1beta1.QueryTotalSharesRequest",
   encode(message: QueryTotalSharesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(8).uint64(message.poolId);
     }
     return writer;
@@ -2173,7 +2173,7 @@ function createBaseQueryCalcJoinPoolNoSwapSharesRequest(): QueryCalcJoinPoolNoSw
 export const QueryCalcJoinPoolNoSwapSharesRequest = {
   typeUrl: "/osmosis.gamm.v1beta1.QueryCalcJoinPoolNoSwapSharesRequest",
   encode(message: QueryCalcJoinPoolNoSwapSharesRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(8).uint64(message.poolId);
     }
     for (const v of message.tokensIn) {
@@ -2297,7 +2297,7 @@ export const QueryCalcJoinPoolNoSwapSharesResponse = {
     for (const v of message.tokensOut) {
       Coin.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.sharesOut !== "") {
+    if (message.sharesOut !== undefined) {
       writer.uint32(18).string(message.sharesOut);
     }
     return writer;
@@ -2414,13 +2414,13 @@ function createBaseQuerySpotPriceRequest(): QuerySpotPriceRequest {
 export const QuerySpotPriceRequest = {
   typeUrl: "/osmosis.gamm.v1beta1.QuerySpotPriceRequest",
   encode(message: QuerySpotPriceRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(8).uint64(message.poolId);
     }
-    if (message.baseAssetDenom !== "") {
+    if (message.baseAssetDenom !== undefined) {
       writer.uint32(18).string(message.baseAssetDenom);
     }
-    if (message.quoteAssetDenom !== "") {
+    if (message.quoteAssetDenom !== undefined) {
       writer.uint32(26).string(message.quoteAssetDenom);
     }
     return writer;
@@ -2541,7 +2541,7 @@ export const QueryPoolsWithFilterRequest = {
     for (const v of message.minLiquidity) {
       Coin.encode(v!, writer.uint32(10).fork()).ldelim();
     }
-    if (message.poolType !== "") {
+    if (message.poolType !== undefined) {
       writer.uint32(18).string(message.poolType);
     }
     if (message.pagination !== undefined) {
@@ -2793,7 +2793,7 @@ function createBaseQuerySpotPriceResponse(): QuerySpotPriceResponse {
 export const QuerySpotPriceResponse = {
   typeUrl: "/osmosis.gamm.v1beta1.QuerySpotPriceResponse",
   encode(message: QuerySpotPriceResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.spotPrice !== "") {
+    if (message.spotPrice !== undefined) {
       writer.uint32(10).string(message.spotPrice);
     }
     return writer;
@@ -2888,13 +2888,13 @@ function createBaseQuerySwapExactAmountInRequest(): QuerySwapExactAmountInReques
 export const QuerySwapExactAmountInRequest = {
   typeUrl: "/osmosis.gamm.v1beta1.QuerySwapExactAmountInRequest",
   encode(message: QuerySwapExactAmountInRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(16).uint64(message.poolId);
     }
-    if (message.tokenIn !== "") {
+    if (message.tokenIn !== undefined) {
       writer.uint32(26).string(message.tokenIn);
     }
     for (const v of message.routes) {
@@ -3036,7 +3036,7 @@ function createBaseQuerySwapExactAmountInResponse(): QuerySwapExactAmountInRespo
 export const QuerySwapExactAmountInResponse = {
   typeUrl: "/osmosis.gamm.v1beta1.QuerySwapExactAmountInResponse",
   encode(message: QuerySwapExactAmountInResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.tokenOutAmount !== "") {
+    if (message.tokenOutAmount !== undefined) {
       writer.uint32(10).string(message.tokenOutAmount);
     }
     return writer;
@@ -3131,16 +3131,16 @@ function createBaseQuerySwapExactAmountOutRequest(): QuerySwapExactAmountOutRequ
 export const QuerySwapExactAmountOutRequest = {
   typeUrl: "/osmosis.gamm.v1beta1.QuerySwapExactAmountOutRequest",
   encode(message: QuerySwapExactAmountOutRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(16).uint64(message.poolId);
     }
     for (const v of message.routes) {
       SwapAmountOutRoute.encode(v!, writer.uint32(26).fork()).ldelim();
     }
-    if (message.tokenOut !== "") {
+    if (message.tokenOut !== undefined) {
       writer.uint32(34).string(message.tokenOut);
     }
     return writer;
@@ -3279,7 +3279,7 @@ function createBaseQuerySwapExactAmountOutResponse(): QuerySwapExactAmountOutRes
 export const QuerySwapExactAmountOutResponse = {
   typeUrl: "/osmosis.gamm.v1beta1.QuerySwapExactAmountOutResponse",
   encode(message: QuerySwapExactAmountOutResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.tokenInAmount !== "") {
+    if (message.tokenInAmount !== undefined) {
       writer.uint32(10).string(message.tokenInAmount);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/gamm/v1beta1/tx.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/gamm/v1beta1/tx.ts
@@ -279,13 +279,13 @@ function createBaseMsgJoinPool(): MsgJoinPool {
 export const MsgJoinPool = {
   typeUrl: "/osmosis.gamm.v1beta1.MsgJoinPool",
   encode(message: MsgJoinPool, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(16).uint64(message.poolId);
     }
-    if (message.shareOutAmount !== "") {
+    if (message.shareOutAmount !== undefined) {
       writer.uint32(26).string(message.shareOutAmount);
     }
     for (const v of message.tokenInMaxs) {
@@ -428,7 +428,7 @@ function createBaseMsgJoinPoolResponse(): MsgJoinPoolResponse {
 export const MsgJoinPoolResponse = {
   typeUrl: "/osmosis.gamm.v1beta1.MsgJoinPoolResponse",
   encode(message: MsgJoinPoolResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.shareOutAmount !== "") {
+    if (message.shareOutAmount !== undefined) {
       writer.uint32(10).string(message.shareOutAmount);
     }
     for (const v of message.tokenIn) {
@@ -549,13 +549,13 @@ function createBaseMsgExitPool(): MsgExitPool {
 export const MsgExitPool = {
   typeUrl: "/osmosis.gamm.v1beta1.MsgExitPool",
   encode(message: MsgExitPool, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(16).uint64(message.poolId);
     }
-    if (message.shareInAmount !== "") {
+    if (message.shareInAmount !== undefined) {
       writer.uint32(26).string(message.shareInAmount);
     }
     for (const v of message.tokenOutMins) {
@@ -802,10 +802,10 @@ function createBaseSwapAmountInRoute(): SwapAmountInRoute {
 export const SwapAmountInRoute = {
   typeUrl: "/osmosis.gamm.v1beta1.SwapAmountInRoute",
   encode(message: SwapAmountInRoute, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(8).uint64(message.poolId);
     }
-    if (message.tokenOutDenom !== "") {
+    if (message.tokenOutDenom !== undefined) {
       writer.uint32(18).string(message.tokenOutDenom);
     }
     return writer;
@@ -913,7 +913,7 @@ function createBaseMsgSwapExactAmountIn(): MsgSwapExactAmountIn {
 export const MsgSwapExactAmountIn = {
   typeUrl: "/osmosis.gamm.v1beta1.MsgSwapExactAmountIn",
   encode(message: MsgSwapExactAmountIn, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
     for (const v of message.routes) {
@@ -922,7 +922,7 @@ export const MsgSwapExactAmountIn = {
     if (message.tokenIn !== undefined) {
       Coin.encode(message.tokenIn, writer.uint32(26).fork()).ldelim();
     }
-    if (message.tokenOutMinAmount !== "") {
+    if (message.tokenOutMinAmount !== undefined) {
       writer.uint32(34).string(message.tokenOutMinAmount);
     }
     return writer;
@@ -1061,7 +1061,7 @@ function createBaseMsgSwapExactAmountInResponse(): MsgSwapExactAmountInResponse 
 export const MsgSwapExactAmountInResponse = {
   typeUrl: "/osmosis.gamm.v1beta1.MsgSwapExactAmountInResponse",
   encode(message: MsgSwapExactAmountInResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.tokenOutAmount !== "") {
+    if (message.tokenOutAmount !== undefined) {
       writer.uint32(10).string(message.tokenOutAmount);
     }
     return writer;
@@ -1154,10 +1154,10 @@ function createBaseSwapAmountOutRoute(): SwapAmountOutRoute {
 export const SwapAmountOutRoute = {
   typeUrl: "/osmosis.gamm.v1beta1.SwapAmountOutRoute",
   encode(message: SwapAmountOutRoute, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(8).uint64(message.poolId);
     }
-    if (message.tokenInDenom !== "") {
+    if (message.tokenInDenom !== undefined) {
       writer.uint32(18).string(message.tokenInDenom);
     }
     return writer;
@@ -1265,13 +1265,13 @@ function createBaseMsgSwapExactAmountOut(): MsgSwapExactAmountOut {
 export const MsgSwapExactAmountOut = {
   typeUrl: "/osmosis.gamm.v1beta1.MsgSwapExactAmountOut",
   encode(message: MsgSwapExactAmountOut, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
     for (const v of message.routes) {
       SwapAmountOutRoute.encode(v!, writer.uint32(18).fork()).ldelim();
     }
-    if (message.tokenInMaxAmount !== "") {
+    if (message.tokenInMaxAmount !== undefined) {
       writer.uint32(26).string(message.tokenInMaxAmount);
     }
     if (message.tokenOut !== undefined) {
@@ -1413,7 +1413,7 @@ function createBaseMsgSwapExactAmountOutResponse(): MsgSwapExactAmountOutRespons
 export const MsgSwapExactAmountOutResponse = {
   typeUrl: "/osmosis.gamm.v1beta1.MsgSwapExactAmountOutResponse",
   encode(message: MsgSwapExactAmountOutResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.tokenInAmount !== "") {
+    if (message.tokenInAmount !== undefined) {
       writer.uint32(10).string(message.tokenInAmount);
     }
     return writer;
@@ -1508,16 +1508,16 @@ function createBaseMsgJoinSwapExternAmountIn(): MsgJoinSwapExternAmountIn {
 export const MsgJoinSwapExternAmountIn = {
   typeUrl: "/osmosis.gamm.v1beta1.MsgJoinSwapExternAmountIn",
   encode(message: MsgJoinSwapExternAmountIn, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(16).uint64(message.poolId);
     }
     if (message.tokenIn !== undefined) {
       Coin.encode(message.tokenIn, writer.uint32(26).fork()).ldelim();
     }
-    if (message.shareOutMinAmount !== "") {
+    if (message.shareOutMinAmount !== undefined) {
       writer.uint32(34).string(message.shareOutMinAmount);
     }
     return writer;
@@ -1646,7 +1646,7 @@ function createBaseMsgJoinSwapExternAmountInResponse(): MsgJoinSwapExternAmountI
 export const MsgJoinSwapExternAmountInResponse = {
   typeUrl: "/osmosis.gamm.v1beta1.MsgJoinSwapExternAmountInResponse",
   encode(message: MsgJoinSwapExternAmountInResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.shareOutAmount !== "") {
+    if (message.shareOutAmount !== undefined) {
       writer.uint32(10).string(message.shareOutAmount);
     }
     return writer;
@@ -1742,19 +1742,19 @@ function createBaseMsgJoinSwapShareAmountOut(): MsgJoinSwapShareAmountOut {
 export const MsgJoinSwapShareAmountOut = {
   typeUrl: "/osmosis.gamm.v1beta1.MsgJoinSwapShareAmountOut",
   encode(message: MsgJoinSwapShareAmountOut, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(16).uint64(message.poolId);
     }
-    if (message.tokenInDenom !== "") {
+    if (message.tokenInDenom !== undefined) {
       writer.uint32(26).string(message.tokenInDenom);
     }
-    if (message.shareOutAmount !== "") {
+    if (message.shareOutAmount !== undefined) {
       writer.uint32(34).string(message.shareOutAmount);
     }
-    if (message.tokenInMaxAmount !== "") {
+    if (message.tokenInMaxAmount !== undefined) {
       writer.uint32(42).string(message.tokenInMaxAmount);
     }
     return writer;
@@ -1892,7 +1892,7 @@ function createBaseMsgJoinSwapShareAmountOutResponse(): MsgJoinSwapShareAmountOu
 export const MsgJoinSwapShareAmountOutResponse = {
   typeUrl: "/osmosis.gamm.v1beta1.MsgJoinSwapShareAmountOutResponse",
   encode(message: MsgJoinSwapShareAmountOutResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.tokenInAmount !== "") {
+    if (message.tokenInAmount !== undefined) {
       writer.uint32(10).string(message.tokenInAmount);
     }
     return writer;
@@ -1988,19 +1988,19 @@ function createBaseMsgExitSwapShareAmountIn(): MsgExitSwapShareAmountIn {
 export const MsgExitSwapShareAmountIn = {
   typeUrl: "/osmosis.gamm.v1beta1.MsgExitSwapShareAmountIn",
   encode(message: MsgExitSwapShareAmountIn, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(16).uint64(message.poolId);
     }
-    if (message.tokenOutDenom !== "") {
+    if (message.tokenOutDenom !== undefined) {
       writer.uint32(26).string(message.tokenOutDenom);
     }
-    if (message.shareInAmount !== "") {
+    if (message.shareInAmount !== undefined) {
       writer.uint32(34).string(message.shareInAmount);
     }
-    if (message.tokenOutMinAmount !== "") {
+    if (message.tokenOutMinAmount !== undefined) {
       writer.uint32(42).string(message.tokenOutMinAmount);
     }
     return writer;
@@ -2138,7 +2138,7 @@ function createBaseMsgExitSwapShareAmountInResponse(): MsgExitSwapShareAmountInR
 export const MsgExitSwapShareAmountInResponse = {
   typeUrl: "/osmosis.gamm.v1beta1.MsgExitSwapShareAmountInResponse",
   encode(message: MsgExitSwapShareAmountInResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.tokenOutAmount !== "") {
+    if (message.tokenOutAmount !== undefined) {
       writer.uint32(10).string(message.tokenOutAmount);
     }
     return writer;
@@ -2233,16 +2233,16 @@ function createBaseMsgExitSwapExternAmountOut(): MsgExitSwapExternAmountOut {
 export const MsgExitSwapExternAmountOut = {
   typeUrl: "/osmosis.gamm.v1beta1.MsgExitSwapExternAmountOut",
   encode(message: MsgExitSwapExternAmountOut, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(16).uint64(message.poolId);
     }
     if (message.tokenOut !== undefined) {
       Coin.encode(message.tokenOut, writer.uint32(26).fork()).ldelim();
     }
-    if (message.shareInMaxAmount !== "") {
+    if (message.shareInMaxAmount !== undefined) {
       writer.uint32(34).string(message.shareInMaxAmount);
     }
     return writer;
@@ -2371,7 +2371,7 @@ function createBaseMsgExitSwapExternAmountOutResponse(): MsgExitSwapExternAmount
 export const MsgExitSwapExternAmountOutResponse = {
   typeUrl: "/osmosis.gamm.v1beta1.MsgExitSwapExternAmountOutResponse",
   encode(message: MsgExitSwapExternAmountOutResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.shareInAmount !== "") {
+    if (message.shareInAmount !== undefined) {
       writer.uint32(10).string(message.shareInAmount);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/gamm/v2/query.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/gamm/v2/query.ts
@@ -52,13 +52,13 @@ function createBaseQuerySpotPriceRequest(): QuerySpotPriceRequest {
 export const QuerySpotPriceRequest = {
   typeUrl: "/osmosis.gamm.v2.QuerySpotPriceRequest",
   encode(message: QuerySpotPriceRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(8).uint64(message.poolId);
     }
-    if (message.baseAssetDenom !== "") {
+    if (message.baseAssetDenom !== undefined) {
       writer.uint32(18).string(message.baseAssetDenom);
     }
-    if (message.quoteAssetDenom !== "") {
+    if (message.quoteAssetDenom !== undefined) {
       writer.uint32(26).string(message.quoteAssetDenom);
     }
     return writer;
@@ -174,7 +174,7 @@ function createBaseQuerySpotPriceResponse(): QuerySpotPriceResponse {
 export const QuerySpotPriceResponse = {
   typeUrl: "/osmosis.gamm.v2.QuerySpotPriceResponse",
   encode(message: QuerySpotPriceResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.spotPrice !== "") {
+    if (message.spotPrice !== undefined) {
       writer.uint32(10).string(message.spotPrice);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/ibc-rate-limit/v1beta1/params.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/ibc-rate-limit/v1beta1/params.ts
@@ -21,7 +21,7 @@ function createBaseParams(): Params {
 export const Params = {
   typeUrl: "/osmosis.ibcratelimit.v1beta1.Params",
   encode(message: Params, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.contractAddress !== "") {
+    if (message.contractAddress !== undefined) {
       writer.uint32(10).string(message.contractAddress);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/incentives/gauge.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/incentives/gauge.ts
@@ -91,10 +91,10 @@ function createBaseGauge(): Gauge {
 export const Gauge = {
   typeUrl: "/osmosis.incentives.Gauge",
   encode(message: Gauge, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.id !== BigInt(0)) {
+    if (message.id !== undefined) {
       writer.uint32(8).uint64(message.id);
     }
-    if (message.isPerpetual === true) {
+    if (message.isPerpetual !== undefined) {
       writer.uint32(16).bool(message.isPerpetual);
     }
     if (message.distributeTo !== undefined) {
@@ -106,10 +106,10 @@ export const Gauge = {
     if (message.startTime !== undefined) {
       Timestamp.encode(toTimestamp(message.startTime), writer.uint32(42).fork()).ldelim();
     }
-    if (message.numEpochsPaidOver !== BigInt(0)) {
+    if (message.numEpochsPaidOver !== undefined) {
       writer.uint32(48).uint64(message.numEpochsPaidOver);
     }
-    if (message.filledEpochs !== BigInt(0)) {
+    if (message.filledEpochs !== undefined) {
       writer.uint32(56).uint64(message.filledEpochs);
     }
     for (const v of message.distributedCoins) {

--- a/__fixtures__/v-next/outputv4/osmosis/incentives/genesis.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/incentives/genesis.ts
@@ -58,7 +58,7 @@ export const GenesisState = {
     for (const v of message.lockableDurations) {
       Duration.encode(v!, writer.uint32(26).fork()).ldelim();
     }
-    if (message.lastGaugeId !== BigInt(0)) {
+    if (message.lastGaugeId !== undefined) {
       writer.uint32(32).uint64(message.lastGaugeId);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/incentives/params.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/incentives/params.ts
@@ -25,7 +25,7 @@ function createBaseParams(): Params {
 export const Params = {
   typeUrl: "/osmosis.incentives.Params",
   encode(message: Params, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.distrEpochIdentifier !== "") {
+    if (message.distrEpochIdentifier !== undefined) {
       writer.uint32(10).string(message.distrEpochIdentifier);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/incentives/query.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/incentives/query.ts
@@ -411,7 +411,7 @@ function createBaseGaugeByIDRequest(): GaugeByIDRequest {
 export const GaugeByIDRequest = {
   typeUrl: "/osmosis.incentives.GaugeByIDRequest",
   encode(message: GaugeByIDRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.id !== BigInt(0)) {
+    if (message.id !== undefined) {
       writer.uint32(8).uint64(message.id);
     }
     return writer;
@@ -1030,7 +1030,7 @@ function createBaseActiveGaugesPerDenomRequest(): ActiveGaugesPerDenomRequest {
 export const ActiveGaugesPerDenomRequest = {
   typeUrl: "/osmosis.incentives.ActiveGaugesPerDenomRequest",
   encode(message: ActiveGaugesPerDenomRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(10).string(message.denom);
     }
     if (message.pagination !== undefined) {
@@ -1475,7 +1475,7 @@ function createBaseUpcomingGaugesPerDenomRequest(): UpcomingGaugesPerDenomReques
 export const UpcomingGaugesPerDenomRequest = {
   typeUrl: "/osmosis.incentives.UpcomingGaugesPerDenomRequest",
   encode(message: UpcomingGaugesPerDenomRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(10).string(message.denom);
     }
     if (message.pagination !== undefined) {
@@ -1706,7 +1706,7 @@ function createBaseRewardsEstRequest(): RewardsEstRequest {
 export const RewardsEstRequest = {
   typeUrl: "/osmosis.incentives.RewardsEstRequest",
   encode(message: RewardsEstRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
     writer.uint32(18).fork();
@@ -1714,7 +1714,7 @@ export const RewardsEstRequest = {
       writer.uint64(v);
     }
     writer.ldelim();
-    if (message.endEpoch !== BigInt(0)) {
+    if (message.endEpoch !== undefined) {
       writer.uint32(24).int64(message.endEpoch);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/incentives/tx.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/incentives/tx.ts
@@ -88,10 +88,10 @@ function createBaseMsgCreateGauge(): MsgCreateGauge {
 export const MsgCreateGauge = {
   typeUrl: "/osmosis.incentives.MsgCreateGauge",
   encode(message: MsgCreateGauge, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.isPerpetual === true) {
+    if (message.isPerpetual !== undefined) {
       writer.uint32(8).bool(message.isPerpetual);
     }
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(18).string(message.owner);
     }
     if (message.distributeTo !== undefined) {
@@ -103,7 +103,7 @@ export const MsgCreateGauge = {
     if (message.startTime !== undefined) {
       Timestamp.encode(toTimestamp(message.startTime), writer.uint32(42).fork()).ldelim();
     }
-    if (message.numEpochsPaidOver !== BigInt(0)) {
+    if (message.numEpochsPaidOver !== undefined) {
       writer.uint32(48).uint64(message.numEpochsPaidOver);
     }
     return writer;
@@ -341,10 +341,10 @@ function createBaseMsgAddToGauge(): MsgAddToGauge {
 export const MsgAddToGauge = {
   typeUrl: "/osmosis.incentives.MsgAddToGauge",
   encode(message: MsgAddToGauge, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.gaugeId !== BigInt(0)) {
+    if (message.gaugeId !== undefined) {
       writer.uint32(16).uint64(message.gaugeId);
     }
     for (const v of message.rewards) {

--- a/__fixtures__/v-next/outputv4/osmosis/lockup/genesis.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/lockup/genesis.ts
@@ -28,7 +28,7 @@ function createBaseGenesisState(): GenesisState {
 export const GenesisState = {
   typeUrl: "/osmosis.lockup.GenesisState",
   encode(message: GenesisState, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.lastLockId !== BigInt(0)) {
+    if (message.lastLockId !== undefined) {
       writer.uint32(8).uint64(message.lastLockId);
     }
     for (const v of message.locks) {

--- a/__fixtures__/v-next/outputv4/osmosis/lockup/lock.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/lockup/lock.ts
@@ -184,10 +184,10 @@ function createBasePeriodLock(): PeriodLock {
 export const PeriodLock = {
   typeUrl: "/osmosis.lockup.PeriodLock",
   encode(message: PeriodLock, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.ID !== BigInt(0)) {
+    if (message.ID !== undefined) {
       writer.uint32(8).uint64(message.ID);
     }
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(18).string(message.owner);
     }
     if (message.duration !== undefined) {
@@ -354,7 +354,7 @@ export const QueryCondition = {
     if (message.lockQueryType !== 0) {
       writer.uint32(8).int32(message.lockQueryType);
     }
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(18).string(message.denom);
     }
     if (message.duration !== undefined) {
@@ -490,10 +490,10 @@ function createBaseSyntheticLock(): SyntheticLock {
 export const SyntheticLock = {
   typeUrl: "/osmosis.lockup.SyntheticLock",
   encode(message: SyntheticLock, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.underlyingLockId !== BigInt(0)) {
+    if (message.underlyingLockId !== undefined) {
       writer.uint32(8).uint64(message.underlyingLockId);
     }
-    if (message.synthDenom !== "") {
+    if (message.synthDenom !== undefined) {
       writer.uint32(18).string(message.synthDenom);
     }
     if (message.endTime !== undefined) {

--- a/__fixtures__/v-next/outputv4/osmosis/lockup/query.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/lockup/query.ts
@@ -718,7 +718,7 @@ function createBaseAccountUnlockableCoinsRequest(): AccountUnlockableCoinsReques
 export const AccountUnlockableCoinsRequest = {
   typeUrl: "/osmosis.lockup.AccountUnlockableCoinsRequest",
   encode(message: AccountUnlockableCoinsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
     return writer;
@@ -914,7 +914,7 @@ function createBaseAccountUnlockingCoinsRequest(): AccountUnlockingCoinsRequest 
 export const AccountUnlockingCoinsRequest = {
   typeUrl: "/osmosis.lockup.AccountUnlockingCoinsRequest",
   encode(message: AccountUnlockingCoinsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
     return writer;
@@ -1110,7 +1110,7 @@ function createBaseAccountLockedCoinsRequest(): AccountLockedCoinsRequest {
 export const AccountLockedCoinsRequest = {
   typeUrl: "/osmosis.lockup.AccountLockedCoinsRequest",
   encode(message: AccountLockedCoinsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
     return writer;
@@ -1307,7 +1307,7 @@ function createBaseAccountLockedPastTimeRequest(): AccountLockedPastTimeRequest 
 export const AccountLockedPastTimeRequest = {
   typeUrl: "/osmosis.lockup.AccountLockedPastTimeRequest",
   encode(message: AccountLockedPastTimeRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
     if (message.timestamp !== undefined) {
@@ -1518,7 +1518,7 @@ function createBaseAccountLockedPastTimeNotUnlockingOnlyRequest(): AccountLocked
 export const AccountLockedPastTimeNotUnlockingOnlyRequest = {
   typeUrl: "/osmosis.lockup.AccountLockedPastTimeNotUnlockingOnlyRequest",
   encode(message: AccountLockedPastTimeNotUnlockingOnlyRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
     if (message.timestamp !== undefined) {
@@ -1729,7 +1729,7 @@ function createBaseAccountUnlockedBeforeTimeRequest(): AccountUnlockedBeforeTime
 export const AccountUnlockedBeforeTimeRequest = {
   typeUrl: "/osmosis.lockup.AccountUnlockedBeforeTimeRequest",
   encode(message: AccountUnlockedBeforeTimeRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
     if (message.timestamp !== undefined) {
@@ -1941,13 +1941,13 @@ function createBaseAccountLockedPastTimeDenomRequest(): AccountLockedPastTimeDen
 export const AccountLockedPastTimeDenomRequest = {
   typeUrl: "/osmosis.lockup.AccountLockedPastTimeDenomRequest",
   encode(message: AccountLockedPastTimeDenomRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
     if (message.timestamp !== undefined) {
       Timestamp.encode(toTimestamp(message.timestamp), writer.uint32(18).fork()).ldelim();
     }
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(26).string(message.denom);
     }
     return writer;
@@ -2166,7 +2166,7 @@ function createBaseLockedDenomRequest(): LockedDenomRequest {
 export const LockedDenomRequest = {
   typeUrl: "/osmosis.lockup.LockedDenomRequest",
   encode(message: LockedDenomRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(10).string(message.denom);
     }
     if (message.duration !== undefined) {
@@ -2274,7 +2274,7 @@ function createBaseLockedDenomResponse(): LockedDenomResponse {
 export const LockedDenomResponse = {
   typeUrl: "/osmosis.lockup.LockedDenomResponse",
   encode(message: LockedDenomResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.amount !== "") {
+    if (message.amount !== undefined) {
       writer.uint32(10).string(message.amount);
     }
     return writer;
@@ -2366,7 +2366,7 @@ function createBaseLockedRequest(): LockedRequest {
 export const LockedRequest = {
   typeUrl: "/osmosis.lockup.LockedRequest",
   encode(message: LockedRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.lockId !== BigInt(0)) {
+    if (message.lockId !== undefined) {
       writer.uint32(8).uint64(message.lockId);
     }
     return writer;
@@ -2554,7 +2554,7 @@ function createBaseSyntheticLockupsByLockupIDRequest(): SyntheticLockupsByLockup
 export const SyntheticLockupsByLockupIDRequest = {
   typeUrl: "/osmosis.lockup.SyntheticLockupsByLockupIDRequest",
   encode(message: SyntheticLockupsByLockupIDRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.lockId !== BigInt(0)) {
+    if (message.lockId !== undefined) {
       writer.uint32(8).uint64(message.lockId);
     }
     return writer;
@@ -2753,7 +2753,7 @@ function createBaseAccountLockedLongerDurationRequest(): AccountLockedLongerDura
 export const AccountLockedLongerDurationRequest = {
   typeUrl: "/osmosis.lockup.AccountLockedLongerDurationRequest",
   encode(message: AccountLockedLongerDurationRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
     if (message.duration !== undefined) {
@@ -2966,7 +2966,7 @@ function createBaseAccountLockedDurationRequest(): AccountLockedDurationRequest 
 export const AccountLockedDurationRequest = {
   typeUrl: "/osmosis.lockup.AccountLockedDurationRequest",
   encode(message: AccountLockedDurationRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
     if (message.duration !== undefined) {
@@ -3179,7 +3179,7 @@ function createBaseAccountLockedLongerDurationNotUnlockingOnlyRequest(): Account
 export const AccountLockedLongerDurationNotUnlockingOnlyRequest = {
   typeUrl: "/osmosis.lockup.AccountLockedLongerDurationNotUnlockingOnlyRequest",
   encode(message: AccountLockedLongerDurationNotUnlockingOnlyRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
     if (message.duration !== undefined) {
@@ -3393,13 +3393,13 @@ function createBaseAccountLockedLongerDurationDenomRequest(): AccountLockedLonge
 export const AccountLockedLongerDurationDenomRequest = {
   typeUrl: "/osmosis.lockup.AccountLockedLongerDurationDenomRequest",
   encode(message: AccountLockedLongerDurationDenomRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
     if (message.duration !== undefined) {
       Duration.encode(message.duration, writer.uint32(18).fork()).ldelim();
     }
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(26).string(message.denom);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/lockup/tx.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/lockup/tx.ts
@@ -152,7 +152,7 @@ function createBaseMsgLockTokens(): MsgLockTokens {
 export const MsgLockTokens = {
   typeUrl: "/osmosis.lockup.MsgLockTokens",
   encode(message: MsgLockTokens, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
     if (message.duration !== undefined) {
@@ -286,7 +286,7 @@ function createBaseMsgLockTokensResponse(): MsgLockTokensResponse {
 export const MsgLockTokensResponse = {
   typeUrl: "/osmosis.lockup.MsgLockTokensResponse",
   encode(message: MsgLockTokensResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.ID !== BigInt(0)) {
+    if (message.ID !== undefined) {
       writer.uint32(8).uint64(message.ID);
     }
     return writer;
@@ -380,7 +380,7 @@ function createBaseMsgBeginUnlockingAll(): MsgBeginUnlockingAll {
 export const MsgBeginUnlockingAll = {
   typeUrl: "/osmosis.lockup.MsgBeginUnlockingAll",
   encode(message: MsgBeginUnlockingAll, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
     return writer;
@@ -578,10 +578,10 @@ function createBaseMsgBeginUnlocking(): MsgBeginUnlocking {
 export const MsgBeginUnlocking = {
   typeUrl: "/osmosis.lockup.MsgBeginUnlocking",
   encode(message: MsgBeginUnlocking, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.ID !== BigInt(0)) {
+    if (message.ID !== undefined) {
       writer.uint32(16).uint64(message.ID);
     }
     for (const v of message.coins) {
@@ -712,7 +712,7 @@ function createBaseMsgBeginUnlockingResponse(): MsgBeginUnlockingResponse {
 export const MsgBeginUnlockingResponse = {
   typeUrl: "/osmosis.lockup.MsgBeginUnlockingResponse",
   encode(message: MsgBeginUnlockingResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.success === true) {
+    if (message.success !== undefined) {
       writer.uint32(8).bool(message.success);
     }
     return writer;
@@ -806,10 +806,10 @@ function createBaseMsgExtendLockup(): MsgExtendLockup {
 export const MsgExtendLockup = {
   typeUrl: "/osmosis.lockup.MsgExtendLockup",
   encode(message: MsgExtendLockup, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.ID !== BigInt(0)) {
+    if (message.ID !== undefined) {
       writer.uint32(16).uint64(message.ID);
     }
     if (message.duration !== undefined) {
@@ -930,7 +930,7 @@ function createBaseMsgExtendLockupResponse(): MsgExtendLockupResponse {
 export const MsgExtendLockupResponse = {
   typeUrl: "/osmosis.lockup.MsgExtendLockupResponse",
   encode(message: MsgExtendLockupResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.success === true) {
+    if (message.success !== undefined) {
       writer.uint32(8).bool(message.success);
     }
     return writer;
@@ -1024,10 +1024,10 @@ function createBaseMsgForceUnlock(): MsgForceUnlock {
 export const MsgForceUnlock = {
   typeUrl: "/osmosis.lockup.MsgForceUnlock",
   encode(message: MsgForceUnlock, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.owner !== "") {
+    if (message.owner !== undefined) {
       writer.uint32(10).string(message.owner);
     }
-    if (message.ID !== BigInt(0)) {
+    if (message.ID !== undefined) {
       writer.uint32(16).uint64(message.ID);
     }
     for (const v of message.coins) {
@@ -1158,7 +1158,7 @@ function createBaseMsgForceUnlockResponse(): MsgForceUnlockResponse {
 export const MsgForceUnlockResponse = {
   typeUrl: "/osmosis.lockup.MsgForceUnlockResponse",
   encode(message: MsgForceUnlockResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.success === true) {
+    if (message.success !== undefined) {
       writer.uint32(8).bool(message.success);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/mint/v1beta1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/mint/v1beta1/genesis.ts
@@ -40,7 +40,7 @@ export const GenesisState = {
     if (message.params !== undefined) {
       Params.encode(message.params, writer.uint32(18).fork()).ldelim();
     }
-    if (message.reductionStartedEpoch !== BigInt(0)) {
+    if (message.reductionStartedEpoch !== undefined) {
       writer.uint32(24).int64(message.reductionStartedEpoch);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/mint/v1beta1/mint.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/mint/v1beta1/mint.ts
@@ -139,7 +139,7 @@ function createBaseMinter(): Minter {
 export const Minter = {
   typeUrl: "/osmosis.mint.v1beta1.Minter",
   encode(message: Minter, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.epochProvisions !== "") {
+    if (message.epochProvisions !== undefined) {
       writer.uint32(10).string(Decimal.fromUserInput(message.epochProvisions, 18).atomics);
     }
     return writer;
@@ -232,10 +232,10 @@ function createBaseWeightedAddress(): WeightedAddress {
 export const WeightedAddress = {
   typeUrl: "/osmosis.mint.v1beta1.WeightedAddress",
   encode(message: WeightedAddress, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
-    if (message.weight !== "") {
+    if (message.weight !== undefined) {
       writer.uint32(18).string(Decimal.fromUserInput(message.weight, 18).atomics);
     }
     return writer;
@@ -341,16 +341,16 @@ function createBaseDistributionProportions(): DistributionProportions {
 export const DistributionProportions = {
   typeUrl: "/osmosis.mint.v1beta1.DistributionProportions",
   encode(message: DistributionProportions, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.staking !== "") {
+    if (message.staking !== undefined) {
       writer.uint32(10).string(Decimal.fromUserInput(message.staking, 18).atomics);
     }
-    if (message.poolIncentives !== "") {
+    if (message.poolIncentives !== undefined) {
       writer.uint32(18).string(Decimal.fromUserInput(message.poolIncentives, 18).atomics);
     }
-    if (message.developerRewards !== "") {
+    if (message.developerRewards !== undefined) {
       writer.uint32(26).string(Decimal.fromUserInput(message.developerRewards, 18).atomics);
     }
-    if (message.communityPool !== "") {
+    if (message.communityPool !== undefined) {
       writer.uint32(34).string(Decimal.fromUserInput(message.communityPool, 18).atomics);
     }
     return writer;
@@ -482,19 +482,19 @@ function createBaseParams(): Params {
 export const Params = {
   typeUrl: "/osmosis.mint.v1beta1.Params",
   encode(message: Params, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.mintDenom !== "") {
+    if (message.mintDenom !== undefined) {
       writer.uint32(10).string(message.mintDenom);
     }
-    if (message.genesisEpochProvisions !== "") {
+    if (message.genesisEpochProvisions !== undefined) {
       writer.uint32(18).string(Decimal.fromUserInput(message.genesisEpochProvisions, 18).atomics);
     }
-    if (message.epochIdentifier !== "") {
+    if (message.epochIdentifier !== undefined) {
       writer.uint32(26).string(message.epochIdentifier);
     }
-    if (message.reductionPeriodInEpochs !== BigInt(0)) {
+    if (message.reductionPeriodInEpochs !== undefined) {
       writer.uint32(32).int64(message.reductionPeriodInEpochs);
     }
-    if (message.reductionFactor !== "") {
+    if (message.reductionFactor !== undefined) {
       writer.uint32(42).string(Decimal.fromUserInput(message.reductionFactor, 18).atomics);
     }
     if (message.distributionProportions !== undefined) {
@@ -503,7 +503,7 @@ export const Params = {
     for (const v of message.weightedDeveloperRewardsReceivers) {
       WeightedAddress.encode(v!, writer.uint32(58).fork()).ldelim();
     }
-    if (message.mintingRewardsDistributionStartEpoch !== BigInt(0)) {
+    if (message.mintingRewardsDistributionStartEpoch !== undefined) {
       writer.uint32(64).int64(message.mintingRewardsDistributionStartEpoch);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/pool-incentives/v1beta1/gov.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/pool-incentives/v1beta1/gov.ts
@@ -76,10 +76,10 @@ function createBaseReplacePoolIncentivesProposal(): ReplacePoolIncentivesProposa
 export const ReplacePoolIncentivesProposal = {
   typeUrl: "/osmosis.poolincentives.v1beta1.ReplacePoolIncentivesProposal",
   encode(message: ReplacePoolIncentivesProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
     for (const v of message.records) {
@@ -210,10 +210,10 @@ function createBaseUpdatePoolIncentivesProposal(): UpdatePoolIncentivesProposal 
 export const UpdatePoolIncentivesProposal = {
   typeUrl: "/osmosis.poolincentives.v1beta1.UpdatePoolIncentivesProposal",
   encode(message: UpdatePoolIncentivesProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
     for (const v of message.records) {

--- a/__fixtures__/v-next/outputv4/osmosis/pool-incentives/v1beta1/incentives.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/pool-incentives/v1beta1/incentives.ts
@@ -84,7 +84,7 @@ function createBaseParams(): Params {
 export const Params = {
   typeUrl: "/osmosis.poolincentives.v1beta1.Params",
   encode(message: Params, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.mintedDenom !== "") {
+    if (message.mintedDenom !== undefined) {
       writer.uint32(10).string(message.mintedDenom);
     }
     return writer;
@@ -281,7 +281,7 @@ function createBaseDistrInfo(): DistrInfo {
 export const DistrInfo = {
   typeUrl: "/osmosis.poolincentives.v1beta1.DistrInfo",
   encode(message: DistrInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.totalWeight !== "") {
+    if (message.totalWeight !== undefined) {
       writer.uint32(10).string(message.totalWeight);
     }
     for (const v of message.records) {
@@ -400,10 +400,10 @@ function createBaseDistrRecord(): DistrRecord {
 export const DistrRecord = {
   typeUrl: "/osmosis.poolincentives.v1beta1.DistrRecord",
   encode(message: DistrRecord, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.gaugeId !== BigInt(0)) {
+    if (message.gaugeId !== undefined) {
       writer.uint32(8).uint64(message.gaugeId);
     }
-    if (message.weight !== "") {
+    if (message.weight !== undefined) {
       writer.uint32(18).string(message.weight);
     }
     return writer;
@@ -510,10 +510,10 @@ function createBasePoolToGauge(): PoolToGauge {
 export const PoolToGauge = {
   typeUrl: "/osmosis.poolincentives.v1beta1.PoolToGauge",
   encode(message: PoolToGauge, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(8).uint64(message.poolId);
     }
-    if (message.gaugeId !== BigInt(0)) {
+    if (message.gaugeId !== undefined) {
       writer.uint32(16).uint64(message.gaugeId);
     }
     if (message.duration !== undefined) {

--- a/__fixtures__/v-next/outputv4/osmosis/pool-incentives/v1beta1/query.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/pool-incentives/v1beta1/query.ts
@@ -140,7 +140,7 @@ function createBaseQueryGaugeIdsRequest(): QueryGaugeIdsRequest {
 export const QueryGaugeIdsRequest = {
   typeUrl: "/osmosis.poolincentives.v1beta1.QueryGaugeIdsRequest",
   encode(message: QueryGaugeIdsRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(8).uint64(message.poolId);
     }
     return writer;
@@ -340,13 +340,13 @@ function createBaseQueryGaugeIdsResponse_GaugeIdWithDuration(): QueryGaugeIdsRes
 export const QueryGaugeIdsResponse_GaugeIdWithDuration = {
   typeUrl: "/osmosis.poolincentives.v1beta1.GaugeIdWithDuration",
   encode(message: QueryGaugeIdsResponse_GaugeIdWithDuration, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.gaugeId !== BigInt(0)) {
+    if (message.gaugeId !== undefined) {
       writer.uint32(8).uint64(message.gaugeId);
     }
     if (message.duration !== undefined) {
       Duration.encode(message.duration, writer.uint32(18).fork()).ldelim();
     }
-    if (message.gaugeIncentivePercentage !== "") {
+    if (message.gaugeIncentivePercentage !== undefined) {
       writer.uint32(26).string(message.gaugeIncentivePercentage);
     }
     return writer;
@@ -1050,13 +1050,13 @@ function createBaseIncentivizedPool(): IncentivizedPool {
 export const IncentivizedPool = {
   typeUrl: "/osmosis.poolincentives.v1beta1.IncentivizedPool",
   encode(message: IncentivizedPool, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(8).uint64(message.poolId);
     }
     if (message.lockableDuration !== undefined) {
       Duration.encode(message.lockableDuration, writer.uint32(18).fork()).ldelim();
     }
-    if (message.gaugeId !== BigInt(0)) {
+    if (message.gaugeId !== undefined) {
       writer.uint32(24).uint64(message.gaugeId);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/sumtree/v1beta1/tree.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/sumtree/v1beta1/tree.ts
@@ -149,7 +149,7 @@ export const Child = {
     if (message.index.length !== 0) {
       writer.uint32(10).bytes(message.index);
     }
-    if (message.accumulation !== "") {
+    if (message.accumulation !== undefined) {
       writer.uint32(18).string(message.accumulation);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/superfluid/params.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/superfluid/params.ts
@@ -28,7 +28,7 @@ function createBaseParams(): Params {
 export const Params = {
   typeUrl: "/osmosis.superfluid.Params",
   encode(message: Params, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.minimumRiskFactor !== "") {
+    if (message.minimumRiskFactor !== undefined) {
       writer.uint32(10).string(Decimal.fromUserInput(message.minimumRiskFactor, 18).atomics);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/superfluid/query.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/superfluid/query.ts
@@ -523,7 +523,7 @@ function createBaseAssetTypeRequest(): AssetTypeRequest {
 export const AssetTypeRequest = {
   typeUrl: "/osmosis.superfluid.AssetTypeRequest",
   encode(message: AssetTypeRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(10).string(message.denom);
     }
     return writer;
@@ -884,7 +884,7 @@ function createBaseAssetMultiplierRequest(): AssetMultiplierRequest {
 export const AssetMultiplierRequest = {
   typeUrl: "/osmosis.superfluid.AssetMultiplierRequest",
   encode(message: AssetMultiplierRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(10).string(message.denom);
     }
     return writer;
@@ -1073,16 +1073,16 @@ function createBaseSuperfluidIntermediaryAccountInfo(): SuperfluidIntermediaryAc
 export const SuperfluidIntermediaryAccountInfo = {
   typeUrl: "/osmosis.superfluid.SuperfluidIntermediaryAccountInfo",
   encode(message: SuperfluidIntermediaryAccountInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(10).string(message.denom);
     }
-    if (message.valAddr !== "") {
+    if (message.valAddr !== undefined) {
       writer.uint32(18).string(message.valAddr);
     }
-    if (message.gaugeId !== BigInt(0)) {
+    if (message.gaugeId !== undefined) {
       writer.uint32(24).uint64(message.gaugeId);
     }
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(34).string(message.address);
     }
     return writer;
@@ -1424,7 +1424,7 @@ function createBaseConnectedIntermediaryAccountRequest(): ConnectedIntermediaryA
 export const ConnectedIntermediaryAccountRequest = {
   typeUrl: "/osmosis.superfluid.ConnectedIntermediaryAccountRequest",
   encode(message: ConnectedIntermediaryAccountRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.lockId !== BigInt(0)) {
+    if (message.lockId !== undefined) {
       writer.uint32(8).uint64(message.lockId);
     }
     return writer;
@@ -1612,7 +1612,7 @@ function createBaseQueryTotalDelegationByValidatorForDenomRequest(): QueryTotalD
 export const QueryTotalDelegationByValidatorForDenomRequest = {
   typeUrl: "/osmosis.superfluid.QueryTotalDelegationByValidatorForDenomRequest",
   encode(message: QueryTotalDelegationByValidatorForDenomRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(10).string(message.denom);
     }
     return writer;
@@ -1810,13 +1810,13 @@ function createBaseDelegations(): Delegations {
 export const Delegations = {
   typeUrl: "/osmosis.superfluid.Delegations",
   encode(message: Delegations, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.valAddr !== "") {
+    if (message.valAddr !== undefined) {
       writer.uint32(10).string(message.valAddr);
     }
-    if (message.amountSfsd !== "") {
+    if (message.amountSfsd !== undefined) {
       writer.uint32(18).string(message.amountSfsd);
     }
-    if (message.osmoEquivalent !== "") {
+    if (message.osmoEquivalent !== undefined) {
       writer.uint32(26).string(message.osmoEquivalent);
     }
     return writer;
@@ -2003,7 +2003,7 @@ function createBaseTotalSuperfluidDelegationsResponse(): TotalSuperfluidDelegati
 export const TotalSuperfluidDelegationsResponse = {
   typeUrl: "/osmosis.superfluid.TotalSuperfluidDelegationsResponse",
   encode(message: TotalSuperfluidDelegationsResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.totalDelegations !== "") {
+    if (message.totalDelegations !== undefined) {
       writer.uint32(10).string(message.totalDelegations);
     }
     return writer;
@@ -2097,13 +2097,13 @@ function createBaseSuperfluidDelegationAmountRequest(): SuperfluidDelegationAmou
 export const SuperfluidDelegationAmountRequest = {
   typeUrl: "/osmosis.superfluid.SuperfluidDelegationAmountRequest",
   encode(message: SuperfluidDelegationAmountRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddress !== "") {
+    if (message.delegatorAddress !== undefined) {
       writer.uint32(10).string(message.delegatorAddress);
     }
-    if (message.validatorAddress !== "") {
+    if (message.validatorAddress !== undefined) {
       writer.uint32(18).string(message.validatorAddress);
     }
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(26).string(message.denom);
     }
     return writer;
@@ -2321,7 +2321,7 @@ function createBaseSuperfluidDelegationsByDelegatorRequest(): SuperfluidDelegati
 export const SuperfluidDelegationsByDelegatorRequest = {
   typeUrl: "/osmosis.superfluid.SuperfluidDelegationsByDelegatorRequest",
   encode(message: SuperfluidDelegationsByDelegatorRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddress !== "") {
+    if (message.delegatorAddress !== undefined) {
       writer.uint32(10).string(message.delegatorAddress);
     }
     return writer;
@@ -2562,10 +2562,10 @@ function createBaseSuperfluidUndelegationsByDelegatorRequest(): SuperfluidUndele
 export const SuperfluidUndelegationsByDelegatorRequest = {
   typeUrl: "/osmosis.superfluid.SuperfluidUndelegationsByDelegatorRequest",
   encode(message: SuperfluidUndelegationsByDelegatorRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddress !== "") {
+    if (message.delegatorAddress !== undefined) {
       writer.uint32(10).string(message.delegatorAddress);
     }
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(18).string(message.denom);
     }
     return writer;
@@ -2827,10 +2827,10 @@ function createBaseSuperfluidDelegationsByValidatorDenomRequest(): SuperfluidDel
 export const SuperfluidDelegationsByValidatorDenomRequest = {
   typeUrl: "/osmosis.superfluid.SuperfluidDelegationsByValidatorDenomRequest",
   encode(message: SuperfluidDelegationsByValidatorDenomRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.validatorAddress !== "") {
+    if (message.validatorAddress !== undefined) {
       writer.uint32(10).string(message.validatorAddress);
     }
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(18).string(message.denom);
     }
     return writer;
@@ -3038,10 +3038,10 @@ function createBaseEstimateSuperfluidDelegatedAmountByValidatorDenomRequest(): E
 export const EstimateSuperfluidDelegatedAmountByValidatorDenomRequest = {
   typeUrl: "/osmosis.superfluid.EstimateSuperfluidDelegatedAmountByValidatorDenomRequest",
   encode(message: EstimateSuperfluidDelegatedAmountByValidatorDenomRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.validatorAddress !== "") {
+    if (message.validatorAddress !== undefined) {
       writer.uint32(10).string(message.validatorAddress);
     }
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(18).string(message.denom);
     }
     return writer;
@@ -3248,7 +3248,7 @@ function createBaseQueryTotalDelegationByDelegatorRequest(): QueryTotalDelegatio
 export const QueryTotalDelegationByDelegatorRequest = {
   typeUrl: "/osmosis.superfluid.QueryTotalDelegationByDelegatorRequest",
   encode(message: QueryTotalDelegationByDelegatorRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddress !== "") {
+    if (message.delegatorAddress !== undefined) {
       writer.uint32(10).string(message.delegatorAddress);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/superfluid/superfluid.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/superfluid/superfluid.ts
@@ -180,7 +180,7 @@ function createBaseSuperfluidAsset(): SuperfluidAsset {
 export const SuperfluidAsset = {
   typeUrl: "/osmosis.superfluid.SuperfluidAsset",
   encode(message: SuperfluidAsset, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(10).string(message.denom);
     }
     if (message.assetType !== 0) {
@@ -288,13 +288,13 @@ function createBaseSuperfluidIntermediaryAccount(): SuperfluidIntermediaryAccoun
 export const SuperfluidIntermediaryAccount = {
   typeUrl: "/osmosis.superfluid.SuperfluidIntermediaryAccount",
   encode(message: SuperfluidIntermediaryAccount, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(10).string(message.denom);
     }
-    if (message.valAddr !== "") {
+    if (message.valAddr !== undefined) {
       writer.uint32(18).string(message.valAddr);
     }
-    if (message.gaugeId !== BigInt(0)) {
+    if (message.gaugeId !== undefined) {
       writer.uint32(24).uint64(message.gaugeId);
     }
     return writer;
@@ -412,13 +412,13 @@ function createBaseOsmoEquivalentMultiplierRecord(): OsmoEquivalentMultiplierRec
 export const OsmoEquivalentMultiplierRecord = {
   typeUrl: "/osmosis.superfluid.OsmoEquivalentMultiplierRecord",
   encode(message: OsmoEquivalentMultiplierRecord, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.epochNumber !== BigInt(0)) {
+    if (message.epochNumber !== undefined) {
       writer.uint32(8).int64(message.epochNumber);
     }
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(18).string(message.denom);
     }
-    if (message.multiplier !== "") {
+    if (message.multiplier !== undefined) {
       writer.uint32(26).string(Decimal.fromUserInput(message.multiplier, 18).atomics);
     }
     return writer;
@@ -537,10 +537,10 @@ function createBaseSuperfluidDelegationRecord(): SuperfluidDelegationRecord {
 export const SuperfluidDelegationRecord = {
   typeUrl: "/osmosis.superfluid.SuperfluidDelegationRecord",
   encode(message: SuperfluidDelegationRecord, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.delegatorAddress !== "") {
+    if (message.delegatorAddress !== undefined) {
       writer.uint32(10).string(message.delegatorAddress);
     }
-    if (message.validatorAddress !== "") {
+    if (message.validatorAddress !== undefined) {
       writer.uint32(18).string(message.validatorAddress);
     }
     if (message.delegationAmount !== undefined) {
@@ -676,10 +676,10 @@ function createBaseLockIdIntermediaryAccountConnection(): LockIdIntermediaryAcco
 export const LockIdIntermediaryAccountConnection = {
   typeUrl: "/osmosis.superfluid.LockIdIntermediaryAccountConnection",
   encode(message: LockIdIntermediaryAccountConnection, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.lockId !== BigInt(0)) {
+    if (message.lockId !== undefined) {
       writer.uint32(8).uint64(message.lockId);
     }
-    if (message.intermediaryAccount !== "") {
+    if (message.intermediaryAccount !== undefined) {
       writer.uint32(18).string(message.intermediaryAccount);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/superfluid/tx.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/superfluid/tx.ts
@@ -144,13 +144,13 @@ function createBaseMsgSuperfluidDelegate(): MsgSuperfluidDelegate {
 export const MsgSuperfluidDelegate = {
   typeUrl: "/osmosis.superfluid.MsgSuperfluidDelegate",
   encode(message: MsgSuperfluidDelegate, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
-    if (message.lockId !== BigInt(0)) {
+    if (message.lockId !== undefined) {
       writer.uint32(16).uint64(message.lockId);
     }
-    if (message.valAddr !== "") {
+    if (message.valAddr !== undefined) {
       writer.uint32(26).string(message.valAddr);
     }
     return writer;
@@ -340,10 +340,10 @@ function createBaseMsgSuperfluidUndelegate(): MsgSuperfluidUndelegate {
 export const MsgSuperfluidUndelegate = {
   typeUrl: "/osmosis.superfluid.MsgSuperfluidUndelegate",
   encode(message: MsgSuperfluidUndelegate, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
-    if (message.lockId !== BigInt(0)) {
+    if (message.lockId !== undefined) {
       writer.uint32(16).uint64(message.lockId);
     }
     return writer;
@@ -522,10 +522,10 @@ function createBaseMsgSuperfluidUnbondLock(): MsgSuperfluidUnbondLock {
 export const MsgSuperfluidUnbondLock = {
   typeUrl: "/osmosis.superfluid.MsgSuperfluidUnbondLock",
   encode(message: MsgSuperfluidUnbondLock, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
-    if (message.lockId !== BigInt(0)) {
+    if (message.lockId !== undefined) {
       writer.uint32(16).uint64(message.lockId);
     }
     return writer;
@@ -705,13 +705,13 @@ function createBaseMsgLockAndSuperfluidDelegate(): MsgLockAndSuperfluidDelegate 
 export const MsgLockAndSuperfluidDelegate = {
   typeUrl: "/osmosis.superfluid.MsgLockAndSuperfluidDelegate",
   encode(message: MsgLockAndSuperfluidDelegate, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
     for (const v of message.coins) {
       Coin.encode(v!, writer.uint32(18).fork()).ldelim();
     }
-    if (message.valAddr !== "") {
+    if (message.valAddr !== undefined) {
       writer.uint32(26).string(message.valAddr);
     }
     return writer;
@@ -837,7 +837,7 @@ function createBaseMsgLockAndSuperfluidDelegateResponse(): MsgLockAndSuperfluidD
 export const MsgLockAndSuperfluidDelegateResponse = {
   typeUrl: "/osmosis.superfluid.MsgLockAndSuperfluidDelegateResponse",
   encode(message: MsgLockAndSuperfluidDelegateResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.ID !== BigInt(0)) {
+    if (message.ID !== undefined) {
       writer.uint32(8).uint64(message.ID);
     }
     return writer;
@@ -932,10 +932,10 @@ function createBaseMsgUnPoolWhitelistedPool(): MsgUnPoolWhitelistedPool {
 export const MsgUnPoolWhitelistedPool = {
   typeUrl: "/osmosis.superfluid.MsgUnPoolWhitelistedPool",
   encode(message: MsgUnPoolWhitelistedPool, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(16).uint64(message.poolId);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/superfluid/v1beta1/gov.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/superfluid/v1beta1/gov.ts
@@ -80,10 +80,10 @@ function createBaseSetSuperfluidAssetsProposal(): SetSuperfluidAssetsProposal {
 export const SetSuperfluidAssetsProposal = {
   typeUrl: "/osmosis.superfluid.v1beta1.SetSuperfluidAssetsProposal",
   encode(message: SetSuperfluidAssetsProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
     for (const v of message.assets) {
@@ -214,10 +214,10 @@ function createBaseRemoveSuperfluidAssetsProposal(): RemoveSuperfluidAssetsPropo
 export const RemoveSuperfluidAssetsProposal = {
   typeUrl: "/osmosis.superfluid.v1beta1.RemoveSuperfluidAssetsProposal",
   encode(message: RemoveSuperfluidAssetsProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
     for (const v of message.superfluidAssetDenoms) {
@@ -349,10 +349,10 @@ function createBaseUpdateUnpoolWhiteListProposal(): UpdateUnpoolWhiteListProposa
 export const UpdateUnpoolWhiteListProposal = {
   typeUrl: "/osmosis.superfluid.v1beta1.UpdateUnpoolWhiteListProposal",
   encode(message: UpdateUnpoolWhiteListProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
     writer.uint32(26).fork();
@@ -360,7 +360,7 @@ export const UpdateUnpoolWhiteListProposal = {
       writer.uint64(v);
     }
     writer.ldelim();
-    if (message.isOverwrite === true) {
+    if (message.isOverwrite !== undefined) {
       writer.uint32(32).bool(message.isOverwrite);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/tokenfactory/v1beta1/authorityMetadata.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/tokenfactory/v1beta1/authorityMetadata.ts
@@ -30,7 +30,7 @@ function createBaseDenomAuthorityMetadata(): DenomAuthorityMetadata {
 export const DenomAuthorityMetadata = {
   typeUrl: "/osmosis.tokenfactory.v1beta1.DenomAuthorityMetadata",
   encode(message: DenomAuthorityMetadata, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.admin !== "") {
+    if (message.admin !== undefined) {
       writer.uint32(10).string(message.admin);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/tokenfactory/v1beta1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/tokenfactory/v1beta1/genesis.ts
@@ -170,7 +170,7 @@ function createBaseGenesisDenom(): GenesisDenom {
 export const GenesisDenom = {
   typeUrl: "/osmosis.tokenfactory.v1beta1.GenesisDenom",
   encode(message: GenesisDenom, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(10).string(message.denom);
     }
     if (message.authorityMetadata !== undefined) {

--- a/__fixtures__/v-next/outputv4/osmosis/tokenfactory/v1beta1/query.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/tokenfactory/v1beta1/query.ts
@@ -271,7 +271,7 @@ function createBaseQueryDenomAuthorityMetadataRequest(): QueryDenomAuthorityMeta
 export const QueryDenomAuthorityMetadataRequest = {
   typeUrl: "/osmosis.tokenfactory.v1beta1.QueryDenomAuthorityMetadataRequest",
   encode(message: QueryDenomAuthorityMetadataRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(10).string(message.denom);
     }
     return writer;
@@ -457,7 +457,7 @@ function createBaseQueryDenomsFromCreatorRequest(): QueryDenomsFromCreatorReques
 export const QueryDenomsFromCreatorRequest = {
   typeUrl: "/osmosis.tokenfactory.v1beta1.QueryDenomsFromCreatorRequest",
   encode(message: QueryDenomsFromCreatorRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.creator !== "") {
+    if (message.creator !== undefined) {
       writer.uint32(10).string(message.creator);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/tokenfactory/v1beta1/tx.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/tokenfactory/v1beta1/tx.ts
@@ -187,10 +187,10 @@ function createBaseMsgCreateDenom(): MsgCreateDenom {
 export const MsgCreateDenom = {
   typeUrl: "/osmosis.tokenfactory.v1beta1.MsgCreateDenom",
   encode(message: MsgCreateDenom, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
-    if (message.subdenom !== "") {
+    if (message.subdenom !== undefined) {
       writer.uint32(18).string(message.subdenom);
     }
     return writer;
@@ -293,7 +293,7 @@ function createBaseMsgCreateDenomResponse(): MsgCreateDenomResponse {
 export const MsgCreateDenomResponse = {
   typeUrl: "/osmosis.tokenfactory.v1beta1.MsgCreateDenomResponse",
   encode(message: MsgCreateDenomResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.newTokenDenom !== "") {
+    if (message.newTokenDenom !== undefined) {
       writer.uint32(10).string(message.newTokenDenom);
     }
     return writer;
@@ -386,7 +386,7 @@ function createBaseMsgMint(): MsgMint {
 export const MsgMint = {
   typeUrl: "/osmosis.tokenfactory.v1beta1.MsgMint",
   encode(message: MsgMint, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
     if (message.amount !== undefined) {
@@ -568,7 +568,7 @@ function createBaseMsgBurn(): MsgBurn {
 export const MsgBurn = {
   typeUrl: "/osmosis.tokenfactory.v1beta1.MsgBurn",
   encode(message: MsgBurn, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
     if (message.amount !== undefined) {
@@ -751,13 +751,13 @@ function createBaseMsgChangeAdmin(): MsgChangeAdmin {
 export const MsgChangeAdmin = {
   typeUrl: "/osmosis.tokenfactory.v1beta1.MsgChangeAdmin",
   encode(message: MsgChangeAdmin, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(18).string(message.denom);
     }
-    if (message.newAdmin !== "") {
+    if (message.newAdmin !== undefined) {
       writer.uint32(26).string(message.newAdmin);
     }
     return writer;
@@ -945,7 +945,7 @@ function createBaseMsgSetDenomMetadata(): MsgSetDenomMetadata {
 export const MsgSetDenomMetadata = {
   typeUrl: "/osmosis.tokenfactory.v1beta1.MsgSetDenomMetadata",
   encode(message: MsgSetDenomMetadata, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(10).string(message.sender);
     }
     if (message.metadata !== undefined) {

--- a/__fixtures__/v-next/outputv4/osmosis/twap/v1beta1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/twap/v1beta1/genesis.ts
@@ -42,7 +42,7 @@ function createBaseParams(): Params {
 export const Params = {
   typeUrl: "/osmosis.twap.v1beta1.Params",
   encode(message: Params, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.pruneEpochIdentifier !== "") {
+    if (message.pruneEpochIdentifier !== undefined) {
       writer.uint32(10).string(message.pruneEpochIdentifier);
     }
     if (message.recordHistoryKeepPeriod !== undefined) {

--- a/__fixtures__/v-next/outputv4/osmosis/twap/v1beta1/query.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/twap/v1beta1/query.ts
@@ -86,13 +86,13 @@ function createBaseArithmeticTwapRequest(): ArithmeticTwapRequest {
 export const ArithmeticTwapRequest = {
   typeUrl: "/osmosis.twap.v1beta1.ArithmeticTwapRequest",
   encode(message: ArithmeticTwapRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(8).uint64(message.poolId);
     }
-    if (message.baseAsset !== "") {
+    if (message.baseAsset !== undefined) {
       writer.uint32(18).string(message.baseAsset);
     }
-    if (message.quoteAsset !== "") {
+    if (message.quoteAsset !== undefined) {
       writer.uint32(26).string(message.quoteAsset);
     }
     if (message.startTime !== undefined) {
@@ -236,7 +236,7 @@ function createBaseArithmeticTwapResponse(): ArithmeticTwapResponse {
 export const ArithmeticTwapResponse = {
   typeUrl: "/osmosis.twap.v1beta1.ArithmeticTwapResponse",
   encode(message: ArithmeticTwapResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.arithmeticTwap !== "") {
+    if (message.arithmeticTwap !== undefined) {
       writer.uint32(10).string(Decimal.fromUserInput(message.arithmeticTwap, 18).atomics);
     }
     return writer;
@@ -331,13 +331,13 @@ function createBaseArithmeticTwapToNowRequest(): ArithmeticTwapToNowRequest {
 export const ArithmeticTwapToNowRequest = {
   typeUrl: "/osmosis.twap.v1beta1.ArithmeticTwapToNowRequest",
   encode(message: ArithmeticTwapToNowRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(8).uint64(message.poolId);
     }
-    if (message.baseAsset !== "") {
+    if (message.baseAsset !== undefined) {
       writer.uint32(18).string(message.baseAsset);
     }
-    if (message.quoteAsset !== "") {
+    if (message.quoteAsset !== undefined) {
       writer.uint32(26).string(message.quoteAsset);
     }
     if (message.startTime !== undefined) {
@@ -467,7 +467,7 @@ function createBaseArithmeticTwapToNowResponse(): ArithmeticTwapToNowResponse {
 export const ArithmeticTwapToNowResponse = {
   typeUrl: "/osmosis.twap.v1beta1.ArithmeticTwapToNowResponse",
   encode(message: ArithmeticTwapToNowResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.arithmeticTwap !== "") {
+    if (message.arithmeticTwap !== undefined) {
       writer.uint32(10).string(Decimal.fromUserInput(message.arithmeticTwap, 18).atomics);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/twap/v1beta1/twap_record.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/twap/v1beta1/twap_record.ts
@@ -82,31 +82,31 @@ function createBaseTwapRecord(): TwapRecord {
 export const TwapRecord = {
   typeUrl: "/osmosis.twap.v1beta1.TwapRecord",
   encode(message: TwapRecord, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.poolId !== BigInt(0)) {
+    if (message.poolId !== undefined) {
       writer.uint32(8).uint64(message.poolId);
     }
-    if (message.asset0Denom !== "") {
+    if (message.asset0Denom !== undefined) {
       writer.uint32(18).string(message.asset0Denom);
     }
-    if (message.asset1Denom !== "") {
+    if (message.asset1Denom !== undefined) {
       writer.uint32(26).string(message.asset1Denom);
     }
-    if (message.height !== BigInt(0)) {
+    if (message.height !== undefined) {
       writer.uint32(32).int64(message.height);
     }
     if (message.time !== undefined) {
       Timestamp.encode(toTimestamp(message.time), writer.uint32(42).fork()).ldelim();
     }
-    if (message.p0LastSpotPrice !== "") {
+    if (message.p0LastSpotPrice !== undefined) {
       writer.uint32(50).string(Decimal.fromUserInput(message.p0LastSpotPrice, 18).atomics);
     }
-    if (message.p1LastSpotPrice !== "") {
+    if (message.p1LastSpotPrice !== undefined) {
       writer.uint32(58).string(Decimal.fromUserInput(message.p1LastSpotPrice, 18).atomics);
     }
-    if (message.p0ArithmeticTwapAccumulator !== "") {
+    if (message.p0ArithmeticTwapAccumulator !== undefined) {
       writer.uint32(66).string(Decimal.fromUserInput(message.p0ArithmeticTwapAccumulator, 18).atomics);
     }
-    if (message.p1ArithmeticTwapAccumulator !== "") {
+    if (message.p1ArithmeticTwapAccumulator !== undefined) {
       writer.uint32(74).string(Decimal.fromUserInput(message.p1ArithmeticTwapAccumulator, 18).atomics);
     }
     if (message.lastErrorTime !== undefined) {

--- a/__fixtures__/v-next/outputv4/osmosis/txfees/v1beta1/feetoken.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/txfees/v1beta1/feetoken.ts
@@ -34,10 +34,10 @@ function createBaseFeeToken(): FeeToken {
 export const FeeToken = {
   typeUrl: "/osmosis.txfees.v1beta1.FeeToken",
   encode(message: FeeToken, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(10).string(message.denom);
     }
-    if (message.poolID !== BigInt(0)) {
+    if (message.poolID !== undefined) {
       writer.uint32(16).uint64(message.poolID);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/osmosis/txfees/v1beta1/genesis.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/txfees/v1beta1/genesis.ts
@@ -25,7 +25,7 @@ function createBaseGenesisState(): GenesisState {
 export const GenesisState = {
   typeUrl: "/osmosis.txfees.v1beta1.GenesisState",
   encode(message: GenesisState, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.basedenom !== "") {
+    if (message.basedenom !== undefined) {
       writer.uint32(10).string(message.basedenom);
     }
     for (const v of message.feetokens) {

--- a/__fixtures__/v-next/outputv4/osmosis/txfees/v1beta1/gov.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/txfees/v1beta1/gov.ts
@@ -40,10 +40,10 @@ function createBaseUpdateFeeTokenProposal(): UpdateFeeTokenProposal {
 export const UpdateFeeTokenProposal = {
   typeUrl: "/osmosis.txfees.v1beta1.UpdateFeeTokenProposal",
   encode(message: UpdateFeeTokenProposal, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.title !== "") {
+    if (message.title !== undefined) {
       writer.uint32(10).string(message.title);
     }
-    if (message.description !== "") {
+    if (message.description !== undefined) {
       writer.uint32(18).string(message.description);
     }
     if (message.feetoken !== undefined) {

--- a/__fixtures__/v-next/outputv4/osmosis/txfees/v1beta1/query.ts
+++ b/__fixtures__/v-next/outputv4/osmosis/txfees/v1beta1/query.ts
@@ -278,7 +278,7 @@ function createBaseQueryDenomSpotPriceRequest(): QueryDenomSpotPriceRequest {
 export const QueryDenomSpotPriceRequest = {
   typeUrl: "/osmosis.txfees.v1beta1.QueryDenomSpotPriceRequest",
   encode(message: QueryDenomSpotPriceRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(10).string(message.denom);
     }
     return writer;
@@ -371,10 +371,10 @@ function createBaseQueryDenomSpotPriceResponse(): QueryDenomSpotPriceResponse {
 export const QueryDenomSpotPriceResponse = {
   typeUrl: "/osmosis.txfees.v1beta1.QueryDenomSpotPriceResponse",
   encode(message: QueryDenomSpotPriceResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.poolID !== BigInt(0)) {
+    if (message.poolID !== undefined) {
       writer.uint32(8).uint64(message.poolID);
     }
-    if (message.spotPrice !== "") {
+    if (message.spotPrice !== undefined) {
       writer.uint32(18).string(Decimal.fromUserInput(message.spotPrice, 18).atomics);
     }
     return writer;
@@ -479,7 +479,7 @@ function createBaseQueryDenomPoolIdRequest(): QueryDenomPoolIdRequest {
 export const QueryDenomPoolIdRequest = {
   typeUrl: "/osmosis.txfees.v1beta1.QueryDenomPoolIdRequest",
   encode(message: QueryDenomPoolIdRequest, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.denom !== "") {
+    if (message.denom !== undefined) {
       writer.uint32(10).string(message.denom);
     }
     return writer;
@@ -571,7 +571,7 @@ function createBaseQueryDenomPoolIdResponse(): QueryDenomPoolIdResponse {
 export const QueryDenomPoolIdResponse = {
   typeUrl: "/osmosis.txfees.v1beta1.QueryDenomPoolIdResponse",
   encode(message: QueryDenomPoolIdResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.poolID !== BigInt(0)) {
+    if (message.poolID !== undefined) {
       writer.uint32(8).uint64(message.poolID);
     }
     return writer;
@@ -738,7 +738,7 @@ function createBaseQueryBaseDenomResponse(): QueryBaseDenomResponse {
 export const QueryBaseDenomResponse = {
   typeUrl: "/osmosis.txfees.v1beta1.QueryBaseDenomResponse",
   encode(message: QueryBaseDenomResponse, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.baseDenom !== "") {
+    if (message.baseDenom !== undefined) {
       writer.uint32(10).string(message.baseDenom);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/tendermint/abci/types.ts
+++ b/__fixtures__/v-next/outputv4/tendermint/abci/types.ts
@@ -1251,7 +1251,7 @@ function createBaseRequestEcho(): RequestEcho {
 export const RequestEcho = {
   typeUrl: "/tendermint.abci.RequestEcho",
   encode(message: RequestEcho, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.message !== "") {
+    if (message.message !== undefined) {
       writer.uint32(10).string(message.message);
     }
     return writer;
@@ -1406,13 +1406,13 @@ function createBaseRequestInfo(): RequestInfo {
 export const RequestInfo = {
   typeUrl: "/tendermint.abci.RequestInfo",
   encode(message: RequestInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.version !== "") {
+    if (message.version !== undefined) {
       writer.uint32(10).string(message.version);
     }
-    if (message.blockVersion !== BigInt(0)) {
+    if (message.blockVersion !== undefined) {
       writer.uint32(16).uint64(message.blockVersion);
     }
-    if (message.p2pVersion !== BigInt(0)) {
+    if (message.p2pVersion !== undefined) {
       writer.uint32(24).uint64(message.p2pVersion);
     }
     return writer;
@@ -1525,10 +1525,10 @@ function createBaseRequestSetOption(): RequestSetOption {
 export const RequestSetOption = {
   typeUrl: "/tendermint.abci.RequestSetOption",
   encode(message: RequestSetOption, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.value !== "") {
+    if (message.value !== undefined) {
       writer.uint32(18).string(message.value);
     }
     return writer;
@@ -1633,7 +1633,7 @@ export const RequestInitChain = {
     if (message.time !== undefined) {
       Timestamp.encode(toTimestamp(message.time), writer.uint32(10).fork()).ldelim();
     }
-    if (message.chainId !== "") {
+    if (message.chainId !== undefined) {
       writer.uint32(18).string(message.chainId);
     }
     if (message.consensusParams !== undefined) {
@@ -1645,7 +1645,7 @@ export const RequestInitChain = {
     if (message.appStateBytes.length !== 0) {
       writer.uint32(42).bytes(message.appStateBytes);
     }
-    if (message.initialHeight !== BigInt(0)) {
+    if (message.initialHeight !== undefined) {
       writer.uint32(48).int64(message.initialHeight);
     }
     return writer;
@@ -1808,13 +1808,13 @@ export const RequestQuery = {
     if (message.data.length !== 0) {
       writer.uint32(10).bytes(message.data);
     }
-    if (message.path !== "") {
+    if (message.path !== undefined) {
       writer.uint32(18).string(message.path);
     }
-    if (message.height !== BigInt(0)) {
+    if (message.height !== undefined) {
       writer.uint32(24).int64(message.height);
     }
-    if (message.prove === true) {
+    if (message.prove !== undefined) {
       writer.uint32(32).bool(message.prove);
     }
     return writer;
@@ -2269,7 +2269,7 @@ function createBaseRequestEndBlock(): RequestEndBlock {
 export const RequestEndBlock = {
   typeUrl: "/tendermint.abci.RequestEndBlock",
   encode(message: RequestEndBlock, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.height !== BigInt(0)) {
+    if (message.height !== undefined) {
       writer.uint32(8).int64(message.height);
     }
     return writer;
@@ -2596,13 +2596,13 @@ function createBaseRequestLoadSnapshotChunk(): RequestLoadSnapshotChunk {
 export const RequestLoadSnapshotChunk = {
   typeUrl: "/tendermint.abci.RequestLoadSnapshotChunk",
   encode(message: RequestLoadSnapshotChunk, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.height !== BigInt(0)) {
+    if (message.height !== undefined) {
       writer.uint32(8).uint64(message.height);
     }
-    if (message.format !== 0) {
+    if (message.format !== undefined) {
       writer.uint32(16).uint32(message.format);
     }
-    if (message.chunk !== 0) {
+    if (message.chunk !== undefined) {
       writer.uint32(24).uint32(message.chunk);
     }
     return writer;
@@ -2714,13 +2714,13 @@ function createBaseRequestApplySnapshotChunk(): RequestApplySnapshotChunk {
 export const RequestApplySnapshotChunk = {
   typeUrl: "/tendermint.abci.RequestApplySnapshotChunk",
   encode(message: RequestApplySnapshotChunk, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.index !== 0) {
+    if (message.index !== undefined) {
       writer.uint32(8).uint32(message.index);
     }
     if (message.chunk.length !== 0) {
       writer.uint32(18).bytes(message.chunk);
     }
-    if (message.sender !== "") {
+    if (message.sender !== undefined) {
       writer.uint32(26).string(message.sender);
     }
     return writer;
@@ -3171,7 +3171,7 @@ function createBaseResponseException(): ResponseException {
 export const ResponseException = {
   typeUrl: "/tendermint.abci.ResponseException",
   encode(message: ResponseException, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.error !== "") {
+    if (message.error !== undefined) {
       writer.uint32(10).string(message.error);
     }
     return writer;
@@ -3257,7 +3257,7 @@ function createBaseResponseEcho(): ResponseEcho {
 export const ResponseEcho = {
   typeUrl: "/tendermint.abci.ResponseEcho",
   encode(message: ResponseEcho, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.message !== "") {
+    if (message.message !== undefined) {
       writer.uint32(10).string(message.message);
     }
     return writer;
@@ -3414,16 +3414,16 @@ function createBaseResponseInfo(): ResponseInfo {
 export const ResponseInfo = {
   typeUrl: "/tendermint.abci.ResponseInfo",
   encode(message: ResponseInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.data !== "") {
+    if (message.data !== undefined) {
       writer.uint32(10).string(message.data);
     }
-    if (message.version !== "") {
+    if (message.version !== undefined) {
       writer.uint32(18).string(message.version);
     }
-    if (message.appVersion !== BigInt(0)) {
+    if (message.appVersion !== undefined) {
       writer.uint32(24).uint64(message.appVersion);
     }
-    if (message.lastBlockHeight !== BigInt(0)) {
+    if (message.lastBlockHeight !== undefined) {
       writer.uint32(32).int64(message.lastBlockHeight);
     }
     if (message.lastBlockAppHash.length !== 0) {
@@ -3562,13 +3562,13 @@ function createBaseResponseSetOption(): ResponseSetOption {
 export const ResponseSetOption = {
   typeUrl: "/tendermint.abci.ResponseSetOption",
   encode(message: ResponseSetOption, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.code !== 0) {
+    if (message.code !== undefined) {
       writer.uint32(8).uint32(message.code);
     }
-    if (message.log !== "") {
+    if (message.log !== undefined) {
       writer.uint32(26).string(message.log);
     }
-    if (message.info !== "") {
+    if (message.info !== undefined) {
       writer.uint32(34).string(message.info);
     }
     return writer;
@@ -3814,16 +3814,16 @@ function createBaseResponseQuery(): ResponseQuery {
 export const ResponseQuery = {
   typeUrl: "/tendermint.abci.ResponseQuery",
   encode(message: ResponseQuery, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.code !== 0) {
+    if (message.code !== undefined) {
       writer.uint32(8).uint32(message.code);
     }
-    if (message.log !== "") {
+    if (message.log !== undefined) {
       writer.uint32(26).string(message.log);
     }
-    if (message.info !== "") {
+    if (message.info !== undefined) {
       writer.uint32(34).string(message.info);
     }
-    if (message.index !== BigInt(0)) {
+    if (message.index !== undefined) {
       writer.uint32(40).int64(message.index);
     }
     if (message.key.length !== 0) {
@@ -3835,10 +3835,10 @@ export const ResponseQuery = {
     if (message.proofOps !== undefined) {
       ProofOps.encode(message.proofOps, writer.uint32(66).fork()).ldelim();
     }
-    if (message.height !== BigInt(0)) {
+    if (message.height !== undefined) {
       writer.uint32(72).int64(message.height);
     }
-    if (message.codespace !== "") {
+    if (message.codespace !== undefined) {
       writer.uint32(82).string(message.codespace);
     }
     return writer;
@@ -4123,28 +4123,28 @@ function createBaseResponseCheckTx(): ResponseCheckTx {
 export const ResponseCheckTx = {
   typeUrl: "/tendermint.abci.ResponseCheckTx",
   encode(message: ResponseCheckTx, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.code !== 0) {
+    if (message.code !== undefined) {
       writer.uint32(8).uint32(message.code);
     }
     if (message.data.length !== 0) {
       writer.uint32(18).bytes(message.data);
     }
-    if (message.log !== "") {
+    if (message.log !== undefined) {
       writer.uint32(26).string(message.log);
     }
-    if (message.info !== "") {
+    if (message.info !== undefined) {
       writer.uint32(34).string(message.info);
     }
-    if (message.gasWanted !== BigInt(0)) {
+    if (message.gasWanted !== undefined) {
       writer.uint32(40).int64(message.gasWanted);
     }
-    if (message.gasUsed !== BigInt(0)) {
+    if (message.gasUsed !== undefined) {
       writer.uint32(48).int64(message.gasUsed);
     }
     for (const v of message.events) {
       Event.encode(v!, writer.uint32(58).fork()).ldelim();
     }
-    if (message.codespace !== "") {
+    if (message.codespace !== undefined) {
       writer.uint32(66).string(message.codespace);
     }
     return writer;
@@ -4330,28 +4330,28 @@ function createBaseResponseDeliverTx(): ResponseDeliverTx {
 export const ResponseDeliverTx = {
   typeUrl: "/tendermint.abci.ResponseDeliverTx",
   encode(message: ResponseDeliverTx, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.code !== 0) {
+    if (message.code !== undefined) {
       writer.uint32(8).uint32(message.code);
     }
     if (message.data.length !== 0) {
       writer.uint32(18).bytes(message.data);
     }
-    if (message.log !== "") {
+    if (message.log !== undefined) {
       writer.uint32(26).string(message.log);
     }
-    if (message.info !== "") {
+    if (message.info !== undefined) {
       writer.uint32(34).string(message.info);
     }
-    if (message.gasWanted !== BigInt(0)) {
+    if (message.gasWanted !== undefined) {
       writer.uint32(40).int64(message.gasWanted);
     }
-    if (message.gasUsed !== BigInt(0)) {
+    if (message.gasUsed !== undefined) {
       writer.uint32(48).int64(message.gasUsed);
     }
     for (const v of message.events) {
       Event.encode(v!, writer.uint32(58).fork()).ldelim();
     }
-    if (message.codespace !== "") {
+    if (message.codespace !== undefined) {
       writer.uint32(66).string(message.codespace);
     }
     return writer;
@@ -4676,7 +4676,7 @@ export const ResponseCommit = {
     if (message.data.length !== 0) {
       writer.uint32(18).bytes(message.data);
     }
-    if (message.retainHeight !== BigInt(0)) {
+    if (message.retainHeight !== undefined) {
       writer.uint32(24).int64(message.retainHeight);
     }
     return writer;
@@ -5334,10 +5334,10 @@ function createBaseBlockParams(): BlockParams {
 export const BlockParams = {
   typeUrl: "/tendermint.abci.BlockParams",
   encode(message: BlockParams, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.maxBytes !== BigInt(0)) {
+    if (message.maxBytes !== undefined) {
       writer.uint32(8).int64(message.maxBytes);
     }
-    if (message.maxGas !== BigInt(0)) {
+    if (message.maxGas !== undefined) {
       writer.uint32(16).int64(message.maxGas);
     }
     return writer;
@@ -5439,7 +5439,7 @@ function createBaseLastCommitInfo(): LastCommitInfo {
 export const LastCommitInfo = {
   typeUrl: "/tendermint.abci.LastCommitInfo",
   encode(message: LastCommitInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.round !== 0) {
+    if (message.round !== undefined) {
       writer.uint32(8).int32(message.round);
     }
     for (const v of message.votes) {
@@ -5552,7 +5552,7 @@ function createBaseEvent(): Event {
 export const Event = {
   typeUrl: "/tendermint.abci.Event",
   encode(message: Event, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.type !== "") {
+    if (message.type !== undefined) {
       writer.uint32(10).string(message.type);
     }
     for (const v of message.attributes) {
@@ -5672,7 +5672,7 @@ export const EventAttribute = {
     if (message.value.length !== 0) {
       writer.uint32(18).bytes(message.value);
     }
-    if (message.index === true) {
+    if (message.index !== undefined) {
       writer.uint32(24).bool(message.index);
     }
     return writer;
@@ -5783,10 +5783,10 @@ function createBaseTxResult(): TxResult {
 export const TxResult = {
   typeUrl: "/tendermint.abci.TxResult",
   encode(message: TxResult, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.height !== BigInt(0)) {
+    if (message.height !== undefined) {
       writer.uint32(8).int64(message.height);
     }
-    if (message.index !== 0) {
+    if (message.index !== undefined) {
       writer.uint32(16).uint32(message.index);
     }
     if (message.tx.length !== 0) {
@@ -5919,7 +5919,7 @@ export const Validator = {
     if (message.address.length !== 0) {
       writer.uint32(10).bytes(message.address);
     }
-    if (message.power !== BigInt(0)) {
+    if (message.power !== undefined) {
       writer.uint32(24).int64(message.power);
     }
     return writer;
@@ -6022,7 +6022,7 @@ export const ValidatorUpdate = {
     if (message.pubKey !== undefined) {
       PublicKey.encode(message.pubKey, writer.uint32(10).fork()).ldelim();
     }
-    if (message.power !== BigInt(0)) {
+    if (message.power !== undefined) {
       writer.uint32(16).int64(message.power);
     }
     return writer;
@@ -6127,7 +6127,7 @@ export const VoteInfo = {
     if (message.validator !== undefined) {
       Validator.encode(message.validator, writer.uint32(10).fork()).ldelim();
     }
-    if (message.signedLastBlock === true) {
+    if (message.signedLastBlock !== undefined) {
       writer.uint32(16).bool(message.signedLastBlock);
     }
     return writer;
@@ -6236,13 +6236,13 @@ export const Evidence = {
     if (message.validator !== undefined) {
       Validator.encode(message.validator, writer.uint32(18).fork()).ldelim();
     }
-    if (message.height !== BigInt(0)) {
+    if (message.height !== undefined) {
       writer.uint32(24).int64(message.height);
     }
     if (message.time !== undefined) {
       Timestamp.encode(toTimestamp(message.time), writer.uint32(34).fork()).ldelim();
     }
-    if (message.totalVotingPower !== BigInt(0)) {
+    if (message.totalVotingPower !== undefined) {
       writer.uint32(40).int64(message.totalVotingPower);
     }
     return writer;
@@ -6382,13 +6382,13 @@ function createBaseSnapshot(): Snapshot {
 export const Snapshot = {
   typeUrl: "/tendermint.abci.Snapshot",
   encode(message: Snapshot, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.height !== BigInt(0)) {
+    if (message.height !== undefined) {
       writer.uint32(8).uint64(message.height);
     }
-    if (message.format !== 0) {
+    if (message.format !== undefined) {
       writer.uint32(16).uint32(message.format);
     }
-    if (message.chunks !== 0) {
+    if (message.chunks !== undefined) {
       writer.uint32(24).uint32(message.chunks);
     }
     if (message.hash.length !== 0) {

--- a/__fixtures__/v-next/outputv4/tendermint/crypto/proof.ts
+++ b/__fixtures__/v-next/outputv4/tendermint/crypto/proof.ts
@@ -92,10 +92,10 @@ function createBaseProof(): Proof {
 export const Proof = {
   typeUrl: "/tendermint.crypto.Proof",
   encode(message: Proof, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.total !== BigInt(0)) {
+    if (message.total !== undefined) {
       writer.uint32(8).int64(message.total);
     }
-    if (message.index !== BigInt(0)) {
+    if (message.index !== undefined) {
       writer.uint32(16).int64(message.index);
     }
     if (message.leafHash.length !== 0) {
@@ -341,13 +341,13 @@ function createBaseDominoOp(): DominoOp {
 export const DominoOp = {
   typeUrl: "/tendermint.crypto.DominoOp",
   encode(message: DominoOp, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.key !== "") {
+    if (message.key !== undefined) {
       writer.uint32(10).string(message.key);
     }
-    if (message.input !== "") {
+    if (message.input !== undefined) {
       writer.uint32(18).string(message.input);
     }
-    if (message.output !== "") {
+    if (message.output !== undefined) {
       writer.uint32(26).string(message.output);
     }
     return writer;
@@ -457,7 +457,7 @@ function createBaseProofOp(): ProofOp {
 export const ProofOp = {
   typeUrl: "/tendermint.crypto.ProofOp",
   encode(message: ProofOp, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.type !== "") {
+    if (message.type !== undefined) {
       writer.uint32(10).string(message.type);
     }
     if (message.key.length !== 0) {

--- a/__fixtures__/v-next/outputv4/tendermint/libs/bits/types.ts
+++ b/__fixtures__/v-next/outputv4/tendermint/libs/bits/types.ts
@@ -22,7 +22,7 @@ function createBaseBitArray(): BitArray {
 export const BitArray = {
   typeUrl: "/tendermint.libs.bits.BitArray",
   encode(message: BitArray, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.bits !== BigInt(0)) {
+    if (message.bits !== undefined) {
       writer.uint32(8).int64(message.bits);
     }
     writer.uint32(18).fork();

--- a/__fixtures__/v-next/outputv4/tendermint/p2p/types.ts
+++ b/__fixtures__/v-next/outputv4/tendermint/p2p/types.ts
@@ -92,13 +92,13 @@ function createBaseProtocolVersion(): ProtocolVersion {
 export const ProtocolVersion = {
   typeUrl: "/tendermint.p2p.ProtocolVersion",
   encode(message: ProtocolVersion, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.p2p !== BigInt(0)) {
+    if (message.p2p !== undefined) {
       writer.uint32(8).uint64(message.p2p);
     }
-    if (message.block !== BigInt(0)) {
+    if (message.block !== undefined) {
       writer.uint32(16).uint64(message.block);
     }
-    if (message.app !== BigInt(0)) {
+    if (message.app !== undefined) {
       writer.uint32(24).uint64(message.app);
     }
     return writer;
@@ -222,22 +222,22 @@ export const NodeInfo = {
     if (message.protocolVersion !== undefined) {
       ProtocolVersion.encode(message.protocolVersion, writer.uint32(10).fork()).ldelim();
     }
-    if (message.nodeId !== "") {
+    if (message.nodeId !== undefined) {
       writer.uint32(18).string(message.nodeId);
     }
-    if (message.listenAddr !== "") {
+    if (message.listenAddr !== undefined) {
       writer.uint32(26).string(message.listenAddr);
     }
-    if (message.network !== "") {
+    if (message.network !== undefined) {
       writer.uint32(34).string(message.network);
     }
-    if (message.version !== "") {
+    if (message.version !== undefined) {
       writer.uint32(42).string(message.version);
     }
     if (message.channels.length !== 0) {
       writer.uint32(50).bytes(message.channels);
     }
-    if (message.moniker !== "") {
+    if (message.moniker !== undefined) {
       writer.uint32(58).string(message.moniker);
     }
     if (message.other !== undefined) {
@@ -408,10 +408,10 @@ function createBaseNodeInfoOther(): NodeInfoOther {
 export const NodeInfoOther = {
   typeUrl: "/tendermint.p2p.NodeInfoOther",
   encode(message: NodeInfoOther, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.txIndex !== "") {
+    if (message.txIndex !== undefined) {
       writer.uint32(10).string(message.txIndex);
     }
-    if (message.rpcAddress !== "") {
+    if (message.rpcAddress !== undefined) {
       writer.uint32(18).string(message.rpcAddress);
     }
     return writer;
@@ -510,7 +510,7 @@ function createBasePeerInfo(): PeerInfo {
 export const PeerInfo = {
   typeUrl: "/tendermint.p2p.PeerInfo",
   encode(message: PeerInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.id !== "") {
+    if (message.id !== undefined) {
       writer.uint32(10).string(message.id);
     }
     for (const v of message.addressInfo) {
@@ -639,7 +639,7 @@ function createBasePeerAddressInfo(): PeerAddressInfo {
 export const PeerAddressInfo = {
   typeUrl: "/tendermint.p2p.PeerAddressInfo",
   encode(message: PeerAddressInfo, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.address !== "") {
+    if (message.address !== undefined) {
       writer.uint32(10).string(message.address);
     }
     if (message.lastDialSuccess !== undefined) {
@@ -648,7 +648,7 @@ export const PeerAddressInfo = {
     if (message.lastDialFailure !== undefined) {
       Timestamp.encode(toTimestamp(message.lastDialFailure), writer.uint32(26).fork()).ldelim();
     }
-    if (message.dialFailures !== 0) {
+    if (message.dialFailures !== undefined) {
       writer.uint32(32).uint32(message.dialFailures);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/tendermint/types/evidence.ts
+++ b/__fixtures__/v-next/outputv4/tendermint/types/evidence.ts
@@ -189,10 +189,10 @@ export const DuplicateVoteEvidence = {
     if (message.voteB !== undefined) {
       Vote.encode(message.voteB, writer.uint32(18).fork()).ldelim();
     }
-    if (message.totalVotingPower !== BigInt(0)) {
+    if (message.totalVotingPower !== undefined) {
       writer.uint32(24).int64(message.totalVotingPower);
     }
-    if (message.validatorPower !== BigInt(0)) {
+    if (message.validatorPower !== undefined) {
       writer.uint32(32).int64(message.validatorPower);
     }
     if (message.timestamp !== undefined) {
@@ -340,13 +340,13 @@ export const LightClientAttackEvidence = {
     if (message.conflictingBlock !== undefined) {
       LightBlock.encode(message.conflictingBlock, writer.uint32(10).fork()).ldelim();
     }
-    if (message.commonHeight !== BigInt(0)) {
+    if (message.commonHeight !== undefined) {
       writer.uint32(16).int64(message.commonHeight);
     }
     for (const v of message.byzantineValidators) {
       Validator.encode(v!, writer.uint32(26).fork()).ldelim();
     }
-    if (message.totalVotingPower !== BigInt(0)) {
+    if (message.totalVotingPower !== undefined) {
       writer.uint32(32).int64(message.totalVotingPower);
     }
     if (message.timestamp !== undefined) {

--- a/__fixtures__/v-next/outputv4/tendermint/types/params.ts
+++ b/__fixtures__/v-next/outputv4/tendermint/types/params.ts
@@ -291,13 +291,13 @@ function createBaseBlockParams(): BlockParams {
 export const BlockParams = {
   typeUrl: "/tendermint.types.BlockParams",
   encode(message: BlockParams, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.maxBytes !== BigInt(0)) {
+    if (message.maxBytes !== undefined) {
       writer.uint32(8).int64(message.maxBytes);
     }
-    if (message.maxGas !== BigInt(0)) {
+    if (message.maxGas !== undefined) {
       writer.uint32(16).int64(message.maxGas);
     }
-    if (message.timeIotaMs !== BigInt(0)) {
+    if (message.timeIotaMs !== undefined) {
       writer.uint32(24).int64(message.timeIotaMs);
     }
     return writer;
@@ -413,13 +413,13 @@ function createBaseEvidenceParams(): EvidenceParams {
 export const EvidenceParams = {
   typeUrl: "/tendermint.types.EvidenceParams",
   encode(message: EvidenceParams, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.maxAgeNumBlocks !== BigInt(0)) {
+    if (message.maxAgeNumBlocks !== undefined) {
       writer.uint32(8).int64(message.maxAgeNumBlocks);
     }
     if (message.maxAgeDuration !== undefined) {
       Duration.encode(message.maxAgeDuration, writer.uint32(18).fork()).ldelim();
     }
-    if (message.maxBytes !== BigInt(0)) {
+    if (message.maxBytes !== undefined) {
       writer.uint32(24).int64(message.maxBytes);
     }
     return writer;
@@ -631,7 +631,7 @@ function createBaseVersionParams(): VersionParams {
 export const VersionParams = {
   typeUrl: "/tendermint.types.VersionParams",
   encode(message: VersionParams, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.appVersion !== BigInt(0)) {
+    if (message.appVersion !== undefined) {
       writer.uint32(8).uint64(message.appVersion);
     }
     return writer;
@@ -720,10 +720,10 @@ function createBaseHashedParams(): HashedParams {
 export const HashedParams = {
   typeUrl: "/tendermint.types.HashedParams",
   encode(message: HashedParams, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.blockMaxBytes !== BigInt(0)) {
+    if (message.blockMaxBytes !== undefined) {
       writer.uint32(8).int64(message.blockMaxBytes);
     }
-    if (message.blockMaxGas !== BigInt(0)) {
+    if (message.blockMaxGas !== undefined) {
       writer.uint32(16).int64(message.blockMaxGas);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/tendermint/types/types.ts
+++ b/__fixtures__/v-next/outputv4/tendermint/types/types.ts
@@ -357,7 +357,7 @@ function createBasePartSetHeader(): PartSetHeader {
 export const PartSetHeader = {
   typeUrl: "/tendermint.types.PartSetHeader",
   encode(message: PartSetHeader, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.total !== 0) {
+    if (message.total !== undefined) {
       writer.uint32(8).uint32(message.total);
     }
     if (message.hash.length !== 0) {
@@ -459,7 +459,7 @@ function createBasePart(): Part {
 export const Part = {
   typeUrl: "/tendermint.types.Part",
   encode(message: Part, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.index !== 0) {
+    if (message.index !== undefined) {
       writer.uint32(8).uint32(message.index);
     }
     if (message.bytes.length !== 0) {
@@ -694,10 +694,10 @@ export const Header = {
     if (message.version !== undefined) {
       Consensus.encode(message.version, writer.uint32(10).fork()).ldelim();
     }
-    if (message.chainId !== "") {
+    if (message.chainId !== undefined) {
       writer.uint32(18).string(message.chainId);
     }
-    if (message.height !== BigInt(0)) {
+    if (message.height !== undefined) {
       writer.uint32(24).int64(message.height);
     }
     if (message.time !== undefined) {
@@ -1073,10 +1073,10 @@ export const Vote = {
     if (message.type !== 0) {
       writer.uint32(8).int32(message.type);
     }
-    if (message.height !== BigInt(0)) {
+    if (message.height !== undefined) {
       writer.uint32(16).int64(message.height);
     }
-    if (message.round !== 0) {
+    if (message.round !== undefined) {
       writer.uint32(24).int32(message.round);
     }
     if (message.blockId !== undefined) {
@@ -1088,7 +1088,7 @@ export const Vote = {
     if (message.validatorAddress.length !== 0) {
       writer.uint32(50).bytes(message.validatorAddress);
     }
-    if (message.validatorIndex !== 0) {
+    if (message.validatorIndex !== undefined) {
       writer.uint32(56).int32(message.validatorIndex);
     }
     if (message.signature.length !== 0) {
@@ -1261,10 +1261,10 @@ function createBaseCommit(): Commit {
 export const Commit = {
   typeUrl: "/tendermint.types.Commit",
   encode(message: Commit, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.height !== BigInt(0)) {
+    if (message.height !== undefined) {
       writer.uint32(8).int64(message.height);
     }
-    if (message.round !== 0) {
+    if (message.round !== undefined) {
       writer.uint32(16).int32(message.round);
     }
     if (message.blockId !== undefined) {
@@ -1545,13 +1545,13 @@ export const Proposal = {
     if (message.type !== 0) {
       writer.uint32(8).int32(message.type);
     }
-    if (message.height !== BigInt(0)) {
+    if (message.height !== undefined) {
       writer.uint32(16).int64(message.height);
     }
-    if (message.round !== 0) {
+    if (message.round !== undefined) {
       writer.uint32(24).int32(message.round);
     }
-    if (message.polRound !== 0) {
+    if (message.polRound !== undefined) {
       writer.uint32(32).int32(message.polRound);
     }
     if (message.blockId !== undefined) {
@@ -1932,13 +1932,13 @@ export const BlockMeta = {
     if (message.blockId !== undefined) {
       BlockID.encode(message.blockId, writer.uint32(10).fork()).ldelim();
     }
-    if (message.blockSize !== BigInt(0)) {
+    if (message.blockSize !== undefined) {
       writer.uint32(16).int64(message.blockSize);
     }
     if (message.header !== undefined) {
       Header.encode(message.header, writer.uint32(26).fork()).ldelim();
     }
-    if (message.numTxs !== BigInt(0)) {
+    if (message.numTxs !== undefined) {
       writer.uint32(32).int64(message.numTxs);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/tendermint/types/validator.ts
+++ b/__fixtures__/v-next/outputv4/tendermint/types/validator.ts
@@ -60,7 +60,7 @@ export const ValidatorSet = {
     if (message.proposer !== undefined) {
       Validator.encode(message.proposer, writer.uint32(18).fork()).ldelim();
     }
-    if (message.totalVotingPower !== BigInt(0)) {
+    if (message.totalVotingPower !== undefined) {
       writer.uint32(24).int64(message.totalVotingPower);
     }
     return writer;
@@ -193,10 +193,10 @@ export const Validator = {
     if (message.pubKey !== undefined) {
       PublicKey.encode(message.pubKey, writer.uint32(18).fork()).ldelim();
     }
-    if (message.votingPower !== BigInt(0)) {
+    if (message.votingPower !== undefined) {
       writer.uint32(24).int64(message.votingPower);
     }
-    if (message.proposerPriority !== BigInt(0)) {
+    if (message.proposerPriority !== undefined) {
       writer.uint32(32).int64(message.proposerPriority);
     }
     return writer;
@@ -325,7 +325,7 @@ export const SimpleValidator = {
     if (message.pubKey !== undefined) {
       PublicKey.encode(message.pubKey, writer.uint32(10).fork()).ldelim();
     }
-    if (message.votingPower !== BigInt(0)) {
+    if (message.votingPower !== undefined) {
       writer.uint32(16).int64(message.votingPower);
     }
     return writer;

--- a/__fixtures__/v-next/outputv4/tendermint/version/types.ts
+++ b/__fixtures__/v-next/outputv4/tendermint/version/types.ts
@@ -54,10 +54,10 @@ function createBaseApp(): App {
 export const App = {
   typeUrl: "/tendermint.version.App",
   encode(message: App, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.protocol !== BigInt(0)) {
+    if (message.protocol !== undefined) {
       writer.uint32(8).uint64(message.protocol);
     }
-    if (message.software !== "") {
+    if (message.software !== undefined) {
       writer.uint32(18).string(message.software);
     }
     return writer;
@@ -157,10 +157,10 @@ function createBaseConsensus(): Consensus {
 export const Consensus = {
   typeUrl: "/tendermint.version.Consensus",
   encode(message: Consensus, writer: BinaryWriter = BinaryWriter.create()): BinaryWriter {
-    if (message.block !== BigInt(0)) {
+    if (message.block !== undefined) {
       writer.uint32(8).uint64(message.block);
     }
-    if (message.app !== BigInt(0)) {
+    if (message.app !== undefined) {
       writer.uint32(16).uint64(message.app);
     }
     return writer;

--- a/packages/ast/src/encoding/proto/encode/utils.ts
+++ b/packages/ast/src/encoding/proto/encode/utils.ts
@@ -72,8 +72,8 @@ const notZero = (prop: string): t.Expression => {
 };
 
 // TODO research, shouldn't we AND these two tests?
-const wrapOptional = (prop: string, test: t.Expression, isOptional: boolean) => {
-    if (isOptional) {
+const wrapOptional = (prop: string, test: t.Expression, isOptional: boolean, args?: EncodeMethod) => {
+    if (isOptional || args?.context?.options?.prototypes?.allowEncodeDefaultScalars) {
         return notUndefined(prop);
     }
     return test;
@@ -176,43 +176,43 @@ export const encode = {
     double(args: EncodeMethod) {
         const prop = args.field.name;
         const num = getTagNumber(args.field);
-        return types.double(num, prop, args.isOptional);
+        return types.double(num, prop, args.isOptional, args);
     },
 
     float(args: EncodeMethod) {
         const prop = args.field.name;
         const num = getTagNumber(args.field);
-        return types.float(num, prop, args.isOptional);
+        return types.float(num, prop, args.isOptional, args);
     },
 
     int32(args: EncodeMethod) {
         const prop = args.field.name;
         const num = getTagNumber(args.field);
-        return types.int32(num, prop, args.isOptional);
+        return types.int32(num, prop, args.isOptional, args);
     },
 
     sint32(args: EncodeMethod) {
         const prop = args.field.name;
         const num = getTagNumber(args.field);
-        return types.sint32(num, prop, args.isOptional);
+        return types.sint32(num, prop, args.isOptional, args);
     },
 
     uint32(args: EncodeMethod) {
         const prop = args.field.name;
         const num = getTagNumber(args.field);
-        return types.uint32(num, prop, args.isOptional);
+        return types.uint32(num, prop, args.isOptional, args);
     },
 
     fixed32(args: EncodeMethod) {
         const prop = args.field.name;
         const num = getTagNumber(args.field);
-        return types.fixed32(num, prop, args.isOptional);
+        return types.fixed32(num, prop, args.isOptional, args);
     },
 
     sfixed32(args: EncodeMethod) {
         const prop = args.field.name;
         const num = getTagNumber(args.field);
-        return types.sfixed32(num, prop, args.isOptional);
+        return types.sfixed32(num, prop, args.isOptional, args);
     },
 
     int64(args: EncodeMethod) {
@@ -248,7 +248,7 @@ export const encode = {
     bool(args: EncodeMethod) {
         const prop = args.field.name;
         const num = getTagNumber(args.field);
-        return types.bool(num, prop, args.isOptional);
+        return types.bool(num, prop, args.isOptional, args);
     },
 
     type(args: EncodeMethod) {
@@ -366,7 +366,7 @@ export const types = {
                 'cosmossdk.io/math.LegacyDec');
 
         return t.ifStatement(
-            wrapOptional(prop, notEmptyString(prop), isOptional),
+            wrapOptional(prop, notEmptyString(prop), isOptional, args),
             useCosmosSDKDec && isCosmosSDKDec
                 ? customType(num, prop, 'string', args.field.options?.['(gogoproto.customtype)'], args)
                 : scalarType(num, prop, 'string')
@@ -379,9 +379,9 @@ export const types = {
         }
     */
 
-    double(num: number, prop: string, isOptional: boolean) {
+    double(num: number, prop: string, isOptional: boolean, args?: EncodeMethod) {
         return t.ifStatement(
-            wrapOptional(prop, notZero(prop), isOptional),
+            wrapOptional(prop, notZero(prop), isOptional, args),
             scalarType(num, prop, 'double')
         )
     },
@@ -392,9 +392,9 @@ export const types = {
         }
     */
 
-    float(num: number, prop: string, isOptional: boolean) {
+    float(num: number, prop: string, isOptional: boolean, args?: EncodeMethod) {
         return t.ifStatement(
-            wrapOptional(prop, notZero(prop), isOptional),
+            wrapOptional(prop, notZero(prop), isOptional, args),
             scalarType(num, prop, 'float')
         )
     },
@@ -404,9 +404,9 @@ export const types = {
     //     writer.uint32(24).int32(message.int32Value);
     //   }
 
-    int32(num: number, prop: string, isOptional: boolean) {
+    int32(num: number, prop: string, isOptional: boolean, args?: EncodeMethod) {
         return t.ifStatement(
-            wrapOptional(prop, notZero(prop), isOptional),
+            wrapOptional(prop, notZero(prop), isOptional, args),
             scalarType(num, prop, 'int32')
         );
     },
@@ -415,9 +415,9 @@ export const types = {
     //     writer.uint32(24).sint32(message.sint32Value);
     //   }
 
-    sint32(num: number, prop: string, isOptional: boolean) {
+    sint32(num: number, prop: string, isOptional: boolean, args?: EncodeMethod) {
         return t.ifStatement(
-            wrapOptional(prop, notZero(prop), isOptional),
+            wrapOptional(prop, notZero(prop), isOptional, args),
             scalarType(num, prop, 'sint32')
         );
     },
@@ -426,23 +426,23 @@ export const types = {
     //     writer.uint32(24).uint32(message.int32Value);
     //   }
 
-    uint32(num: number, prop: string, isOptional: boolean) {
+    uint32(num: number, prop: string, isOptional: boolean, args?: EncodeMethod) {
         return t.ifStatement(
-            wrapOptional(prop, notZero(prop), isOptional),
+            wrapOptional(prop, notZero(prop), isOptional, args),
             scalarType(num, prop, 'uint32')
         );
     },
 
-    fixed32(num: number, prop: string, isOptional: boolean) {
+    fixed32(num: number, prop: string, isOptional: boolean, args?: EncodeMethod) {
         return t.ifStatement(
-            wrapOptional(prop, notZero(prop), isOptional),
+            wrapOptional(prop, notZero(prop), isOptional, args),
             scalarType(num, prop, 'fixed32')
         );
     },
 
-    sfixed32(num: number, prop: string, isOptional: boolean) {
+    sfixed32(num: number, prop: string, isOptional: boolean, args?: EncodeMethod) {
         return t.ifStatement(
-            wrapOptional(prop, notZero(prop), isOptional),
+            wrapOptional(prop, notZero(prop), isOptional, args),
             scalarType(num, prop, 'sfixed32')
         );
     },
@@ -454,7 +454,7 @@ export const types = {
 
     int64(num: number, prop: string, isOptional: boolean, args: EncodeMethod) {
         return t.ifStatement(
-            wrapOptional(prop, TypeLong.getLongNotZero(prop, args.context), isOptional),
+            wrapOptional(prop, TypeLong.getLongNotZero(prop, args.context), isOptional, args),
             scalarType(num, prop, 'int64', args)
         )
     },
@@ -465,7 +465,7 @@ export const types = {
 
     sint64(num: number, prop: string, isOptional: boolean, args: EncodeMethod) {
         return t.ifStatement(
-            wrapOptional(prop, TypeLong.getLongNotZero(prop, args.context), isOptional),
+            wrapOptional(prop, TypeLong.getLongNotZero(prop, args.context), isOptional, args),
             scalarType(num, prop, 'sint64', args)
         )
     },
@@ -476,21 +476,21 @@ export const types = {
 
     uint64(num: number, prop: string, isOptional: boolean, args: EncodeMethod) {
         return t.ifStatement(
-            wrapOptional(prop, TypeLong.getLongNotZero(prop, args.context), isOptional),
+            wrapOptional(prop, TypeLong.getLongNotZero(prop, args.context), isOptional, args),
             scalarType(num, prop, 'uint64', args)
         )
     },
 
     fixed64(num: number, prop: string, isOptional: boolean, args: EncodeMethod) {
         return t.ifStatement(
-            wrapOptional(prop, TypeLong.getLongNotZero(prop, args.context), isOptional),
+            wrapOptional(prop, TypeLong.getLongNotZero(prop, args.context), isOptional, args),
             scalarType(num, prop, 'fixed64', args)
         )
     },
 
     sfixed64(num: number, prop: string, isOptional: boolean, args: EncodeMethod) {
         return t.ifStatement(
-            wrapOptional(prop, TypeLong.getLongNotZero(prop, args.context), isOptional),
+            wrapOptional(prop, TypeLong.getLongNotZero(prop, args.context), isOptional, args),
             scalarType(num, prop, 'sfixed64', args)
         )
     },
@@ -499,10 +499,10 @@ export const types = {
     //     writer.uint32(32).bool(message.disableMacros);
     //   }
 
-    bool(num: number, prop: string, isOptional: boolean) {
+    bool(num: number, prop: string, isOptional: boolean, args?: EncodeMethod) {
 
         return t.ifStatement(
-            wrapOptional(prop, ifTrue(prop), isOptional),
+            wrapOptional(prop, ifTrue(prop), isOptional, args),
             scalarType(num, prop, 'bool')
         )
     },

--- a/packages/ast/types/encoding/proto/encode/utils.d.ts
+++ b/packages/ast/types/encoding/proto/encode/utils.d.ts
@@ -29,19 +29,19 @@ export declare const encode: {
 };
 export declare const types: {
     string(num: number, prop: string, isOptional: boolean, args: EncodeMethod): t.IfStatement;
-    double(num: number, prop: string, isOptional: boolean): t.IfStatement;
-    float(num: number, prop: string, isOptional: boolean): t.IfStatement;
-    int32(num: number, prop: string, isOptional: boolean): t.IfStatement;
-    sint32(num: number, prop: string, isOptional: boolean): t.IfStatement;
-    uint32(num: number, prop: string, isOptional: boolean): t.IfStatement;
-    fixed32(num: number, prop: string, isOptional: boolean): t.IfStatement;
-    sfixed32(num: number, prop: string, isOptional: boolean): t.IfStatement;
+    double(num: number, prop: string, isOptional: boolean, args?: EncodeMethod): t.IfStatement;
+    float(num: number, prop: string, isOptional: boolean, args?: EncodeMethod): t.IfStatement;
+    int32(num: number, prop: string, isOptional: boolean, args?: EncodeMethod): t.IfStatement;
+    sint32(num: number, prop: string, isOptional: boolean, args?: EncodeMethod): t.IfStatement;
+    uint32(num: number, prop: string, isOptional: boolean, args?: EncodeMethod): t.IfStatement;
+    fixed32(num: number, prop: string, isOptional: boolean, args?: EncodeMethod): t.IfStatement;
+    sfixed32(num: number, prop: string, isOptional: boolean, args?: EncodeMethod): t.IfStatement;
     int64(num: number, prop: string, isOptional: boolean, args: EncodeMethod): t.IfStatement;
     sint64(num: number, prop: string, isOptional: boolean, args: EncodeMethod): t.IfStatement;
     uint64(num: number, prop: string, isOptional: boolean, args: EncodeMethod): t.IfStatement;
     fixed64(num: number, prop: string, isOptional: boolean, args: EncodeMethod): t.IfStatement;
     sfixed64(num: number, prop: string, isOptional: boolean, args: EncodeMethod): t.IfStatement;
-    bool(num: number, prop: string, isOptional: boolean): t.IfStatement;
+    bool(num: number, prop: string, isOptional: boolean, args?: EncodeMethod): t.IfStatement;
     type(num: number, prop: string, name: string, isAnyType: boolean): t.IfStatement;
     enum(context: ProtoParseContext, num: number, field: ProtoField, isOptional: boolean, isOneOf: boolean): t.IfStatement;
     bytes(num: number, prop: string, isOptional: boolean): t.IfStatement;

--- a/packages/telescope/README.md
+++ b/packages/telescope/README.md
@@ -288,6 +288,7 @@ telescope({
 | `prototypes.fieldDefaultIsOptional`       | boolean value representing default optionality of field         | `false`    |
 | `prototypes.useOptionalNullable`          | use `(gogoproto.nullable)` values in determining optionality    | `true`     |
 | `prototypes.allowUndefinedTypes`          | boolean value allowing `Type`s to be `undefined`                | `false`    |
+| `prototypes.allowEncodeDefaultScalars`          | boolean value allowing encoders encoding default values of scalar types. e.g. empty string, 0 or false                | `false`    |
 | `prototypes.optionalQueryParams`          | boolean value setting queryParams to be optional                | `false`    |
 | `prototypes.optionalPageRequests`         | boolean value setting `PageRequest` fields to optional          | `false`    |
 | `prototypes.addTypeUrlToDecoders`         | add $typeUrl field to generated interfaces          | `true`    |

--- a/packages/telescope/__tests__/telescope-v4.test.ts
+++ b/packages/telescope/__tests__/telescope-v4.test.ts
@@ -59,6 +59,7 @@ const options: TelescopeOptions = {
     fieldDefaultIsOptional: false,
     useOptionalNullable: true,
     allowUndefinedTypes: false,
+    allowEncodeDefaultScalars: true,
     excluded: {
       packages: [
         // 'cosmos.gov.v1',

--- a/packages/types/src/telescope.ts
+++ b/packages/types/src/telescope.ts
@@ -54,6 +54,7 @@ interface TelescopeOpts {
         fieldDefaultIsOptional?: boolean;
         useOptionalNullable?: boolean;
         allowUndefinedTypes?: boolean;
+        allowEncodeDefaultScalars?: boolean;
 
         optionalQueryParams?: boolean;
         optionalPageRequests?: boolean;

--- a/packages/types/types/telescope.d.ts
+++ b/packages/types/types/telescope.d.ts
@@ -48,6 +48,7 @@ interface TelescopeOpts {
         fieldDefaultIsOptional?: boolean;
         useOptionalNullable?: boolean;
         allowUndefinedTypes?: boolean;
+        allowEncodeDefaultScalars?: boolean;
         optionalQueryParams?: boolean;
         optionalPageRequests?: boolean;
         addTypeUrlToObjects?: boolean;


### PR DESCRIPTION
Solving https://github.com/cosmology-tech/telescope/issues/511

added an option: 
    prototypes.allowEncodeDefaultScalars
    boolean value allowing encoders encoding default values of scalar types. e.g. empty string, 0 or false

Encoding logic:
previous:
```
    if (message.proposalId !== BigInt(0)) {
      writer.uint32(8).uint64(message.proposalId);
    }
```

current:
```
    if (message.proposalId !== undefined) {
      writer.uint32(8).uint64(message.proposalId);
    }
```