### PR TITLE
fixed return type of Cosmos_cryptoPubKey_ToAmino

### DIFF
--- a/__fixtures__/v-next/outputv2/cosmos/staking/v1beta1/staking.ts
+++ b/__fixtures__/v-next/outputv2/cosmos/staking/v1beta1/staking.ts
@@ -7,6 +7,7 @@ import { BinaryReader, BinaryWriter } from "../../../binary";
 import { isSet, DeepPartial, toTimestamp, fromTimestamp } from "../../../helpers";
 import { Decimal } from "@cosmjs/math";
 import { encodePubkey, decodePubkey } from "@cosmjs/proto-signing";
+import { Pubkey } from "@cosmjs/amino";
 export const protobufPackage = "cosmos.staking.v1beta1";
 /** BondStatus is the status of a validator. */
 export enum BondStatus {
@@ -3312,6 +3313,6 @@ export const Cosmos_cryptoPubKey_InterfaceDecoder = (input: BinaryReader | Uint8
 export const Cosmos_cryptoPubKey_FromAmino = (content: AnyAmino) => {
   return encodePubkey(content);
 };
-export const Cosmos_cryptoPubKey_ToAmino = (content: Any) => {
+export const Cosmos_cryptoPubKey_ToAmino = (content: Any): Pubkey | null => {
   return decodePubkey(content);
 };

--- a/__fixtures__/v-next/outputv2/cosmos/staking/v1beta1/tx.ts
+++ b/__fixtures__/v-next/outputv2/cosmos/staking/v1beta1/tx.ts
@@ -6,6 +6,7 @@ import { BinaryReader, BinaryWriter } from "../../../binary";
 import { isSet, DeepPartial, toTimestamp, fromTimestamp } from "../../../helpers";
 import { encodePubkey, decodePubkey } from "@cosmjs/proto-signing";
 import { Decimal } from "@cosmjs/math";
+import { Pubkey } from "@cosmjs/amino";
 export const protobufPackage = "cosmos.staking.v1beta1";
 /** MsgCreateValidator defines a SDK message for creating a new validator. */
 export interface MsgCreateValidator {
@@ -1359,6 +1360,6 @@ export const Cosmos_cryptoPubKey_InterfaceDecoder = (input: BinaryReader | Uint8
 export const Cosmos_cryptoPubKey_FromAmino = (content: AnyAmino) => {
   return encodePubkey(content);
 };
-export const Cosmos_cryptoPubKey_ToAmino = (content: Any) => {
+export const Cosmos_cryptoPubKey_ToAmino = (content: Any): Pubkey | null => {
   return decodePubkey(content);
 };

--- a/__fixtures__/v-next/outputv3/cosmos/staking/v1beta1/staking.ts
+++ b/__fixtures__/v-next/outputv3/cosmos/staking/v1beta1/staking.ts
@@ -7,6 +7,7 @@ import { BinaryReader, BinaryWriter } from "../../../binary";
 import { isSet, DeepPartial, toTimestamp, fromTimestamp } from "../../../helpers";
 import { Decimal } from "@cosmjs/math";
 import { encodePubkey, decodePubkey } from "@cosmjs/proto-signing";
+import { Pubkey } from "@cosmjs/amino";
 export const protobufPackage = "cosmos.staking.v1beta1";
 /** BondStatus is the status of a validator. */
 export enum BondStatus {
@@ -3052,6 +3053,6 @@ export const Cosmos_cryptoPubKey_InterfaceDecoder = (input: BinaryReader | Uint8
 export const Cosmos_cryptoPubKey_FromAmino = (content: AnyAmino) => {
   return encodePubkey(content);
 };
-export const Cosmos_cryptoPubKey_ToAmino = (content: Any, useInterfaces: boolean = true) => {
+export const Cosmos_cryptoPubKey_ToAmino = (content: Any, useInterfaces: boolean = true): Pubkey | null => {
   return decodePubkey(content);
 };

--- a/__fixtures__/v-next/outputv3/cosmos/staking/v1beta1/tx.ts
+++ b/__fixtures__/v-next/outputv3/cosmos/staking/v1beta1/tx.ts
@@ -6,6 +6,7 @@ import { BinaryReader, BinaryWriter } from "../../../binary";
 import { isSet, DeepPartial, toTimestamp, fromTimestamp } from "../../../helpers";
 import { encodePubkey, decodePubkey } from "@cosmjs/proto-signing";
 import { Decimal } from "@cosmjs/math";
+import { Pubkey } from "@cosmjs/amino";
 export const protobufPackage = "cosmos.staking.v1beta1";
 /** MsgCreateValidator defines a SDK message for creating a new validator. */
 export interface MsgCreateValidator {
@@ -1229,6 +1230,6 @@ export const Cosmos_cryptoPubKey_InterfaceDecoder = (input: BinaryReader | Uint8
 export const Cosmos_cryptoPubKey_FromAmino = (content: AnyAmino) => {
   return encodePubkey(content);
 };
-export const Cosmos_cryptoPubKey_ToAmino = (content: Any, useInterfaces: boolean = true) => {
+export const Cosmos_cryptoPubKey_ToAmino = (content: Any, useInterfaces: boolean = true): Pubkey | null => {
   return decodePubkey(content);
 };

--- a/packages/ast/src/encoding/proto/implements/__tests__/__snapshots__/interface-to-amino.test.ts.snap
+++ b/packages/ast/src/encoding/proto/implements/__tests__/__snapshots__/interface-to-amino.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MsgCreateValidator MsgCreateValidator 1`] = `
-"export const Cosmos_cryptoPubKey_ToAmino = (content: Any) => {
+"export const Cosmos_cryptoPubKey_ToAmino = (content: Any): Pubkey | null => {
   return decodePubkey(content);
 };"
 `;

--- a/packages/ast/src/encoding/proto/implements/to-amino.ts
+++ b/packages/ast/src/encoding/proto/implements/to-amino.ts
@@ -1,7 +1,7 @@
 import * as t from '@babel/types';
 import { ProtoRef, TraverseTypeUrlRef, TypeUrlRef } from '@cosmology/types';
 import { slugify } from '@cosmology/utils';
-import { identifier } from '../../../utils';
+import { arrowFunctionExpression, identifier } from '../../../utils';
 import { ProtoParseContext } from "../../context";
 
 const firstUpper = (s: string) => s = s.charAt(0).toUpperCase() + s.slice(1);
@@ -18,6 +18,7 @@ export const createInterfaceToAmino = (
     if (interfaceName === 'cosmos.crypto.PubKey') {
         // return a helper!
         context.addUtil('decodePubkey');
+        context.addUtil('Pubkey');
         const functionName = getInterfaceToAminoName(interfaceName);
 
         return makeFunctionWrapper(context, functionName, t.returnStatement(
@@ -27,7 +28,7 @@ export const createInterfaceToAmino = (
                     t.identifier('content')
                 ]
             ),
-        ));
+        ), t.tsTypeAnnotation(t.tsUnionType([t.tsTypeReference(t.identifier("Pubkey")), t.tsNullKeyword()])));
     }
 
 
@@ -43,7 +44,8 @@ export const createInterfaceToAmino = (
 const makeFunctionWrapper = (
     context: ProtoParseContext,
     functionName: string,
-    stmt: t.Statement
+    stmt: t.Statement,
+    returnType?: t.TSTypeAnnotation
 ) => {
     return t.exportNamedDeclaration(
         t.variableDeclaration(
@@ -51,7 +53,7 @@ const makeFunctionWrapper = (
             [
                 t.variableDeclarator(
                     t.identifier(functionName),
-                    t.arrowFunctionExpression(
+                    arrowFunctionExpression(
                         [
                             identifier(
                                 'content',
@@ -80,7 +82,8 @@ const makeFunctionWrapper = (
                         ],
                         t.blockStatement([
                             stmt
-                        ])
+                        ]),
+                        returnType
                     )
 
                 )


### PR DESCRIPTION
toAmino converter needs a explict return type
```
export const Cosmos_cryptoPubKey_ToAmino = (content: Any) => {
  return decodePubkey(content);
};
```
to:
```
export const Cosmos_cryptoPubKey_ToAmino = (content: Any): Pubkey | null => {
  return decodePubkey(content);
};
```