### PR TITLE
fixed #630 amino missing

### DIFF
--- a/packages/parser/src/lookup.ts
+++ b/packages/parser/src/lookup.ts
@@ -1,6 +1,6 @@
 import { ProtoStore } from './store';
 import { ProtoRef } from '@cosmology/types';
-import { getNested, getNestedProto } from './';
+import { checkNestedNameInProto, getNested, getNestedProto } from './';
 import { Lookup } from '@cosmology/types';
 
 export type { Lookup } from '@cosmology/types';
@@ -12,6 +12,16 @@ export const recursiveLookup = (proto: any, name: string, scope: string[] = [], 
         name,
         scope,
         ...proto[name]
+    }
+    //check nested name
+    const nestedNames = name.split("_");
+
+    if (checkNestedNameInProto(proto, nestedNames, scope)) {
+        return {
+            name,
+            scope,
+            ...proto[nestedNames[nestedNames.length - 1]],
+        };
     }
 
     if (allowNested && proto) {
@@ -207,9 +217,9 @@ export const lookup = (
 ) => {
     const root = getRoot(ref);
 
-    if(!root.package) {
-      console.warn(`There's no package definition in ${ref.filename}`)
-      return
+    if (!root.package) {
+        console.warn(`There's no package definition in ${ref.filename}`)
+        return
     }
 
     const nested = getNestedProto(root);

--- a/packages/parser/src/utils.ts
+++ b/packages/parser/src/utils.ts
@@ -222,3 +222,38 @@ export const createEmptyProtoRef = (pkg?: string, filename?: string): ProtoRef =
         }
     }
 };
+/**
+ * Checks if the given nested names exist in the proto object, following the specified scope.
+ *
+ * @param {any} proto - The prototype object to check against.
+ * @param {string[]} nestedNames - An array of nested property names to check in the proto object.
+ * @param {string[]} scope - An array of scope names to validate against the nestedNames.
+ * @returns {boolean} - Returns true if the nested names exist in the proto object and match the scope, otherwise false.
+ */
+export const checkNestedNameInProto = (
+    proto: any,
+    nestedNames: string[],
+    scope: string[]
+): boolean => {
+    // Check if the proto object has the property specified by the last element in nestedNames
+    if (!proto.hasOwnProperty(nestedNames[nestedNames.length - 1])) {
+        return false;
+    }
+
+    // Create temporary copies of nestedNames and scope for manipulation
+    let tempNestedNames = [...nestedNames];
+    let tempScope = [...scope];
+
+    // Remove the last element from tempNestedNames
+    tempNestedNames.pop();
+
+    // Loop through tempNestedNames and tempScope to ensure they match
+    while (tempNestedNames.length > 0) {
+        if (tempNestedNames.pop() !== tempScope.pop()) {
+            return false;
+        }
+    }
+
+    // If all checks pass, return true
+    return true;
+};

--- a/packages/parser/types/utils.d.ts
+++ b/packages/parser/types/utils.d.ts
@@ -24,3 +24,12 @@ export declare const instanceType: (obj: any) => {
  * @returns
  */
 export declare const createEmptyProtoRef: (pkg?: string, filename?: string) => ProtoRef;
+/**
+ * Checks if the given nested names exist in the proto object, following the specified scope.
+ *
+ * @param {any} proto - The prototype object to check against.
+ * @param {string[]} nestedNames - An array of nested property names to check in the proto object.
+ * @param {string[]} scope - An array of scope names to validate against the nestedNames.
+ * @returns {boolean} - Returns true if the nested names exist in the proto object and match the scope, otherwise false.
+ */
+export declare const checkNestedNameInProto: (proto: any, nestedNames: string[], scope: string[]) => boolean;

--- a/packages/telescope/src/imports.ts
+++ b/packages/telescope/src/imports.ts
@@ -281,7 +281,7 @@ const addDerivativeTypesToImports = (
       let lookup = null;
       try {
         lookup = context.store.getImportFromRef(ref, obj.name);
-      } catch (e) {}
+      } catch (e) { }
 
       const appendSuffix = (
         obj: ImportObj,
@@ -334,9 +334,11 @@ const addDerivativeTypesToImports = (
           const foundAmino = context.proto.derivedImports.find((a) => {
             if (a.type !== "Amino") return false;
             if (
-              AminoTypeObject.orig === a.symbol.symbolName &&
-              a.symbol.ref &&
-              a.symbol.source
+              AminoTypeObject.orig.includes("_")
+                ? AminoTypeObject.orig.split("_").at(-1) === a.symbol.symbolName
+                : AminoTypeObject.orig === a.symbol.symbolName &&
+                a.symbol.ref &&
+                a.symbol.source
             ) {
               // UNTIL you fix the ImportObjs to have ref...
               let rel = getRelativePath(a.symbol.ref, a.symbol.source);

--- a/packages/telescope/types/helpers/json-safe.d.ts
+++ b/packages/telescope/types/helpers/json-safe.d.ts
@@ -1,1 +1,1 @@
-export declare const jsonSafe = "\nexport type JsonSafe<T> = {\n  [Prop in keyof T]: T[Prop] extends Uint8Array | bigint | Date ? string : T[Prop];\n}\n";
+export declare const jsonSafe = "\nexport type JsonSafe<T> = T extends Uint8Array | bigint | Date\n  ? string\n  : T extends Array<infer U>\n  ? Array<JsonSafe<U>>\n  : T extends object\n  ? { [K in keyof T]: JsonSafe<T[K]> }\n  : T;\n";


### PR DESCRIPTION
Problem causing:
     I looked through the telescope project and some founding there:
     1. when program goes into reverseAll function , the nested structure content.graph will be decompolized to content:graph structure. This will be saved to field .
     2. addImportDerivative will mark this as readAs: field.parsedType.name , the readAs will be Graph
     3. recursiveLookup and import.ts (AminoTypeObject.orig === a.symbol.symbolName) will only consider the nested Deepest Level. 
 
Solving:
     Consider that Graph will always be the type and import name will be transformed from Content.Graph to Content_Graph. So I add some functions to look into the nested structure when nested structure be found. This change will be smallest compared with changing field or addImportDerivative to avoid bug.

The testcase went well by modification.