### PR TITLE
feat: ESM compatibility

### DIFF
--- a/packages/telescope/src/generators/create-bundle.ts
+++ b/packages/telescope/src/generators/create-bundle.ts
@@ -3,6 +3,7 @@ import { TelescopeBuilder } from '../builder';
 import {
     recursiveModuleBundle
 } from '@cosmology/ast';
+import { restoreJsExtension } from 'src/utils';
 
 export const plugin = (
     builder: TelescopeBuilder,
@@ -12,6 +13,8 @@ export const plugin = (
     if (!builder.options.bundle.enabled) {
         return;
     }
+
+    restoreJsExtension(bundler.bundle.importPaths);
 
     // [x] bundle
     const body = recursiveModuleBundle(builder.options, bundler.bundle.bundleVariables);

--- a/packages/telescope/src/generators/create-stargate-clients.ts
+++ b/packages/telescope/src/generators/create-stargate-clients.ts
@@ -14,6 +14,7 @@ import { ProtoRef } from '@cosmology/types';
 import { camel, pascal } from 'case';
 import { variableSlug } from '@cosmology/utils';
 import { buildAllImportsFromGenericContext } from '../imports';
+import { restoreJsExtension } from 'src/utils';
 
 export const plugin = (
     builder: TelescopeBuilder,
@@ -93,7 +94,10 @@ export const plugin = (
 
     const imports = buildAllImportsFromGenericContext(ctx, clientFile);
 
-    let cProg = [...imports, ...registryImports, ...converterImports]
+    const importDecls = [...imports, ...registryImports, ...converterImports];
+    restoreJsExtension(importDecls);
+
+    let cProg = importDecls
       .concat(aminos)
       .concat(protos)
       .concat(clientOptions)

--- a/packages/telescope/src/helpers/binary-coder.ts
+++ b/packages/telescope/src/helpers/binary-coder.ts
@@ -33,7 +33,7 @@ export const binary = `
 // standalone and requires a support library to be linked with it. This
 // support library is itself covered by the above license.
 
-import { utf8Length, utf8Read, utf8Write } from "./utf8";
+import { utf8Length, utf8Read, utf8Write } from "./utf8.js";
 import {
   int64ToString,
   readInt32,
@@ -49,7 +49,7 @@ import {
   writeByte,
   zzDecode,
   zzEncode,
-} from "./varint";
+} from "./varint.js";
 
 export enum WireType {
   Varint = 0,

--- a/packages/telescope/src/types.ts
+++ b/packages/telescope/src/types.ts
@@ -1,8 +1,9 @@
+import { ImportDeclaration } from '@babel/types';
 import { ProtoServiceMethod, TelescopeOptions } from '@cosmology/types';
 export interface Bundle {
     bundleVariables: {};
     bundleFile: string;
-    importPaths: any[];
+    importPaths: ImportDeclaration[];
     base: string;
 }
 export interface BundlerFile {

--- a/packages/telescope/src/utils/index.ts
+++ b/packages/telescope/src/utils/index.ts
@@ -1,6 +1,7 @@
 import { ProtoRoot, ProtoRef } from '@cosmology/types';
 import { relative, dirname, extname } from 'path';
 import { ImportObj } from '../types';
+import { ImportDeclaration } from '@babel/types';
 
 export const getRoot = (ref: ProtoRef): ProtoRoot => {
   if (ref.traversed) return ref.traversed;
@@ -117,7 +118,21 @@ export const getRelativePath = (f1: string, f2: string) => {
   const rel = relative(dirname(f1), f2);
   let importPath = rel.replace(extname(rel), '');
   if (!/^\./.test(importPath)) importPath = `./${importPath}`;
-  return importPath;
+  return `${importPath}.js`;
+}
+
+/**
+ * Add .js extension to relative imports for compatibility with ESM
+ */
+export const restoreJsExtension = (importDeclarations: ImportDeclaration[]) => {
+  for (const stmt of importDeclarations) {
+    if (
+      stmt.source.value.startsWith(".") &&
+      !stmt.source.value.endsWith(".js")
+    ) {
+      stmt.source.value += ".js";
+    }
+  }
 }
 
 export * from './common-create-bundle';


### PR DESCRIPTION
With ES modules, the file extension is obligatory for relative imports.

This adds the extension to relative imports so the modules can be used in an ESM environment.

It's adapted from https://github.com/Agoric/agoric-sdk/blob/f71b72227f163a56e06c8511261396051383c0d4/patches/%40cosmology%2Btelescope%2B1.4.12.patch
