### PR TITLE
feat: add timeout to the arguments of LcdClient constructor

### DIFF
--- a/packages/lcd/package.json
+++ b/packages/lcd/package.json
@@ -27,9 +27,18 @@
     "clean": "rimraf ./types",
     "prepare": "npm run build",
     "lint": "eslint .",
-    "format": "eslint . --fix"
+    "format": "eslint . --fix",
+    "test": "jest"
   },
   "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "transform": {
+      "^.+\\.ts?$": "ts-jest"
+    },
+    "transformIgnorePatterns": [
+      "<rootDir>/node_modules/"
+    ],
     "testPathIgnorePatterns": [
       "main/",
       "types/"

--- a/packages/lcd/src/rest.spec.ts
+++ b/packages/lcd/src/rest.spec.ts
@@ -1,0 +1,11 @@
+import { LCDClient } from "./rest";
+
+it('createLcdClient', async () => {
+  let client = new LCDClient({ restEndpoint: "http://localhost:1317" });
+  expect(client.restEndpoint).toBe("http://localhost:1317/");
+  expect(client.timeout).toBe(10000);
+
+  client = new LCDClient({ restEndpoint: "http://localhost:1317/", timeout: 20000 });
+  expect(client.restEndpoint).toBe("http://localhost:1317/");
+  expect(client.timeout).toBe(20000);
+});

--- a/packages/lcd/src/rest.ts
+++ b/packages/lcd/src/rest.ts
@@ -1,13 +1,15 @@
 import axios from 'axios';
 export class LCDClient {
     restEndpoint: string;
+    timeout: number;
     private instance: any;
 
-    constructor({ restEndpoint }) {
-        this.restEndpoint = restEndpoint.endsWith('/') ? restEndpoint : `${restEndpoint}/`;
+    constructor(config: { restEndpoint: string, timeout?: number }) {
+        this.restEndpoint = config.restEndpoint.endsWith('/') ? config.restEndpoint : `${config.restEndpoint}/`;
+        this.timeout = config.timeout ?? 10000;
         this.instance = axios.create({
             baseURL: this.restEndpoint,
-            timeout: 10000,
+            timeout: this.timeout,
             headers: {}
         });
         this.get = this.get.bind(this);
@@ -18,7 +20,7 @@ export class LCDClient {
         return new Promise<ResponseType>(async (resolve, reject) => {
             try {
                 const response = await this.instance.get(endpoint, {
-                    timeout: 10000,
+                    timeout: this.timeout,
                     ...opts
                 });
                 if (response && response.data) {
@@ -37,7 +39,7 @@ export class LCDClient {
         return new Promise<ResponseType>(async (resolve, reject) => {
             try {
                 const response = await this.instance.post(endpoint, body, {
-                    timeout: 10000,
+                    timeout: this.timeout,
                     ...opts
                 });
                 if (response && response.data) {

--- a/packages/lcd/types/rest.d.ts
+++ b/packages/lcd/types/rest.d.ts
@@ -1,8 +1,10 @@
 export declare class LCDClient {
     restEndpoint: string;
+    timeout: number;
     private instance;
-    constructor({ restEndpoint }: {
-        restEndpoint: any;
+    constructor(config: {
+        restEndpoint: string;
+        timeout?: number;
     });
     get<ResponseType = unknown>(endpoint: any, opts?: {}): Promise<ResponseType>;
     post<ResponseType = unknown>(endpoint: any, body?: {}, opts?: {}): Promise<ResponseType>;


### PR DESCRIPTION
This PR intends to add an optional `timeout` argument to the constructor of the `LcdClient`, in order to allow users to set the axios timeout when instantiating a client.