### PR TITLE
fix(JsonSafe): handle nested structures and arrays

### DIFF
--- a/packages/telescope/src/helpers/json-safe.ts
+++ b/packages/telescope/src/helpers/json-safe.ts
@@ -1,7 +1,11 @@
 export const jsonSafe = `
-export type JsonSafe<T> = {
-  [Prop in keyof T]: T[Prop] extends Uint8Array | bigint | Date ? string : T[Prop];
-}
+export type JsonSafe<T> = T extends Uint8Array | bigint | Date
+  ? string
+  : T extends Array<infer U>
+  ? Array<JsonSafe<U>>
+  : T extends object
+  ? { [K in keyof T]: JsonSafe<T[K]> }
+  : T;
 `;
 
 


### PR DESCRIPTION
- Update `JsonSafe<T>` type to recursively handle nested objects and arrays